### PR TITLE
Issue 56

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2833,21 +2833,14 @@ With a prefix-arg, the merge will be squashed.
 ;;; Rebasing
 
 (defun magit-rebase-info ()
-  (cond ((file-exists-p ".git/rebase-apply")
-	 (list (magit-name-rev
-		(car (magit-file-lines ".git/rebase-apply/onto")))
-	       (car (magit-file-lines ".git/rebase-apply/next"))
-	       (car (magit-file-lines ".git/rebase-apply/last"))))
-	((file-exists-p ".dotest")
-	 (list (magit-name-rev (car (magit-file-lines ".dotest/onto")))
-	       (car (magit-file-lines ".dotest/next"))
-	       (car (magit-file-lines ".dotest/last"))))
-	((file-exists-p ".git/.dotest-merge")
-	 (list (car (magit-file-lines ".git/.dotest-merge/onto_name"))
-	       (car (magit-file-lines ".git/.dotest-merge/msgnum"))
-	       (car (magit-file-lines ".git/.dotest-merge/end"))))
-	(t
-	 nil)))
+  "Returns a list indicating the state of an in-progress rebase,
+if any."
+  (cond ((file-exists-p ".git/rebase-merge")
+         (list
+          (magit-name-rev (car (magit-file-lines ".git/rebase-merge/message")))
+          (length (magit-file-lines ".git/rebase-merge/done"))
+          (length (magit-file-lines ".git/rebase-merge/git-rebase-todo.backup"))))
+	(t nil)))
 
 (defun magit-rebase-step ()
   (interactive)
@@ -2858,7 +2851,7 @@ With a prefix-arg, the merge will be squashed.
 	      (magit-run-git "rebase" (magit-rev-to-git rev))))
       (let ((cursor-in-echo-area t)
             (message-log-max nil))
-        (message "Rebase in progress.  Abort, Skip, or Continue? ")
+        (message "Rebase in progress. Abort, Skip, or Continue? ")
         (let ((reply (read-event)))
           (case reply
             ((?A ?a)


### PR DESCRIPTION
This is an incomplete solution to issue #56. I can't figure out how to do this properly.

The code that's there as-is hasn't worked since 1.5 as far as I can tell. And the rebase-apply stuff is only written out by git-am.sh if it's in some stgit compat mode.

So I changed it to _just_ work for git rebase -i, which it now almost does. The output now looks like this:

```
Local:  (detached) ~/g/elisp/magit/
Head:   72d9d70 magit-rebase-info: remove dead code and add >= 1.6 support
Rebasing: magit-rebase-info: remove dead code and add >= 1.6 support (1 of 16)
```

The 16 there should be 2. But I couldn't figure out how to write an idiomatic function that takes this:

```
("pick cb925f0 check message..." "pick 2f811b6 take done length" "pick 29332e6 use backup" "" "# Rebase 19e2dd7..29332e6 onto 19e2dd7" "#" ...
```

And returns 3, i.e. stops at the "".

If you can fix that up this can be applied, and it makes rebases much better. You can now see within magit where it is in the rebase process.

We might want to grab even more info out of .git/rebase-merge, there's a lot there that can be scraped.
