### PR TITLE
Fix error with "server-edit" and buffer-read-only in rebase-mode

### DIFF
--- a/rebase-mode.el
+++ b/rebase-mode.el
@@ -101,8 +101,8 @@
 
 (defvar rebase-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "q") 'server-edit)
-    (define-key map (kbd "C-c C-c") 'server-edit)
+    (define-key map (kbd "q") 'rebase-mode-server-edit)
+    (define-key map (kbd "C-c C-c") 'rebase-mode-server-edit)
 
     (define-key map (kbd "a") 'rebase-mode-abort)
     (define-key map (kbd "C-c C-k") 'rebase-mode-abort)
@@ -276,6 +276,12 @@ read-only buffers."
   (interactive "P")
   (let ((inhibit-read-only t))
     (undo arg)))
+
+(defun rebase-mode-server-edit ()
+  "Disable `buffer-read-only' and call `sever-edit'."
+  (interactive)
+  (let (buffer-read-only)
+    (server-edit)))
 
 ;;;###autoload
 (define-derived-mode rebase-mode special-mode "Rebase"


### PR DESCRIPTION
It was previously impossible to actually use rebase-mode because you
could not save the buffer after changing it. Pressing "q" or "C-c C-c"
just caused an error about the buffer being read only. This change
adds "rebase-mode-server-edit", which uses the same workaround as
"rebase-mode-undo", and binds it to the appropriate keys in
"rebase-mode-map".
