### PR TITLE
Makes it easy to add wildcards to git ignore files.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4945,10 +4945,8 @@ If EDIT argument is negative, the prompt proposes wildcard by default.
          (full-extension (concat (file-name-directory file) just-extension))
          (just-file (file-name-nondirectory file))
          ;; change the order in history depending on the negativity of
-         ;; EDIT. If user just types M--, EDIT will equal to symbol
-         ;; `-' and not to a negative number.
-         (history (if (or (eq edit '-)
-                          (and (numberp edit) (< edit 0)))
+         ;; EDIT.
+         (history (if (< (prefix-numeric-value edit) 0)
                       (list full-extension just-extension file just-file)
                     (list file full-extension just-extension just-file))))
     (read-string


### PR DESCRIPTION
This commit proposes to enrich the history in the minibuffer with
wildcard expressions of the current filename. For example, for a
filename `/myfolder/file.o', the following options are proposed in the
minibuffer history (accessible with M-n):

/myfolder/file.o
/myfolder/*.o
*.o
file.o

The options order depends on the negativity of the prefix argument.

This commit additionally provides comments for related functions.

Signed-off-by: Damien Cassou damien.cassou@gmail.com
