### PR TITLE
Fix issues #53 and #54

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2437,7 +2437,7 @@ in the corresponding directories."
 	  (forward-line -1))
     (let ((line (line-number-at-pos)))
       (goto-char (magit-section-beginning hunk))
-      (if (not (looking-at "@@+ .* \\+\\([0-9]+\\),[0-9]+ @@+"))
+      (if (not (looking-at "@@+ .* \\+\\([0-9]+\\)\\(,[0-9]+\\)? @@+"))
 	  (error "Hunk header not found"))
       (let ((target (string-to-number (match-string 1))))
 	(forward-line)


### PR DESCRIPTION
iIssue #54:  When user tries to visit a diff by pressing RET with the cursor on a deleted line, visit a nearby line instead of raising an error.

Issue #53:  Change regexp so that visiting a small diff no longer fails when showing 0 context lines.
