### PR TITLE
Allow "empty" merge commits

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4163,13 +4163,20 @@ environment (potentially empty)."
          (tag-name (cdr (assq 'tag-name fields)))
          (author (cdr (assq 'author fields)))
          (tag-options (cdr (assq 'tag-options fields))))
-    (if (or (not (or allow-empty commit-all amend tag-name (magit-anything-staged-p)))
-            (not (or allow-empty (not commit-all) amend (not (magit-everything-clean-p)))))
-        (error "Refusing to create empty commit. Maybe you want to amend (%s) or allow-empty (%s)?"
-               (key-description (car (where-is-internal
-                                      'magit-log-edit-toggle-amending)))
-               (key-description (car (where-is-internal
-                                      'magit-log-edit-toggle-allow-empty)))))
+
+    (unless (or (magit-anything-staged-p)
+                allow-empty
+                amend
+                tag-name
+                (file-exists-p ".git/MERGE_HEAD")
+                (and commit-all
+                     (not (magit-everything-clean-p))))
+      (error "Refusing to create empty commit. Maybe you want to amend (%s) or allow-empty (%s)?"
+             (key-description (car (where-is-internal
+                                    'magit-log-edit-toggle-amending)))
+             (key-description (car (where-is-internal
+                                    'magit-log-edit-toggle-allow-empty)))))
+
     (magit-log-edit-push-to-comment-ring (buffer-string))
     (magit-log-edit-setup-author-env author)
     (magit-log-edit-set-fields nil)


### PR DESCRIPTION
- magit.el (magit-log-edit-commit): Don't "refus[e] to create empty
  commit" when the commit is a merge, even if it doesn't change any
  files.

I also rewrote the 'if' condition into an easier-to-read list of
conditions where a commit is allowed.
