### PR TITLE
fixing bug in my commit 14fdc8dc7ccb05c4 ("make rewrite start on top of base, not below")

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3432,9 +3432,7 @@ Uncomitted changes in both working tree and staging area are lost.
   (or (not (magit-read-rewrite-info))
       (error "Rewrite in progress"))
   (let* ((orig (magit-rev-parse "HEAD"))
-         (base (if (car (magit-commit-parents from))
-                   from
-                 (error "Can't rewrite a commit without a parent, sorry")))
+         (base from)
 	 (pending (magit-git-lines "rev-list" (concat base ".."))))
     (magit-write-rewrite-info `((orig ,orig)
 				(pending ,@(mapcar #'list pending))))


### PR DESCRIPTION
Since the rewrite base isn't rewritten itself anymore, verifying if it
has any parents is unnecessary and counter-productive:
- Unnecessary because there's no chance of erroneously writing
  parentless commits. It is itself the parent for subsequent commits.
- Counter-productive because it results in faulty behaviour. It
  renders us unable to use the very first commit as rewrite base.
