### PR TITLE
Checkout suffix bug

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2915,7 +2915,7 @@ If REVISION is a remote branch, offer to create a local tracking branch.
                            (unless (string= current-branch default)
                              default)
                            (if current-branch
-                               (cons (concat "refs/heads/" current-branch)
+                               (cons (concat "refs/heads/" current-branch "$")
                                      magit-uninteresting-refs)
                              magit-uninteresting-refs)))))
   (if revision


### PR DESCRIPTION
No issue number for this one, but basically if you have two branches "blah" and "blah-foo", and you've already checked out "blah", then hitting "b c blah-TAB" doesn't complete to "blah-foo" like I'd expect. It turns out the call to magit-read-rev in (magit-define-command checkout) is being given the current branch as a regexp (specifically "refs/heads/CURRENTBRANCH"), which accidentally matches other branch names that happen to have the current branch name as a prefix. So you can't select them from within magit.

This fix appends "$" to the argument, to prevent it from matching too much.

I think a similar fix might be necessary in magit-rebase-step (line 3028).
