### PR TITLE
Refine current diff hunk using `diff-refine-hunk'

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -614,7 +614,7 @@ Do not customize this (used in the `magit-key-mode' implementation).")
     (define-key map (kbd "-") 'magit-diff-smaller-hunks)
     (define-key map (kbd "+") 'magit-diff-larger-hunks)
     (define-key map (kbd "0") 'magit-diff-default-hunks)
-    (define-key map (kbd "h") 'diff-refine-hunk)
+    (define-key map (kbd "h") 'magit-toggle-diff-refine-hunk)
     map))
 
 (defvar magit-commit-mode-map


### PR DESCRIPTION
This just uses diff-mode's "diff-refine-hunk" to highlight exactly those parts of the current magit hunk which have changed.  This is _really_ useful for textually small changes in long lines of code, where it can be very hard to actually see what's what's change, and easy to miss something when scanning by eye.

diff-refine-hunk is pretty clever, so in general it doesn't result in "over-highlighting" -- for instance, it doesn't add additional hilighting for big insertions/deletions (those are obvious from the basic hunk display), and it alights fine-change highlighting to word boundaries to avoid the "insert one character, delete another, 50 times" problem of naive fine-change displays.

To avoid leaving a trail, it removes the refinements when the current hunk (really section) changes.
