### PR TITLE
Key groups better magit delete branch behavior

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2801,7 +2801,7 @@ If the branch is the current one, offers to switch to `master' first.
 	(magit-checkout "master")
       (setq branch nil)))
   (when branch
-    (magit-run-git "branch" "-d" (append magit-custom-options
+    (magit-run-git "branch" "-D" (append magit-custom-options
 					 (magit-rev-to-git branch)))))
 
 (defun magit-move-branch (old new)


### PR DESCRIPTION
You want the first one of these, but I'm not so sure about the s/-d/-D/.

It's probably best not to apply it, and instead add support to magit for asking additional questions:

```
want to delete this? Y/n
Hey, it contains unmerged refs, really? y/N
```
