### PR TITLE
Typo in docstring

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1868,7 +1868,7 @@ It will also define the magit-SYM-command-hook variable.
 The defined function will call the function in the hook in
 order until one return non nil. If they all return nil then body will be called.
 
-It used to define hookable magit command: command defined by this
+It is used to define hookable magit command: command defined by this
 function can be enriched by magit extension like magit-topgit and magit-svn"
   (declare (indent defun)
            (debug (&define name lambda-list


### PR DESCRIPTION
Fixed a typo in magit-define-command docstring.
