### PR TITLE
Fixed the log menu entry (magit-log-menu was removed)

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1857,7 +1857,11 @@ FUNC should leave point at the end of the modified region"
     "---"
     ["Diff working tree" magit-diff-working-tree t]
     ["Diff" magit-diff t]
-    ["Log..." magit-log-menu t]
+    ("Log"
+     ["Short Log" magit-display-log t]
+     ["Long Log" magit-log-long t]
+     ["Reflog" magit-reflog t]
+     ["Extended..." magit-key-mode-popup-logging t])
     "---"
     ["Cherry pick" magit-cherry-pick-item t]
     ["Apply" magit-apply-item t]


### PR DESCRIPTION
magit-log-menu was removed but it is still referenced in the menu (the "Log..." entry doesn't work). My patch changes the "Log" menu to contain a submenu for Short/Long/Reflog or a call to the popup (Extended).
