### PR TITLE
Jump through hoops to run gitk on Windows

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -656,11 +656,11 @@ Many Magit faces inherit from this one by default."
 
 ;;; Compatibilities
 
-(if (functionp 'start-file-process)
-    (defalias 'magit-start-process 'start-file-process)
+(eval-and-compile
+  (if (functionp 'start-file-process)
+      (defalias 'magit-start-process 'start-file-process)
     (defalias 'magit-start-process 'start-process))
 
-(eval-and-compile
   (if (fboundp 'with-silent-modifications)
       (defalias 'magit-with-silent-modifications 'with-silent-modifications)
     (defmacro magit-with-silent-modifications (&rest body)


### PR DESCRIPTION
This works, but it just looks messy to me.  I thought I'd post it here for comments instead of just checking it in..

`gitk` is a shell script, and Windows doesn't know what to do with
those.  Make sure Git's installed directory is on the PATH, then run
it with `sh`.
