### PR TITLE
magit-insert-diff-title: show "typechange" as such, not "?"

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2348,18 +2348,20 @@ in the corresponding directories."
 (defun magit-insert-diff-title (status file file2)
   (let ((status-text (case status
 		       ((unmerged)
-			(format "Unmerged %s" file))
+			(format "Unmerged   %s" file))
 		       ((new)
-			(format "New      %s" file))
+			(format "New        %s" file))
 		       ((deleted)
-			(format "Deleted  %s" file))
+			(format "Deleted    %s" file))
 		       ((renamed)
-			(format "Renamed  %s   (from %s)"
+			(format "Renamed    %s   (from %s)"
 				file file2))
 		       ((modified)
-			(format "Modified %s" file))
+			(format "Modified   %s" file))
+		       ((new-type)
+			(format "Typechange %s" file))
 		       (t
-			(format "?        %s" file)))))
+			(format "?          %s" file)))))
     (insert "\t" status-text "\n")))
 
 (defvar magit-current-diff-range nil


### PR DESCRIPTION
Change the display of type changes (e.g. a regular file now being a
symlink) from a "?" to a "Typechange", like git-status(1) does.

magit-wash-raw-diff already parsed this out since Marius Vollmer added
the code for it in 6e33fdf6c73d11545c9a44df8343916216b16918 in July
2009, but it hasn't ever been used.

It's about time.

Signed-off-by: Ævar Arnfjörð Bjarmason avarab@gmail.com
