### PR TITLE
Automatically determine version within the Git repository.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0.0
+VERSION=$(shell git describe --tags --dirty)
 EMACS=emacs
 PREFIX=/usr/local
 ELS=magit.el magit-svn.el magit-topgit.el magit-key-mode.el magit-bisect.el
@@ -31,12 +31,15 @@ magit.info:
 dist: $(DIST_FILES)
 	mkdir -p magit-$(VERSION)
 	cp $(DIST_FILES) magit-$(VERSION)
+	sed -i "s/$$.s\hell git describe./$(VERSION)/" magit-$(VERSION)/Makefile
+	sed -i "s/@GIT_DEV_VERSION@/$(VERSION)/" magit-$(VERSION)/magit.el
 	tar -cvzf magit-$(VERSION).tar.gz magit-$(VERSION)
 	rm -rf magit-$(VERSION)
 
 install: all
 	mkdir -p $(DESTDIR)/$(PREFIX)/share/emacs/site-lisp
 	install -m 644 $(ELS) $(ELCS) $(DESTDIR)/$(PREFIX)/share/emacs/site-lisp
+	sed -i "s/@GIT_DEV_VERSION@/$(VERSION)/" $(DESTDIR)/$(PREFIX)/share/emacs/site-lisp/magit.el
 	mkdir -p $(DESTDIR)/$(PREFIX)/share/info
 	install -m 644 magit.info $(DESTDIR)/$(PREFIX)/share/info
 	install-info --info-dir=$(DESTDIR)/$(PREFIX)/share/info $(DESTDIR)/$(PREFIX)/share/info/magit.info

--- a/bin/mk_rel.bash
+++ b/bin/mk_rel.bash
@@ -1,51 +1,13 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
-function makefile_ver_ok {
-  grep "VERSION=${1}" Makefile || return 1
-}
-
-function magit_el_ver_ok {
-  grep -e ";; Version: *$1" magit.el || return 1
-}
-
-USAGE="usage: ${0##*/} <tag>"
-
-tag="${1}"
-
-[ ${#} -lt 1 ] && {
-    echo ${USAGE} >&2
-    exit 2
-}
-
-# does the specified tag exist?
-if ! git tag | grep "${tag}"; then
-  echo "Make sure you've tagged '${tag}'"
-  exit 3
+if [ -z "$1" ]; then
+    make dist
+else
+    home_rev=$(git name-rev --name-only HEAD)
+    make clean
+    git checkout "$1"
+    make dist
+    git checkout "$home_rev"
 fi
-
-# grab that tag
-git co "${tag}"
-
-# correct version in magit?
-if ! magit_el_ver_ok "$tag"; then
-  echo "Please set version in magit.el to $tag"
-  git co master
-  exit 1
-fi
-
-# correct version in configure.ac?
-if ! makefile_ver_ok "$tag"; then
-  echo "Please set AC_INIT to $tag in configure.ac"
-  git co master
-  exit 1
-fi
-
-# clean up if we need to
-make clean
-
-make dist
-
-# back to master
-git co master

--- a/magit.el
+++ b/magit.el
@@ -41,7 +41,7 @@
 
 ;; Original Author: Marius Vollmer <marius.vollmer@nokia.com>
 ;; Lead developer: Phil Jackson <phil@shellarchive.co.uk>
-;; Version: 1.0.0
+;; Version: @GIT_DEV_VERSION@
 ;; Keywords: tools
 
 ;;


### PR DESCRIPTION
Does this seem like a good idea to anyone else?

The version number is set to the output of `git describe --tags
--dirty`.  If the current HEAD is tagged (as released version are),
then that will be the name of the tag.  Otherwise it will be the tag
name, plus the number of commits on top of that tag, plus a short hash
of the exact commit, plus "-dirty" if there are changes in the working
tree.  Thus, the version number will actually tell us the exact
version being used when a development snapshot is installed

The Makefile's `dist` and `install` targets will substitute in the
proper version numbers when they create files to be used outside the
Git directory.

bin/mk_rel.bash has been simplified greatly, since there's no longer
any consistency checking for it to do.
