### PR TITLE
Remove ":require magit-wip" from define-minor-mode

### DIFF
--- a/magit-wip.el
+++ b/magit-wip.el
@@ -39,7 +39,6 @@ Currently, this will just give git-wip refs a special appearance
 in Magit log buffers."
   :group 'magit
   :global t
-  :require 'magit-wip
   (magit-wip-setup-namespaces))
 
 (defface magit-log-head-label-wip
@@ -69,5 +68,7 @@ in Magit log buffers."
         (remover (lambda (ns) (setq magit-refs-namespaces (delete ns magit-refs-namespaces)))))
     (mapc (if magit-wip-mode adder remover)
           magit-wip-refs-namespaces)))
+
+(magit-wip-setup-namespaces)
 
 (provide 'magit-wip)


### PR DESCRIPTION
It can cause problems if you load your custom file before loading
magit, which is quite likely. I think the :require option is really
only for core Emacs features.

As a workaround, I call the setup function when the file is loaded,
which will do the setup if the mode variable is true.
