### PR TITLE
magit-log-edit-toggle-amending: handle no commit message body

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4116,7 +4116,7 @@ toggled on.  When it's toggled on for the first time, return
   (interactive)
   (when (eq (magit-log-edit-toggle-field 'amend t) 'first)
     (magit-log-edit-append
-     (magit-format-commit "HEAD" "%s%n%n%b"))))
+     (magit-trim-line (magit-format-commit "HEAD" "%s%n%n%b")))))
 
 (defun magit-log-edit-toggle-signoff ()
   "Toggle whether this commit will include a signoff.


### PR DESCRIPTION
If there is no body, default trimming takes care of the first separator
newline but not the second, so we'll trim another time.
