### PR TITLE
Disable Cygwin dll autoglobbing when git is not run via shell

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -816,9 +816,21 @@ Does not follow symlinks."
 (defun magit-git-lines (&rest args)
   (magit-split-lines (magit-git-output args)))
 
+(defmacro magit-with-cygwin-auto-glob-protection (&rest body)
+  "Disable Cygwin dll autoglobbing for external command execution within BODY"
+  (declare (indent 0))
+  `(let ((process-environment (cons (concat "CYGWIN=noglob"
+                                            (let ((old (getenv "CYGWIN")))
+                                              (if old
+                                                  (concat " " old)
+                                                "")))
+                                    process-environment)))
+     ,@body))
+
 (defun magit-git-exit-code (&rest args)
-  (apply #'process-file magit-git-executable nil nil nil
-	 (append magit-git-standard-options args)))
+  (magit-with-cygwin-auto-glob-protection
+    (apply #'process-file magit-git-executable nil nil nil
+           (append magit-git-standard-options args))))
 
 (defun magit-file-lines (file)
   (when (file-exists-p file)
@@ -1878,88 +1890,89 @@ function can be enriched by magit extension like magit-topgit and magit-svn"
   (if (and magit-process
 	   (get-buffer magit-process-buffer-name))
       (error "Git is already running"))
-  (let ((cmd (car cmd-and-args))
-	(args (cdr cmd-and-args))
-	(dir default-directory)
-	(buf (get-buffer-create magit-process-buffer-name))
-	(successp nil))
-    (magit-set-mode-line-process
-     (magit-process-indicator-from-command cmd-and-args))
-    (setq magit-process-client-buffer (current-buffer))
-    (with-current-buffer buf
-      (view-mode 1)
-      (set (make-local-variable 'view-no-disable-on-exit) t)
-      (setq view-exit-action
-	    (lambda (buffer)
-	      (with-current-buffer buffer
-		(bury-buffer))))
-      (setq buffer-read-only t)
-      (let ((inhibit-read-only t))
-	(setq default-directory dir)
-	(if noerase
-	    (goto-char (point-max))
-	  (erase-buffer))
-	(insert "$ " (or logline
-			 (mapconcat 'identity cmd-and-args " "))
-		"\n")
-	(cond (nowait
-	       (setq magit-process
-		     (let ((process-connection-type magit-process-connection-type))
-		       (apply 'magit-start-process cmd buf cmd args)))
-	       (set-process-sentinel magit-process 'magit-process-sentinel)
-	       (set-process-filter magit-process 'magit-process-filter)
-	       (when input
-		 (with-current-buffer input
-		   (process-send-region magit-process
-					(point-min) (point-max)))
-		 (process-send-eof magit-process)
-		 (sit-for 0.1 t))
-	       (cond ((= magit-process-popup-time 0)
-		      (pop-to-buffer (process-buffer magit-process)))
-		     ((> magit-process-popup-time 0)
-		      (run-with-timer
-		       magit-process-popup-time nil
-		       (function
-			(lambda (buf)
-			  (with-current-buffer buf
-			    (when magit-process
-			      (display-buffer (process-buffer magit-process))
-			      (goto-char (point-max))))))
-		       (current-buffer))))
-	       (setq successp t))
-	      (input
-	       (with-current-buffer input
-		 (setq default-directory dir)
-		 (setq magit-process
-		       ;; Don't use a pty, because it would set icrnl
-		       ;; which would modify the input (issue #20).
-		       (let ((process-connection-type nil))
-			 (apply 'magit-start-process cmd buf cmd args)))
-		 (set-process-filter magit-process 'magit-process-filter)
-		 (process-send-region magit-process
-				      (point-min) (point-max))
-		 (process-send-eof magit-process)
-		 (while (equal (process-status magit-process) 'run)
-		   (sit-for 0.1 t))
-		 (setq successp
-		       (equal (process-exit-status magit-process) 0))
-		 (setq magit-process nil))
-	       (magit-set-mode-line-process nil)
-	       (magit-need-refresh magit-process-client-buffer))
-	      (t
-	       (setq successp
-		     (equal (apply 'process-file cmd nil buf nil args) 0))
-	       (magit-set-mode-line-process nil)
-	       (magit-need-refresh magit-process-client-buffer))))
-      (or successp
-	  noerror
-	  (error
-	   (or (with-current-buffer (get-buffer magit-process-buffer-name)
-		 (when (re-search-backward
-			(concat "^error: \\(.*\\)" paragraph-separate) nil t)
-		   (match-string 1)))
-	       "Git failed")))
-      successp)))
+  (magit-with-cygwin-auto-glob-protection
+    (let ((cmd (car cmd-and-args))
+          (args (cdr cmd-and-args))
+          (dir default-directory)
+          (buf (get-buffer-create magit-process-buffer-name))
+          (successp nil))
+      (magit-set-mode-line-process
+       (magit-process-indicator-from-command cmd-and-args))
+      (setq magit-process-client-buffer (current-buffer))
+      (with-current-buffer buf
+        (view-mode 1)
+        (set (make-local-variable 'view-no-disable-on-exit) t)
+        (setq view-exit-action
+              (lambda (buffer)
+                (with-current-buffer buffer
+                  (bury-buffer))))
+        (setq buffer-read-only t)
+        (let ((inhibit-read-only t))
+          (setq default-directory dir)
+          (if noerase
+              (goto-char (point-max))
+            (erase-buffer))
+          (insert "$ " (or logline
+                           (mapconcat 'identity cmd-and-args " "))
+                  "\n")
+          (cond (nowait
+                 (setq magit-process
+                       (let ((process-connection-type magit-process-connection-type))
+                         (apply 'magit-start-process cmd buf cmd args)))
+                 (set-process-sentinel magit-process 'magit-process-sentinel)
+                 (set-process-filter magit-process 'magit-process-filter)
+                 (when input
+                   (with-current-buffer input
+                     (process-send-region magit-process
+                                          (point-min) (point-max)))
+                   (process-send-eof magit-process)
+                   (sit-for 0.1 t))
+                 (cond ((= magit-process-popup-time 0)
+                        (pop-to-buffer (process-buffer magit-process)))
+                       ((> magit-process-popup-time 0)
+                        (run-with-timer
+                         magit-process-popup-time nil
+                         (function
+                          (lambda (buf)
+                            (with-current-buffer buf
+                              (when magit-process
+                                (display-buffer (process-buffer magit-process))
+                                (goto-char (point-max))))))
+                         (current-buffer))))
+                 (setq successp t))
+                (input
+                 (with-current-buffer input
+                   (setq default-directory dir)
+                   (setq magit-process
+                         ;; Don't use a pty, because it would set icrnl
+                         ;; which would modify the input (issue #20).
+                         (let ((process-connection-type nil))
+                           (apply 'magit-start-process cmd buf cmd args)))
+                   (set-process-filter magit-process 'magit-process-filter)
+                   (process-send-region magit-process
+                                        (point-min) (point-max))
+                   (process-send-eof magit-process)
+                   (while (equal (process-status magit-process) 'run)
+                     (sit-for 0.1 t))
+                   (setq successp
+                         (equal (process-exit-status magit-process) 0))
+                   (setq magit-process nil))
+                 (magit-set-mode-line-process nil)
+                 (magit-need-refresh magit-process-client-buffer))
+                (t
+                 (setq successp
+                       (equal (apply 'process-file cmd nil buf nil args) 0))
+                 (magit-set-mode-line-process nil)
+                 (magit-need-refresh magit-process-client-buffer))))
+        (or successp
+            noerror
+            (error
+             (or (with-current-buffer (get-buffer magit-process-buffer-name)
+                   (when (re-search-backward
+                          (concat "^error: \\(.*\\)" paragraph-separate) nil t)
+                     (match-string 1)))
+                 "Git failed")))
+        successp))))
 
 (autoload 'dired-uncache "dired")
 (defun magit-process-sentinel (process event)


### PR DESCRIPTION
Annoyingly Cygwin dll detects if the application using it was run by a
non-Cygwin application and by default expands wildcards in arguments,
trying to provide "expected" behaviour for those who run Cygwin
applications from cmd, for example.  If Magit, running in native Windows
Emacs, runs Cygwin git directly instead of through a shell, and passes for
example FOO^{commit} as a parameter, brace expansion turns that into
FOO^commit which is what git actually sees and breakage happens.
