### PR TITLE
Fix `magit-save-buffers-predicate-tree-only' when checking unsaved buffers across multiple repositories.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3329,7 +3329,8 @@ to consider it or not when called with that buffer current."
   "Only prompt to save buffers which are within the current git project (as
   determined by the dir passed to `magit-status'."
   (and buffer-file-name
-       (magit-get-top-dir (file-name-directory buffer-file-name))))
+       (eq (magit-get-top-dir dir)
+           (magit-get-top-dir (file-name-directory buffer-file-name)))))
 
 ;;;###autoload
 (defun magit-status (dir)


### PR DESCRIPTION
Old code would prompt to save _any_ dirty buffer which was part of a git
repository, rather than just the specific repo for which `magit-status'
was invoked. Fixed to check only against magit-topdir of the invocation
directory.
