### PR TITLE
Kill commit by resetting hard

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -493,6 +493,7 @@ Many Magit faces inherit from this one by default."
     (define-key map (kbd "x") 'magit-reset-head)
     (define-key map (kbd "e") 'magit-log-show-more-entries)
     (define-key map (kbd "l") 'magit-key-mode-popup-logging)
+    (define-key map (kbd "k") 'magit-discard-item)
     map))
 
 (defvar magit-reflog-mode-map


### PR DESCRIPTION
This makes magit-discard-item usable on commits by offering to call "git reset --hard info^" (info^ = the parent of the commit point is on). Works both in status and log buffers.

This does more than just discard one item though. But that's true for X as well. Maybe this should not be bound to k but to K instead (refer to the recent discussion with David about which keys are supposed to do what; upper case for more destructive things). If so then I'll change the patches accordingly before you merge.
