### PR TITLE
Fix double deleting of a remote branch.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5068,8 +5068,8 @@ With prefix force the removal even it it hasn't been merged."
                     (magit-remove-remote (magit--branch-name-from-section branch-section)))))
     (if (and (magit--is-branch-section-remote branch-section)
              (yes-or-no-p "Remove branch in remote repository as well? "))
-        (magit-remove-branch-in-remote-repo (magit--branch-name-from-section branch-section)))
-    (apply 'magit-run-git (remq nil args))))
+        (magit-remove-branch-in-remote-repo (magit--branch-name-from-section branch-section))
+    (apply 'magit-run-git (remq nil args)))))
 
 (defun magit--remotes ()
   "Return a list of names for known remotes."


### PR DESCRIPTION
When deleting the remote copy of a remote branch, there is no need to also delete the local copy.
The two commands used to delete branches are:
    + delete only the local copy of a remote branch:
      git branch [-d|-D] -r <remote>/<branch>
    + delete the remote copy AND the local copy of a remote branch:
      git push <remote> :<branch>

Here is, in pseudo-code, what this fix is doing.
    + before the fix:
      if (delete-remote-copy)
          git push <remote> :<branch>
      git branch [-d|-D] -r <remote>/<branch>
    + after the fix:
      if (delete-remote-copy)
          git push <remote> :<branch>
      else
          git branch [-d|-D] -r <remote>/<branch>
