### PR TITLE
Puts magit customizable faces in their own subgroup 

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -209,6 +209,7 @@ t mean pty, it enable magit to prompt for passphrase when needed."
 (defgroup magit-faces nil
   "Customize the appearance of Magit"
   :prefix "magit-"
+  :group 'faces
   :group 'magit)
 
 (defface magit-header


### PR DESCRIPTION
Originally the defcustoms that affect magit's behavior and the deffaces that affect it's appearance were all part of the 'magit' customize group.

I've changed them so that they're part of the group magit-faces, which is a sub-group of BOTH the 'magit' and 'faces' groups.  This makes sense, and seems to be typical for other modes within Emacs that define their own faces.
