### PR TITLE
madit-add-log: insert "FILE: ", not "\n * FILE: "

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3986,7 +3986,7 @@ continue it.
 			  (format "^\\* %s" (regexp-quote file)) nil t))
 		    ;; No entry for file, create it.
 		    (goto-char (point-max))
-		    (insert (format "\n* %s" file))
+		    (insert (format "%s" file))
 		    (if fun
 			(insert (format " (%s)" fun)))
 		    (insert ": "))


### PR DESCRIPTION
The most common convention in Git for starting a log entry is to have
the filename followed by a colon, not start the commit message with a
newline, then a " *" followed by the filename and a colon.

With this change we play much nicer with things like "git log
--oneline", and don't show "\* *" for each log entry in magit's log
buffers anymore.

Signed-off-by: Ævar Arnfjörð Bjarmason avarab@gmail.com
