### PR TITLE
Fix for "invalid function: setf" backtrace upon magit-status

### DIFF
--- a/.topdeps
+++ b/.topdeps
@@ -1,0 +1,1 @@
+upstream-master

--- a/.topmsg
+++ b/.topmsg
@@ -1,0 +1,6 @@
+From: Dave Abrahams <dave@boostpro.com>
+Subject: [PATCH] t/invalid-setf-fix
+
+<patch description>
+
+Signed-off-by: Dave Abrahams <dave@boostpro.com>

--- a/magit-topgit.el
+++ b/magit-topgit.el
@@ -23,6 +23,8 @@
 ;;; Code:
 
 (require 'magit)
+(eval-when-compile
+  (require 'cl))
 
 (defcustom magit-topgit-executable "tg"
   "The name of the TopGit executable."


### PR DESCRIPTION
When I do magit-status, I get a backtrace without this fix.  cl-macs needs to be loaded upon compilation of magit-topgit so that the "setf" macro is defined.
