### PR TITLE
Fixes definitions of derived modes

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4492,7 +4492,7 @@ With prefix argument, changes in staging area are kept.
 
 (defvar magit-currently-shown-stash nil)
 
-(define-derived-mode magit-stash-mode magit-mode
+(define-derived-mode magit-stash-mode magit-mode "Magit Stash"
   "Mode for looking at a git stash.
 
 \\{magit-stash-mode-map}"
@@ -4656,7 +4656,7 @@ With a non numeric prefix ARG, show all entries"
              ,@args
              "--"))))
 
-(define-derived-mode magit-log-mode magit-mode "Magit"
+(define-derived-mode magit-log-mode magit-mode "Magit Log"
   "Mode for looking at git log.
 
 \\{magit-log-mode-map}"
@@ -4719,7 +4719,7 @@ This is only non-nil in reflog buffers.")
                     (format "--max-count=%s" magit-log-cutoff-length)
                     args)))))
 
-(define-derived-mode magit-reflog-mode magit-log-mode "Magit"
+(define-derived-mode magit-reflog-mode magit-log-mode "Magit Reflog"
   "Mode for looking at git reflog.
 
 \\{magit-reflog-mode-map}"
@@ -4814,7 +4814,7 @@ restore the window state that was saved before ediff was called."
                          'magit-wash-diffs
                          "diff" (magit-diff-U-arg) args))))
 
-(define-derived-mode magit-diff-mode magit-mode "Magit"
+(define-derived-mode magit-diff-mode magit-mode "Magit Diff"
   "Mode for looking at a git diff.
 
 \\{magit-diff-mode-map}"
@@ -4915,7 +4915,7 @@ This is only meaningful in wazzup buffers.")
                            "--"))))
                   (magit-set-section-info ref section))))))))))
 
-(define-derived-mode magit-wazzup-mode magit-mode
+(define-derived-mode magit-wazzup-mode magit-mode "Magit Wazzup"
   "Mode for looking at commits that could be merged from other branches.
 
 \\{magit-wazzup-mode-map}"
@@ -5186,7 +5186,7 @@ Return values:
       (if old-editor
           (setenv "GIT_EDITOR" old-editor)))))
 
-(define-derived-mode magit-branch-manager-mode magit-mode
+(define-derived-mode magit-branch-manager-mode magit-mode "Magit Branch"
   "Magit Branches")
 
 (defun magit-quit-window (&optional kill-buffer)


### PR DESCRIPTION
Many definitions of derived modes had comments instead of names which
made the Emacs mode line impossible to use

Signed-off-by: Damien Cassou damien.cassou@gmail.com
