### PR TITLE
re-enabled the magit-log-all command

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4459,6 +4459,30 @@ With a non numeric prefix ARG, show all entries"
 		     "--stat" args)
     (magit-log-mode t)))
 
+(defun magit-log-all (&optional arg)
+  "Display the state of all refs in the log output."
+  (interactive "P")
+  (magit-log arg "--all"))
+
+(defun magit-log-first-parent (&optional arg)
+  "Display the log buffer excluding anything more than first
+level commits."
+  (interactive "P")
+  (magit-log arg "--first-parent"))
+
+(defun magit-log-grep (str)
+  "Search for regexp specified by STR in the commit log."
+  (interactive "sGrep in commit log: ")
+  (let ((topdir (magit-get-top-dir default-directory)))
+    (switch-to-buffer magit-log-grep-buffer-name)
+    (magit-mode-init topdir 'log #'magit-refresh-log-buffer "HEAD"
+		     "--pretty=oneline"
+		     (append
+		      (list "-E"
+			    (format "--grep=%s" (shell-quote-argument str)))
+		      magit-custom-options))
+    (magit-log-mode t)))
+
 ;;; Reflog
 
 (defvar magit-reflog-head nil


### PR DESCRIPTION
I was quite disappointed to see that magit-log-all command was removed... I'm using it very often and I even had it bind to C-x C-l ...

I must have miss something as I can even figure how to properly use a git repository without this command ;).

Any comments are welcome.
