### PR TITLE
Stash apply index

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3575,7 +3575,10 @@ With prefix argument, changes in staging area are kept.
     ((diff)
      (magit-apply-diff-item item))
     ((stash)
-     (magit-run-git "stash" "apply" info))))
+     (apply 'magit-run-git `("stash"
+                             "apply"
+                             ,@(when current-prefix-arg '("--index"))
+                             ,info)))))
 
 (defun magit-cherry-pick-item ()
   (interactive)
@@ -3586,7 +3589,10 @@ With prefix argument, changes in staging area are kept.
     ((commit)
      (magit-apply-commit info t))
     ((stash)
-     (magit-run-git "stash" "pop" info))))
+     (apply 'magit-run-git `("stash"
+                             "pop"
+                             ,@(when current-prefix-arg '("--index"))
+                             ,info)))))
 
 (defun magit-revert-item ()
   (interactive)

--- a/magit.texi
+++ b/magit.texi
@@ -459,6 +459,9 @@ You can create a new stash with @kbd{z}.  Your stashes will be listed
 in the status buffer, and you can apply them with @kbd{a} and pop them
 with @kbd{A}.  To drop a stash, use @kbd{k}.
 
+With a prefix argument, both @kbd{a} and @kbd{A} will attempt to
+reinstate the index as well as the working tree from the stash.
+
 Typing @kbd{Z} will create a stash just like @kbd{z}, but will leave
 the changes in your working tree and index.
 


### PR DESCRIPTION
Hi,

Magit is awesome!  Part of this is making the index much easier to use, staging hunks with quick precision.  I use the index more now with magit.  But I quickly ran into a limitation -- I couldn't reinstate both the index and the working tree from a stash (via 'a' or 'A').  

This patch allows adding the optional argument "--index" to git stash apply or pop, which will reinstate not only the working tree, but also the index from a stash (if the current index is clean).  This new feature is activated by adding an optional prefix argument (C-u) to either 'a' or 'A'.  

The documentation is updated as well.

Cheers,
Chris
