### PR TITLE
Read dotted rev range

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -932,8 +932,11 @@ argument or a list of strings used as regexps."
 			     def-beg)))
     (if (not beg)
 	nil
-      (let ((end (magit-read-rev (format "%s end" op) def-end)))
-	(cons beg end)))))
+      (save-match-data
+	(if (string-match "^\\(.+\\)\\.\\.\\(.+\\)$" beg)
+	    (cons (match-string 1 beg) (match-string 2 beg))
+	  (let ((end (magit-read-rev (format "%s end" op) def-end)))
+	    (cons beg end)))))))
 
 (defun magit-rev-to-git (rev)
   (or rev

--- a/magit.texi
+++ b/magit.texi
@@ -335,7 +335,9 @@ representation of the relationships between commits.
 
 Giving a prefix argument to @kbd{l} will ask for the starting and end
 point of the history.  This can be used to show the commits that are
-in one branch, but not in another, for example.
+in one branch, but not in another, for example.  The start point can
+also be a range of revisions ``r1..r2''.  In that case ``r1'' is used
+as the start and ``r2'' as the end point of the history.
 
 Typing @kbd{l L} (or @kbd{l C-u L}) will show the log in a more verbose
 form.


### PR DESCRIPTION
Accept "start..end" when reading revisions interactively 

Can come in handy if you want to pase the result directly from git's output, e.g. when fast-forward merging a branch.
