### PR TITLE
small bugfix for magit-revert-buffers

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1974,6 +1974,7 @@ Please see the manual for a complete description of Magit.
   (dolist (buffer (buffer-list))
     (when (and buffer
 	       (buffer-file-name buffer)
+	       (file-readable-p (buffer-file-name buffer))
 	       (magit-string-has-prefix-p (buffer-file-name buffer) dir)
 	       (or ignore-modtime (not (verify-visited-file-modtime buffer)))
 	       (not (buffer-modified-p buffer)))


### PR DESCRIPTION
This bugfix gets rid of "File ... no longer exists!" errors in magit-revert-buffers by checking to make sure that the file exists and is readable before trying to revert.
