### PR TITLE
Changes to rebase-mode: Added Menu, Support for Exec and minor doc fixes.

### DIFF
--- a/rebase-mode.el
+++ b/rebase-mode.el
@@ -21,6 +21,8 @@
 ;; using 'git rebase -i' or hitting 'E' in Magit). Assumes editing is
 ;; happening in a server.
 
+;;; Code:
+
 (defvar rebase-mode-action-line-re
   (rx
    line-start
@@ -55,7 +57,7 @@
    (list rebase-mode-exec-line-re
          '(1 font-lock-keyword-face))
    (list (rx line-start (char "#") (* not-newline)) 0 font-lock-comment-face))
-  "Font lock keywords for rebase-mode.")
+  "Font lock keywords for `rebase-mode'.")
 
 (defvar key-to-action-map
   '(("c" . "pick")
@@ -83,7 +85,7 @@
 
     map)
   "Keymap for rebase-mode.  Note this will be added to by the
-  top-level code which defines the edit functions.")
+top-level code which defines the edit functions.")
 
 (require 'easymenu)
 (easy-menu-define rebase-mode-menu rebase-mode-map
@@ -127,13 +129,13 @@ that of CHANGE-TO."
       (goto-char start))))
 
 (defun rebase-mode-looking-at-action ()
-  "Returns non-nil if looking at an action line."
+  "Return non-nil if looking at an action line."
   (save-excursion
     (goto-char (point-at-bol))
     (looking-at rebase-mode-action-line-re)))
 
 (defun rebase-mode-looking-at-action-or-exec ()
-  "Returns non-nil if looking at an action line or exec line."
+  "Return non-nil if looking at an action line or exec line."
   (save-excursion
     (goto-char (point-at-bol))
     (or (looking-at rebase-mode-action-line-re)
@@ -150,8 +152,7 @@ that of CHANGE-TO."
       (move-to-column col))))
 
 (defun rebase-mode-move-line-down ()
-  "Assuming the next line is also an action line, move the
-current line down."
+  "Assuming the next line is also an action line, move the current line down."
   (interactive)
   ;; if we're on an action and the next line is also an action
   (when (and (rebase-mode-looking-at-action-or-exec)
@@ -200,7 +201,7 @@ server connection)."
 
 ;;;###autoload
 (defun rebase-mode ()
-  "Major mode for editing of a git rebase file
+  "Major mode for editing of a git rebase file.
 
 Rebase files are generated when you run 'git rebase -i' or run `magit-interactive-rebase'"
 
@@ -220,3 +221,5 @@ Rebase files are generated when you run 'git rebase -i' or run `magit-interactiv
              '("git-rebase-todo" . rebase-mode))
 
 (provide 'rebase-mode)
+
+;;; rebase-mode.el ends here


### PR DESCRIPTION
Following changes to rebase-mode.el
- Added a Menu: I think having a menu is a great way to introduce new users to the usage of the mode.
- Added support for Exec: git rebase -i supports the execution of Shell commands (e.g. make test). I added syntax highlighting, the capability to kill/move exec lines and a function to insert exec lines
- I fixed some errors M-x checkdoc reported.
