### PR TITLE
fix issue #127

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2528,7 +2528,8 @@ must return a string which will represent the log line.")
                                 nil)
                                ((string= (match-string 1 r) "remotes")
                                 'magit-log-head-label-remote)
-                               ((string-match "^patches/[^/]*$" (match-string 1 r)) ; Stacked Git
+                               ((and (not (null (match-string 1 r))) 
+                                     (string-match "^patches/[^/]*$" (match-string 1 r))) ; Stacked Git
                                 'magit-log-head-label-patches)
                                ((string= (match-string 1 r) "bisect")
                                 (if (string= (match-string 2 r) "bad")
@@ -2537,6 +2538,8 @@ must return a string which will represent the log line.")
                                ((string= (match-string 1 r) "tags")
                                 'magit-log-head-label-tags)
                                ((string= (match-string 1 r) "heads")
+                                'magit-log-head-label-local)
+                               (t
                                 'magit-log-head-label-local))))
                      refs
                      " ")


### PR DESCRIPTION
this change fixes issue #127 in 2 steps:
- break the false assumption that we're able to recognise all namings (=> (match-string 1 r) might very well be nil)
- apply default face when naming scheme isn't recognised

For the second point, we might want to introduce a separate face, although in my opinion the "local" one is probably fine.
Ideally we should be able to extend this in extensions, but that's much more work to do it properly
