### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3095,7 +3095,7 @@ PREPEND-REMOTE-NAME is non-nil."
 	(and (y-or-n-p (format "Directory %s does not exists.  Create it? " dir))
 	     (make-directory dir)))
       (let ((default-directory dir))
-	(magit-run* (list "git" "init"))))))
+	(magit-run* (list magit-git-executable "init"))))))
 
 (define-minor-mode magit-status-mode
     "Minor mode for looking at git status.


### PR DESCRIPTION
The following changes could be controversial:
- Make buffer names follow the standard Emacs style. Hopefully people are not yet depending on the old names.
- Make faces inherit from font-lock faces when reasonable, to automatically blend in with the user’s color theme.

However, I believe this is an improvement for most people—especially new users.
