### PR TITLE
Commit edit hook support.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2117,6 +2117,7 @@ function can be enriched by magit extension like magit-topgit and magit-svn"
     ["Quit Magit" magit-quit-window t]))
 
 (defvar magit-mode-hook nil "Hook run by `magit-mode'.")
+(defvar magit-log-edit-commit-hook nil "Hook run by `magit-log-edit-commit'.")
 
 (put 'magit-mode 'mode-class 'special)
 
@@ -4052,6 +4053,7 @@ toggled on.  When it's toggled on for the first time, return
   "Finish edits and create new commit object.
 \('git commit ...')"
   (interactive)
+  (run-hook-with-args 'magit-log-edit-commit-hook)
   (let* ((fields (magit-log-edit-get-fields))
 	 (amend (equal (cdr (assq 'amend fields)) "yes"))
 	 (allow-empty (equal (cdr (assq 'allow-empty fields)) "yes"))


### PR DESCRIPTION
The use case I had was this:

```
(add-hook 'magit-log-edit-commit-hook 'magit-hook-prompt-missing-ticket)
(defun magit-hook-prompt-missing-ticket ()
  "Prompts to cancel the `magit-log-edit-commit' operation if no ticket reference found."
  (unless (save-excursion
            (goto-char (point-min))
            (search-forward-regexp "\\(refs\\|closes\\|fixes\\) #[0-9]+" nil t))
    (when (y-or-n-p "Didn't find a ticket reference. Edit commit message further? ")
      (signal 'quit nil))))
```

With the hook this works just fine.
