### PR TITLE
patch for checkout/create-branch

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1640,7 +1640,13 @@ FUNC should leave point at the end of the modified region"
 	       (magit-need-refresh magit-process-client-buffer))))
       (or successp
 	  noerror
-	  (error "Git failed"))
+	  (error 
+	   (or (save-excursion
+		 (set-buffer (get-buffer magit-process-buffer-name))
+		 (when (re-search-backward 
+			(concat "^error: \\(.*\\)" paragraph-separate) nil t)
+		   (match-string 1)))
+	       "Git failed")))
       successp)))
 
 (autoload 'dired-uncache "dired")


### PR DESCRIPTION
I made some updates to checkout and create-branch that I thought would be useful for others.

1) Before changing the branch the functions now query the user to save any modified buffers. Since this functionality appeared in-line in some other parts of the code I created a new helper function called magit-save-some-buffers.

2) After switching to another branch the functions now run magit-update-vc-modeline to update the buffers.

If these are useful to you, then great. If there is something I missed about how this will impact magit's functionality, then let me know.

Thanks,
 Aaron
