### PR TITLE
Fix changing tracked branch for "remote/branch" name syntax with unknown 

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5024,18 +5024,19 @@ name of the remote and branch name. The remote must be known to git."
                                                               ref)))))
          new-remote new-branch)
     (unless (string= (or new-tracked "") "")
-      (if (string-match "^refs/remotes/\\([^/]+\\)/\\(.+\\)" ; 1: remote name; 2: branch name
-                        new-tracked)
-          (setq new-remote (match-string 1 new-tracked)
-                new-branch (concat "refs/heads/" (match-string 2 new-tracked)))
-        ;; Match refs that are unknown in the local repository. Can be
-        ;; useful if you want to create a new branch in a remote
-        ;; repository.
-        (if (string-match "^\\([^ ]+\\) +(\\(.+\\))$" ; 1: branch name; 2: remote name
-                          new-tracked)
-            (setq new-remote (match-string 2 new-tracked)
-                  new-branch (concat "refs/heads/" (match-string 1 new-tracked)))
-            (error "Cannot parse the remote and branch name"))))
+      (cond (;; Match refs that are unknown in the local repository if
+             ;; `magit-remote-ref-format' is set to
+             ;; `name-then-remote'. Can be useful if you want to
+             ;; create a new branch in a remote repository.
+             (string-match "^\\([^ ]+\\) +(\\(.+\\))$" ; 1: branch name; 2: remote name
+                           new-tracked)
+             (setq new-remote (match-string 2 new-tracked)
+                   new-branch (concat "refs/heads/" (match-string 1 new-tracked))))
+            ((string-match "^\\(?:refs/remotes/\\)?\\([^/]+\\)/\\(.+\\)" ; 1: remote name; 2: branch name
+                           new-tracked)
+             (setq new-remote (match-string 1 new-tracked)
+                   new-branch (concat "refs/heads/" (match-string 2 new-tracked))))
+            (t (error "Cannot parse the remote and branch name"))))
     (magit-set new-remote "branch" local-branch "remote")
     (magit-set new-branch "branch" local-branch "merge")
     (magit-show-branches)


### PR DESCRIPTION
Fix changing tracked branch for "remote/branch" name syntax with unknown remote branches

There are three cases that can be returned from magit-read-rev:
- "refs/remotes/remote/branch" -- This happens if the user enters a
  remote branch name that is known to git.
- "branch (remote)" -- This happens if the remote branch is not known
  to git, e.g. if the user wants to create the branch in the remote by
  pushing to it afterwards. Usually happens if
  `magit-remote-ref-format' is set to 'name-then-remote.
- "remote/branch" -- This happens if the remote branch is not known to
  git, e.g. if the user wants to create the branch in the remote by
  pushing to it afterwards. Usually happens if
  `magit-remote-ref-format' is set to 'remote-slash-name.
