### PR TITLE
Bug fix

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3342,8 +3342,8 @@ Uncomitted changes in both working tree and staging area are lost.
 
 (magit-define-command fetch (remote)
   "Fetch from REMOTE."
-  (interactive (magit-read-remote))
-  (magit-run-git-async "fetch" (or remote)))
+  (interactive (list (magit-read-remote)))
+  (magit-run-git-async "fetch" remote))
 
 (magit-define-command fetch-current ()
   "Run fetch for default remote.


### PR DESCRIPTION
Fix bug introduced in 18d33922ee48d2f8935985725b50a9302d57cefc

Interactive spec must evaluate to a _list_ of arguments to pass to the function.
