### PR TITLE
Prevent `magit-topgit.el` from breaking Magit when TopGit isn't installed

### DIFF
--- a/magit-topgit.el
+++ b/magit-topgit.el
@@ -44,7 +44,8 @@
 ;;; Topic branches (using topgit)
 
 (defun magit-topgit-in-topic-p ()
-  (file-exists-p ".topdeps"))
+  (and (file-exists-p ".topdeps")
+       (executable-find magit-topgit-executable)))
 
 (defun magit-topgit-create-branch (branch parent)
   (when (zerop (or (string-match magit-topgit-branch-prefix branch) -1))
@@ -127,9 +128,10 @@
     (apply 'magit-git-section section title washer args)))
 
 (magit-define-inserter topics ()
-  (magit-topgit-section 'topics
-                        "Topics:" 'magit-topgit-wash-topics
-                        "summary"))
+  (when (executable-find magit-topgit-executable)
+      (magit-topgit-section 'topics
+                            "Topics:" 'magit-topgit-wash-topics
+                            "summary")))
 
 (magit-add-action (item info "discard")
   ((topic)


### PR DESCRIPTION
Since 597fc9faf01ab112f8012faa89388437f8bec1af loading magit-topgit.el has caused an error to be raised while populating the status buffer if magit-topgit-executable can't be found.

You could say just don't load the file if you're not using TopGit, but I don't think existing Magit functionality should break when you load every file in the Magit directory.

This change is intended to make magit-topgit functions that may try to run magit-topgit-executable into no-ops if the command doesn't exist.  (It would be nice if someone who knows more about TopGit than me would make sure it does what's intended and there isn't a better way to do it.)
