### PR TITLE
Fix refresh buffer point change line

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5173,8 +5173,8 @@ name of the remote and branch name. The remote must be known to git."
                                    (propertize (assoc-default 'tracking b)
                                                'face 'magit-log-head-label-remote)
                                    "]")
-                         ""))))
-            (insert "\n"))))
+                         "")))
+            (insert "\n")))))
       (magit-show-branches-mode)
       (goto-char (point-min))
       (if buffer-existed


### PR DESCRIPTION
These three commits fix what happens to the point on refresh.
If it was not at the beginning of the line, the behavior was not as expected (see commit messages for more detail).

As I was working on this, I spotted an inconsistency in the branch manager highlighting (see commit message for the explanation).
