### PR TITLE
Don't break when a user sets abbrevCommit=true in their config.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4415,10 +4415,13 @@ With prefix argument, changes in staging area are kept.
 
 (defvar magit-have-graph 'unset)
 (defvar magit-have-decorate 'unset)
+(defvar magit-have-abbrev 'unset)
 (make-variable-buffer-local 'magit-have-graph)
 (put 'magit-have-graph 'permanent-local t)
 (make-variable-buffer-local 'magit-have-decorate)
 (put 'magit-have-decorate 'permanent-local t)
+(make-variable-buffer-local 'magit-have-abbrev)
+(put 'magit-have-abbrev 'permanent-local t)
 
 (defun magit-configure-have-graph ()
   (if (eq magit-have-graph 'unset)
@@ -4429,6 +4432,11 @@ With prefix argument, changes in staging area are kept.
   (if (eq magit-have-decorate 'unset)
       (let ((res (magit-git-exit-code "log" "--decorate=full" "--max-count=0")))
 	(setq magit-have-decorate (eq res 0)))))
+
+(defun magit-configure-have-abbrev ()
+  (if (eq magit-have-abbrev 'unset)
+      (let ((res (magit-git-exit-code "log" "--no-abbrev-commit" "--max-count=0")))
+	(setq magit-have-abbrev (eq res 0)))))
 
 (defun magit-log-show-more-entries (&optional arg)
   "Grow the number of log entries shown.
@@ -4450,6 +4458,7 @@ With a non numeric prefix ARG, show all entries"
 (defun magit-refresh-log-buffer (range style args)
   (magit-configure-have-graph)
   (magit-configure-have-decorate)
+  (magit-configure-have-abbrev)
   (setq magit-current-range range)
   (magit-create-log-buffer-sections
     (apply #'magit-git-section nil
@@ -4460,6 +4469,7 @@ With a non numeric prefix ARG, show all entries"
 	     ,style
 	     ,@(if magit-have-decorate (list "--decorate=full"))
 	     ,@(if magit-have-graph (list "--graph"))
+	     ,@(if magit-have-abbrev (list "--no-abbrev-commit"))
 	     ,@args
 	     "--"))))
 


### PR DESCRIPTION
I like to have:

```
[log]
abbrevCommit = true
```

in my ~/.gitconfig. magit breaks when I do that. Fix that.
