### PR TITLE
Fix whitespace in yes-or-no question

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4003,7 +4003,7 @@ typing and automatically refreshes the status buffer."
       (let ((set-upstream-on-push (and (not ref-branch)
                                        (or (eq magit-set-upstream-on-push 'dontask)
                                            (and (eq magit-set-upstream-on-push t)
-                                                (yes-or-no-p "Set upstream while pushing?"))))))
+                                                (yes-or-no-p "Set upstream while pushing? "))))))
         (if (and (not branch-remote)
                  (not current-prefix-arg))
             (magit-set push-remote "branch" branch "remote"))


### PR DESCRIPTION
I put a space between the question mark and the "(yes or no)".
