### PR TITLE
documentation typo fixes

### DIFF
--- a/magit.texi
+++ b/magit.texi
@@ -218,8 +218,8 @@ them as described in the previous section.
 The first section shows @emph{Untracked files}, if there are any.  See
 @ref{Untracked files} for more details.
 
-Two section show your local changes.  They are explained fully in the
-next chapter, @ref{Staging and Committing}.
+The next two sections show your local changes.  They are explained
+fully in the next chapter, @ref{Staging and Committing}.
 
 If the current branch is associated with a remote tracking branch, the
 status buffer shows the differences between the current branch and the
@@ -458,7 +458,7 @@ is of a file in the status buffer that needs to be merged, you will be
 able to use Ediff as an interactive merge tool.  Otherwise, Ediff will
 simply show the two versions of the file.
 
-To show the changes from you working tree to another revision, type
+To show the changes from your working tree to another revision, type
 @kbd{d}.  To show the changes between two arbitrary revisions, type
 @kbd{D}.
 


### PR DESCRIPTION
I'm not entirely sure about the first hunk, but the 2nd is clearly a typo.

Incidentally, "The first section shows @emph{Untracked files}" -- but the first section when I ran magit was 'stashes'.
