### PR TITLE
Visit items in the other window by default

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4902,21 +4902,21 @@ This is only meaningful in wazzup buffers.")
 			 (prompt-for-change-log-name))))
   (magit-add-change-log-entry whoami file-name t))
 
-(defun magit-visit-item (&optional other-window)
+(defun magit-visit-item (&optional same-window)
   "Visit current item.
-With a prefix argument, visit in other window."
+With a prefix argument, visit in the same window."
   (interactive (list current-prefix-arg))
   (magit-section-action (item info "visit")
     ((untracked file)
      (funcall
-      (if other-window 'find-file-other-window 'find-file)
+      (if same-window 'find-file 'find-file-other-window)
       info))
     ((diff)
      (let ((file (magit-diff-item-file item)))
        (if (not (file-exists-p file))
            (error "Can't visit deleted file: %s" file))
        (funcall
-        (if other-window 'find-file-other-window 'find-file)
+        (if same-window 'find-file 'find-file-other-window)
         file)))
     ((hunk)
      (let ((file (magit-diff-item-file (magit-hunk-item-diff item)))
@@ -4924,7 +4924,7 @@ With a prefix argument, visit in other window."
        (if (not (file-exists-p file))
            (error "Can't visit deleted file: %s" file))
        (funcall
-        (if other-window 'find-file-other-window 'find-file)
+        (if same-window 'find-file 'find-file-other-window)
         file)
        (goto-char (point-min))
        (forward-line (1- line))))


### PR DESCRIPTION
The default 'magit-status' command pops up itself in the other window by
default, so it makes sense to visit items in the window that the user
came from.
