### PR TITLE
Promote minor modes to major

### DIFF
--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -197,9 +197,8 @@
            (with-current-buffer buf
              (set-buffer buf)
              (goto-char (point-min))
-             (magit-mode-init dir 'commit
-                              #'magit-stgit--refresh-patch-buffer patch)
-             (magit-commit-mode t))))))
+             (magit-mode-init dir 'magit-commit-mode
+                              #'magit-stgit--refresh-patch-buffer patch))))))
 
 (magit-add-action (item info "visit")
   ((series)

--- a/magit.el
+++ b/magit.el
@@ -621,11 +621,6 @@ Do not customize this (used in the `magit-key-mode' implementation).")
     (define-key map (kbd "e") 'magit-log-show-more-entries)
     map))
 
-(defvar magit-reflog-mode-map
-  (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map magit-log-mode-map)
-    map))
-
 (defvar magit-wazzup-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd ".") 'magit-mark-item)
@@ -732,10 +727,6 @@ Does not follow symlinks."
   "Set SYMBOL to VALUE and call `magit-refresh-all'"
   (set-default symbol value)
   (magit-refresh-all))
-
-(defvar magit-submode nil)
-(make-variable-buffer-local 'magit-submode)
-(put 'magit-submode 'permanent-local t)
 
 (defun magit-iswitchb-completing-read (prompt choices &optional predicate require-match
                                        initial-input hist def)
@@ -1002,7 +993,7 @@ out revs involving HEAD."
 
 (defun magit-highlight-line-whitespace ()
   (when (and magit-highlight-whitespace
-             (or magit-status-mode
+             (or (derived-mode-p 'magit-status-mode)
                  (not (eq magit-highlight-whitespace 'status))))
     (if (and magit-highlight-trailing-whitespace
              (looking-at "^[-+].*?\\([ \t]+\\)$"))
@@ -1474,7 +1465,7 @@ see `magit-insert-section' for meaning of the arguments"
     (forward-line -1)
     (magit-goto-next-section))
    ((and (eq (magit-section-type section) 'commit)
-         (memq magit-submode '(log reflog)))
+         (derived-mode-p 'magit-log-mode))
     (magit-show-commit section))))
 
 (defun magit-goto-section-at-path (path)
@@ -1644,7 +1635,7 @@ otherwise do it only on ancestors and descendants of current section."
 
 Do this in on ancestors and descendants of current section."
   (interactive)
-  (if (eq magit-submode 'status)
+  (if (derived-mode-p 'magit-status-mode)
       (call-interactively 'magit-show-level-2)
     (call-interactively 'magit-show-level-1)))
 
@@ -1653,7 +1644,7 @@ Do this in on ancestors and descendants of current section."
 
 Do this for all sections"
   (interactive)
-  (if (eq magit-submode 'status)
+  (if (derived-mode-p 'magit-status-mode)
       (call-interactively 'magit-show-level-2-all)
     (call-interactively 'magit-show-level-1-all)))
 
@@ -2199,10 +2190,9 @@ Please see the manual for a complete description of Magit.
 
 (defun magit-mode-init (dir submode refresh-func &rest refresh-args)
   (setq default-directory dir
-	magit-submode submode
 	magit-refresh-function refresh-func
 	magit-refresh-args refresh-args)
-  (magit-mode)
+  (funcall submode)
   (magit-refresh-buffer))
 
 (defun magit-indentation-for (dir)
@@ -2218,17 +2208,16 @@ Please see the manual for a complete description of Magit.
       (if (with-current-buffer buf
 	    (and default-directory
 		 (equal (expand-file-name default-directory) topdir)
-		 (eq major-mode 'magit-mode)
-		 (eq magit-submode submode)))
+                 (eq major-mode submode)))
 	  (return buf)))))
 
 (defun magit-find-status-buffer (&optional dir)
-  (magit-find-buffer 'status dir))
+  (magit-find-buffer 'magit-status-mode dir))
 
 (defun magit-for-all-buffers (func &optional dir)
   (dolist (buf (buffer-list))
     (with-current-buffer buf
-      (if (and (eq major-mode 'magit-mode)
+      (if (and (derived-mode-p 'magit-mode)
 	       (or (null dir)
 		   (equal default-directory dir)))
 	  (funcall func)))))
@@ -3059,14 +3048,11 @@ insert a line to tell how to insert more of them"
 	     "--cc"
 	     "-p" ,commit))))
 
-(define-minor-mode magit-commit-mode
-    "Minor mode to view a git commit.
+(define-derived-mode magit-commit-mode magit-mode "Magit"
+  "Mode to view a git commit.
 
 \\{magit-commit-mode-map}"
-  :group magit
-  :init-value ()
-  :lighter ()
-  :keymap magit-commit-mode-map)
+  :group 'magit)
 
 (defvar magit-commit-buffer-name "*magit-commit*"
   "Buffer name for displaying commit log messages.")
@@ -3115,9 +3101,8 @@ for this argument.)"
           (setq magit-forward-navigation-history nil))
         (setq magit-currently-shown-commit commit)
         (goto-char (point-min))
-        (magit-mode-init dir 'commit
-                         #'magit-refresh-commit-buffer commit)
-        (magit-commit-mode t))))
+        (magit-mode-init dir 'magit-commit-mode
+                         #'magit-refresh-commit-buffer commit))))
     (if select
         (pop-to-buffer buf))))
 
@@ -3295,14 +3280,11 @@ PREPEND-REMOTE-NAME is non-nil."
       (let ((default-directory dir))
 	(magit-run* (list magit-git-executable "init"))))))
 
-(define-minor-mode magit-status-mode
-    "Minor mode for looking at git status.
+(define-derived-mode magit-status-mode magit-mode "Magit"
+    "Mode for looking at git status.
 
 \\{magit-status-mode-map}"
-  :group magit
-  :init-value ()
-  :lighter ()
-  :keymap magit-status-mode-map)
+  :group 'magit)
 
 (defun magit-save-some-buffers (&optional msg pred)
   "Save some buffers if variable `magit-save-some-buffers' is non-nil.
@@ -3369,8 +3351,7 @@ user input."
 			      (file-name-nondirectory
 			       (directory-file-name topdir)) "*")))))
         (funcall magit-status-buffer-switch-function buf)
-        (magit-mode-init topdir 'status #'magit-refresh-status)
-        (magit-status-mode t)))))
+        (magit-mode-init topdir 'magit-status-mode #'magit-refresh-status)))))
 
 (magit-define-command automatic-merge (revision)
   "Merge REVISION into the current 'HEAD'; commit unless merge fails.
@@ -3941,9 +3922,6 @@ typing and automatically refreshes the status buffer."
 
 ;;; Log edit mode
 
-(defvar magit-log-edit-mode-hook nil
-  "Hook run by `magit-log-edit-mode'.")
-
 (defvar magit-log-edit-buffer-name "*magit-edit-log*"
   "Buffer name for composing commit messages.")
 
@@ -4315,13 +4293,11 @@ With prefix argument, changes in staging area are kept.
 
 (defvar magit-currently-shown-stash nil)
 
-(define-minor-mode magit-stash-mode
-    "Minor mode for looking at a git stash.
+(define-derived-mode magit-stash-mode magit-mode
+    "Mode for looking at a git stash.
 
 \\{magit-stash-mode-map}"
-  :group magit
-  :init-value ()
-  :lighter ())
+  :group 'magit)
 
 (defvar magit-stash-buffer-name "*magit-stash*"
   "Buffer name for displaying a stash.")
@@ -4350,10 +4326,8 @@ With prefix argument, changes in staging area are kept.
              (let* ((range (cons (concat stash "^2^") stash))
                     (magit-current-diff-range range)
                     (args (magit-rev-range-to-git range)))
-               (magit-mode-init dir 'diff #'magit-refresh-diff-buffer
-                                range args)
-               (magit-stash-mode t)))))))
-
+               (magit-mode-init dir 'magit-diff-mode #'magit-refresh-diff-buffer
+                                range args)))))))
 ;;; Commits
 
 (defun magit-commit-at-point (&optional nil-ok-p)
@@ -4505,14 +4479,11 @@ With a non numeric prefix ARG, show all entries"
 	     ,@args
 	     "--"))))
 
-(define-minor-mode magit-log-mode
-    "Minor mode for looking at git log.
+(define-derived-mode magit-log-mode magit-mode "Magit"
+    "Mode for looking at git log.
 
 \\{magit-log-mode-map}"
-  :group magit
-  :init-value ()
-  :lighter ()
-  :keymap magit-log-mode-map)
+  :group 'magit)
 
 (defvar magit-log-buffer-name "*magit-log*"
   "Buffer name for display of log entries.")
@@ -4532,9 +4503,9 @@ With a non numeric prefix ARG, show all entries"
                       magit-custom-options
                       extra-args)))
     (magit-buffer-switch magit-log-buffer-name)
-    (magit-mode-init topdir 'log #'magit-refresh-log-buffer log-range
-		     "--pretty=oneline" args)
-    (magit-log-mode t)))
+    (magit-mode-init topdir 'magit-log-mode #'magit-refresh-log-buffer log-range
+		     "--pretty=oneline" args)))
+
 (define-obsolete-function-alias 'magit-display-log 'magit-log)
 
 (magit-define-command log-long-ranged ()
@@ -4550,9 +4521,8 @@ With a non numeric prefix ARG, show all entries"
 	 (args (append (list (magit-rev-range-to-git range))
 		       magit-custom-options)))
     (magit-buffer-switch magit-log-buffer-name)
-    (magit-mode-init topdir 'log #'magit-refresh-log-buffer range
-		     "--stat" args)
-    (magit-log-mode t)))
+    (magit-mode-init topdir 'magit-log-mode #'magit-refresh-log-buffer range
+		     "--stat" args)))
 
 ;;; Reflog
 
@@ -4572,14 +4542,11 @@ This is only non-nil in reflog buffers.")
                     (format "--max-count=%s" magit-log-cutoff-length)
                     args)))))
 
-(define-minor-mode magit-reflog-mode
-    "Minor mode for looking at git reflog.
+(define-derived-mode magit-reflog-mode magit-log-mode "Magit"
+    "Mode for looking at git reflog.
 
 \\{magit-reflog-mode-map}"
-  :group magit
-  :init-value ()
-  :lighter ()
-  :keymap magit-reflog-mode-map)
+  :group 'magit)
 
 (magit-define-command reflog (&optional ask-for-range)
   (interactive)
@@ -4589,9 +4556,8 @@ This is only non-nil in reflog buffers.")
     (let* ((topdir (magit-get-top-dir default-directory))
            (args (magit-rev-to-git at)))
       (magit-buffer-switch "*magit-reflog*")
-      (magit-mode-init topdir 'reflog
-                       #'magit-refresh-reflog-buffer at args)
-      (magit-reflog-mode t))))
+      (magit-mode-init topdir 'magit-reflog-mode
+                       #'magit-refresh-reflog-buffer at args))))
 
 (magit-define-command reflog-ranged ()
   (interactive)
@@ -4671,13 +4637,11 @@ restore the window state that was saved before ediff was called."
                          'magit-wash-diffs
                          "diff" (magit-diff-U-arg) args))))
 
-(define-minor-mode magit-diff-mode
-    "Minor mode for looking at a git diff.
+(define-derived-mode magit-diff-mode magit-mode "Magit"
+    "Mode for looking at a git diff.
 
 \\{magit-diff-mode-map}"
-  :group magit
-  :init-value ()
-  :lighter ())
+  :group 'magit)
 
 (magit-define-command diff (range)
   (interactive (list (magit-read-rev-range "Diff")))
@@ -4687,8 +4651,7 @@ restore the window state that was saved before ediff was called."
              (buf (get-buffer-create "*magit-diff*")))
         (display-buffer buf)
         (with-current-buffer buf
-          (magit-mode-init dir 'diff #'magit-refresh-diff-buffer range args)
-          (magit-diff-mode t)))))
+          (magit-mode-init dir 'magit-diff-mode #'magit-refresh-diff-buffer range args)))))
 
 (magit-define-command diff-working-tree (rev)
   (interactive (list (magit-read-rev "Diff with" (magit-default-rev))))
@@ -4773,24 +4736,20 @@ This is only meaningful in wazzup buffers.")
 			   "--"))))
 		  (magit-set-section-info ref section))))))))))
 
-(define-minor-mode magit-wazzup-mode
-    "Minor mode for looking at commits that could be merged from other branches.
+(define-derived-mode magit-wazzup-mode magit-mode
+    "Mode for looking at commits that could be merged from other branches.
 
 \\{magit-wazzup-mode-map}"
-  :group magit
-  :init-value ()
-  :lighter ()
-  :keymap magit-wazzup-mode-map)
+  :group 'magit)
 
 (defun magit-wazzup (&optional all)
   (interactive "P")
   (let ((topdir (magit-get-top-dir default-directory))
 	(current-branch (magit-get-current-branch)))
     (magit-buffer-switch "*magit-wazzup*")
-    (magit-mode-init topdir 'wazzup
+    (magit-mode-init topdir 'magit-wazzup-mode
 		     #'magit-refresh-wazzup-buffer
-		     current-branch all)
-    (magit-wazzup-mode t)))
+		     current-branch all)))
 
 ;;; Miscellaneous
 
@@ -5165,7 +5124,7 @@ name of the remote and branch name. The remote must be known to git."
   "Show all of the current branches."
   (interactive)
   (let ((buffer-existed (get-buffer magit-branches-buffer-name)))
-    (unless (eq major-mode 'magit-show-branches-mode)
+    (unless (derived-mode-p 'magit-show-branches-mode)
       (let ((topdir (magit-get-top-dir default-directory)))
         (magit-buffer-switch magit-branches-buffer-name)
         (setq magit-refresh-function 'magit-show-branches)


### PR DESCRIPTION
## Is this a change worth making?  I for one was surprised when I learned that "submodes" were implemented as minor modes rather than derived modes.

Instead of having all those little minor modes and the `magit-submode`
variable to help determine which one is in effect, make
`magit-status-mode`, `magit-log-mode`, etc. actual derived modes of
`magit-mode`.

It seems clearer conceptually and it allows for sensible things like
having `magit-reflog-mode` inherit from `magit-log-mode`.
