### PR TITLE
Fix the logic of `magit-log-edit' function.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4206,25 +4206,33 @@ continue it.
 
 \\{magit-log-edit-mode-map}"
   (interactive "P")
-  (cond ((magit-rebase-info)
-	 (if (y-or-n-p "Rebase in progress.  Continue it? ")
-	     (magit-run-git-async "rebase" "--continue")))
-	(t
-	 (when (and magit-commit-all-when-nothing-staged
-		    (not (magit-anything-staged-p)))
-	   (cond ((eq magit-commit-all-when-nothing-staged 'ask-stage)
-		  (if (and (not (magit-everything-clean-p))
-			   (y-or-n-p "Nothing staged.  Stage everything now? "))
-		      (magit-stage-all)))
-		 ((not (magit-log-edit-get-field 'commit-all))
-		  (magit-log-edit-set-field
-		   'commit-all
-		   (if (or (eq magit-commit-all-when-nothing-staged t)
-			   (y-or-n-p
-			    "Nothing staged.  Commit all unstaged changes? "))
-		       "yes" "no")))))
-	 (when amend-p (magit-log-edit-toggle-amending))
-	 (magit-pop-to-log-edit "commit"))))
+  ;; If repository is dirty there is no point in trying to
+  ;; suggest to continue the rebase. Git will rebuke you and exit with
+  ;; error code, so suggest it only if theres absolutely nothing else
+  ;; to do and rebase is ongoing.
+  (if (magit-everything-clean-p)
+      (when (and (magit-rebase-info)
+                 (y-or-n-p "Rebase in progress.  Continue it? "))
+        (magit-run-git-async "rebase" "--continue"))
+    ;; If there's nothing staged, set commit flag to `nil', thus
+    ;; avoiding unnescessary popping up of the log edit buffer in case
+    ;; when user chose to forgo commiting all unstaged changes
+    (let ((perform-commit-p (magit-anything-staged-p)))
+      (when (and magit-commit-all-when-nothing-staged
+                 (not perform-commit-p))
+        (cond ((eq magit-commit-all-when-nothing-staged 'ask-stage)
+               (when (y-or-n-p "Nothing staged.  Stage everything now? ")
+                 (setq perform-commit-p t)
+                 (magit-stage-all)))
+              ((not (magit-log-edit-get-field 'commit-all))
+               (when (or (eq magit-commit-all-when-nothing-staged t)
+                         (y-or-n-p
+                          "Nothing staged.  Commit all unstaged changes? "))
+                 (magit-log-edit-set-field 'commit-all "yes")
+                 (setq perform-commit-p t)))))
+      (when perform-commit-p
+        (when amend-p (magit-log-edit-toggle-amending))
+        (magit-pop-to-log-edit "commit")))))
 
 (defun magit-add-log ()
   (interactive)


### PR DESCRIPTION
Previous version of `magit-log-edit' had two issues:
1. It didn't support splitting of commits, for example, here's the
workflow in question:

C-c g some-git-repo
M-x magit-interactive-rebase (to some old to be splitted commit)
<edit "git-rebase-todo" file, mark aforementioned commit to be edited>
x HEAD^

or, just for clarity's sake, its command-line equivalent:

cd some git-repo
git rebase -i <some old to be splitted commit>
<edit "git-rebase-todo" file, mark aforementioned commit to be edited>
git reset HEAD^

When then `magit-log-edit' was called in the middle of the ongoing
rebase, by typing "c" in the status buffer it would suggest to
continue it(rebase) and exit silently on user's refusal to do so. If
you were to answer "yes" to the proposal magit would try to continue
the rebase, fail miserably at said task and stop. So, it is easy to see
that after not so long a struggle you would find yourself in a Catch-22
type of a situation:
- You need to commit changes in order to continue the rebase
- You need to finish rebase in order to commit anything

New version addresses that problem by always ignoring ongoing rebase
and performing commit if the repository is dirty. And suggesting to
continue the rebase only if it is clean.
1. It somewhat ignored user's refusal to commit all unstaged changes
   or stage them all and then commit. The code in the old version of the
   function would still call `(magit-pop-to-log-edit "commit")' even if
   user answered "no" to the asked questions.

This version hopefully addresses that too.
