### PR TITLE
Start guis

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -46,7 +46,9 @@
     (running
      (actions
       ("!" "Command from root" magit-shell-command)
-      (":" "Git command" magit-git-command)))
+      (":" "Git command" magit-git-command)
+      ("g" "git gui" magit-run-git-gui)
+      ("k" "gitk" magit-run-gitk)))
 
     (fetching
      (man-page "git-fetch")

--- a/magit.el
+++ b/magit.el
@@ -4499,6 +4499,18 @@ With a prefix arg, do a submodule update --init"
   (let ((default-directory (magit-get-top-dir default-directory)))
     (magit-run-git-async "submodule" "sync")))
 
+(defun magit-run-git-gui ()
+  "Run `git gui' for the current git repository"
+  (interactive)
+  (let* ((default-directory (magit-get-top-dir default-directory)))
+    (start-process "git gui" nil "git" "gui")))
+
+(defun magit-run-gitk ()
+  "Run `gitk --all' for the current git repository"
+  (interactive)
+  (let* ((default-directory (magit-get-top-dir default-directory)))
+    (start-process "gitk" nil "gitk" "--all")))
+
 ;; for emacs 22 compatibility
 
 (defun magit-string-match-p (regexp string &optional start)


### PR DESCRIPTION
Two more external commands to start via the "actions" popup: "git gui" (bound to "g") and "gitk --all" (bound to "k").
