### PR TITLE
Corrected magit-add-log when looking for a file.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4354,7 +4354,11 @@ continue it.
                              (if (bolp)
                                  (open-line 1)
                                (newline))
-                             (insert (format "(%s): " fun))))))))))))
+                             (insert (format "(%s): " fun))))))
+                   (t
+                    ;; found entry for file, look for beginning  it
+                    (when (looking-at ":")
+                      (forward-char 2)))))))))
 
 ;;; Tags
 


### PR DESCRIPTION
As I was looking at issue #328, I spotted the following problem.

In the case the commit message looks like:
- file:
  (fun1)
  (fun2)

magit-add-log was improperly putting the point on the colon (:).
