### PR TITLE
Found a better way to do add-change-log-entry

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5099,16 +5099,14 @@ This is only meaningful in wazzup buffers.")
     ((branch)
      (call-interactively 'magit-move-branch))))
 
-(defun magit-eval-as-if-visiting-file-item (exp)
-  (interactive)
-  (let ((marker
-         (save-window-excursion
-           (magit-visit-file-item)
-           (set-marker (make-marker) (point)))))
-    (save-excursion
-      (with-current-buffer (marker-buffer marker)
-        (goto-char marker)
-        (eval exp)))))
+(defmacro magit-visiting-file-item (&rest body)
+  `(let ((marker (save-window-excursion
+                   (magit-visit-file-item)
+                   (set-marker (make-marker) (point)))))
+     (save-excursion
+       (with-current-buffer (marker-buffer marker)
+         (goto-char marker)
+         ,@body))))
 
 (defun magit-add-change-log-entry-no-option (&optional other-window)
   "Add a change log entry for current change.
@@ -5116,12 +5114,12 @@ With a prefix argument, edit in other window.
 The name of the change log file is set by variable change-log-default-name."
   (interactive "P")
   (if other-window
-      (magit-eval-as-if-visiting-file-item '(funcall 'add-change-log-entry-other-window))
-    (magit-eval-as-if-visiting-file-item '(funcall 'add-change-log-entry))))
+      (magit-visiting-file-item (add-change-log-entry-other-window))
+    (magit-visiting-file-item (add-change-log-entry))))
 
 (defun magit-add-change-log-entry-other-window ()
   (interactive)
-  (magit-eval-as-if-visiting-file-item '(call-interactively 'add-change-log-entry-other-window)))
+  (magit-visiting-file-item (call-interactively 'add-change-log-entry-other-window)))
 
 (defun magit-visit-file-item (&optional other-window)
   "Visit current file associated with item.


### PR DESCRIPTION
I figured out why it was not really working nicely.
I was trying to concile two very different goals:
- being magit-friendly
- shadow exactly `add-change-log-entry`

I reconciled the two by creating a function for each use case:
- one on "L" works like the rest of magit with C-u being the other-window flag
- one on "C-x 4 a" works like `add-chaneg-log-entry-other-window` and C-u asks for a username and changelog filename

As far as getting the username and email from git it is not the role of magit but add-log.el.
I'll see if I can get a clean solution for them to merge.
In the meantime I use the following code in my .emacs:

```
(make-local-variable 'add-log-full-name)
(make-local-variable 'add-log-mailing-address)
(defun set-git-name-and-email ()
  (when (and buffer-file-name
             (eq (vc-backend buffer-file-name) 'Git))
    (setq add-log-full-name (substring (shell-command-to-string "git config user.name") 0 -1))
    (setq add-log-mailing-address (substring (shell-command-to-string "git config user.email") 0 -1))))
(add-hook 'find-file-hook 'set-git-name-and-email)
```
