### PR TITLE
magit-bisect-skip doesn't take an argument; so don't pass one when callin

### DIFF
--- a/magit-bisect.el
+++ b/magit-bisect.el
@@ -87,7 +87,7 @@ match REQUIRED-STATUS."
 
 (defun magit-bisect-skip ()
   "Tell git to skip the current revision during a bisect session."
-  (interactive "P")
+  (interactive)
   (unless (magit--bisecting-p 'running)
     (error "Not bisecting"))
   (magit--bisect-cmd "skip"))


### PR DESCRIPTION
magit-bisect-skip doesn't take an argument; so don't pass one when calling it interactively

Fix for bug introduced in 5d1336a

@pjweisberg thanks
