### PR TITLE
magit log failed when string-match got a nil

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2469,7 +2469,8 @@ must return a string which will represent the log line.")
 			'face (cond
 			       ((string= r "refs/stash")
 				'magit-log-head-label-local)
-			       ((string= (match-string 1 r) "remotes")
+                               ((null (match-string 1 r)) nil)
+                               ((string= (match-string 1 r) "remotes")
 				'magit-log-head-label-remote)
 			       ((string-match "^patches/[^/]*$" (match-string 1 r)) ; Stacked Git
 				'magit-log-head-label-patches)


### PR DESCRIPTION
This fix avoids string-match on nil, which happened when I tried to view the log for one of my repos.

-Mike
