### PR TITLE
Make `magit-fetch-current` ask for a remote if there is none specified.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3308,15 +3308,17 @@ Uncomitted changes in both working tree and staging area are lost.
 
 ;;; Updating, pull, and push
 
-(magit-define-command fetch ()
+(magit-define-command fetch (&optional remote)
   "Run fetch."
   (interactive)
-  (magit-run-git-async "fetch" (magit-read-remote)))
+  (magit-run-git-async "fetch" (or remote
+                                   (magit-read-remote))))
 
 (magit-define-command fetch-current ()
   "Run fetch."
   (interactive)
-  (magit-run-git-async "fetch"))
+  (magit-fetch (or (magit-get-current-remote)
+                   (magit-read-remote))))
 
 (magit-define-command remote-update ()
   "Update all remotes."


### PR DESCRIPTION
Make `magit-fetch-current` ask for a remote if there is none specified for the current branch, instead of raising an error.

Fixes the issue that Phil pointed out in the comment to #83.  The real issue in #83, though, is that the documentation is outdated.
