### PR TITLE
added call to magit-configure-have-abbrev in magit-refresh-commit-buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3110,6 +3110,7 @@ insert a line to tell how to insert more of them"
                     'face 'magit-log-sha1))
 
 (defun magit-refresh-commit-buffer (commit)
+  (magit-configure-have-abbrev)
   (magit-create-buffer-sections
     (apply #'magit-git-section nil nil
 	   'magit-wash-commit


### PR DESCRIPTION
Commit 76a2b9b66 introduced a bug where diffs are blank when navigating through them from the log view on machines where --no-abbrev-commit is not available.  This looks to be due to magit-have-abbrev not being initialized in magit-refresh-commit-buffer.  This patch adds a call to magit-configure-have-abbrev to the ensure the variable is initialized.
