### PR TITLE
Fix scenario where diff.no-prefix or show.no-prefix are set in git confi...

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2378,7 +2378,8 @@ in the corresponding directories."
   (magit-refresh))
 
 (defun magit-diff-line-file ()
-  (cond ((looking-at "^diff --git ./\\(.*\\) ./\\(.*\\)$")
+  (cond ((or (looking-at "^diff --git ./\\(.*\\) ./\\(.*\\)$")
+             (looking-at "^diff --git \\(.*\\) \\(.*\\)$"))
 	 (match-string-no-properties 2))
 	((looking-at "^diff --cc +\\(.*\\)$")
 	 (match-string-no-properties 1))


### PR DESCRIPTION
...g. Previously this would error when no match happened on the diff line.

For people contributing to apache, --no-prefix is required on the patches, to fit into the automated testing systems.
