### PR TITLE
Support username in svn-remote URLs

### DIFF
--- a/magit-svn.el
+++ b/magit-svn.el
@@ -75,6 +75,7 @@
              (src (replace-regexp-in-string "\\*" "\\\\(.*\\\\)" (car pats)))
              (dst (replace-regexp-in-string "\\*" "\\\\1" (cadr pats)))
              (base-url (replace-regexp-in-string "\\+" "\\\\+" base-url))
+             (base-url (replace-regexp-in-string "//.+@" "//" base-url))
              (pat1 (concat "^" src "$"))
              (pat2 (cond ((equal src "") (concat "^" base-url "$"))
                          (t (concat "^" base-url "/" src "$")))))


### PR DESCRIPTION
At work I have to deal with a svn repo over https. This caused issues in magit due to the username in the repo URL: https://blabla@forge.workplace.fr/... so I wrote this tiny patch which solved everything for me.

This patch has been sitting in my fork for ages, so I can't really remember what the error was, but I'm positive some things didn't work and this fixed them :)
