### PR TITLE
Allow path to repo as input when magit-repo-dirs is set

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -796,7 +796,7 @@ Otherwise, return nil."
         (file-name-as-directory
          (or (cdr (assoc reply repos))
              (if (file-directory-p reply)
-                 reply
+                 (expand-file-name reply)
                (error "Not a repository or a directory: %s" reply)))))
     (file-name-as-directory
      (read-directory-name "Git repository: "


### PR DESCRIPTION
When magit-status interactively asks for the repository, don't raise an error if the user gives a directory instead of a named repo.  You still need to use C-u C-u if you want completion for directories.
