### PR TITLE
Some MSYSGit support added for show-commit.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3096,7 +3096,18 @@ for this argument.)"
                      nil nil t))
   (when (magit-section-p commit)
     (setq commit (magit-section-info commit)))
-  (unless (eql 0 (magit-git-exit-code "cat-file" "-e" (format "%s^{commit}" commit)))
+  (unless (eql 0
+               (apply ; changed to using call-process-shell-command
+                ; due to a quirk with getting MYSHAH1^{commit} through to msysgit on win32
+                'call-process-shell-command
+                (mapconcat
+                 'identity
+                 (append
+                  (list magit-git-executable)
+                  magit-git-standard-options
+                  (list "cat-file" "-e" (format "\"%s^{commit}\"" commit)))
+                 " ")
+                nil nil nil))
     (error "%s is not a commit" commit))
   (let ((dir default-directory)
         (buf (get-buffer-create magit-commit-buffer-name)))


### PR DESCRIPTION
For some reason, MSYSGit couldn't accept MySHAH1HERE^{commit} through "process-file", whereas "call-process-shell-command" takes a string that win32 somehow lets through.

Quoting the param to process-file for some reason did not work, there must be some post-processing that would remove them from the outside.
