### PR TITLE
New switches for stashing.

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -103,7 +103,9 @@
       ("z" "Save" magit-stash)
       ("s" "Snapshot" magit-stash-snapshot))
      (switches
-      ("-k" "Keep index" "--keep-index")))
+      ("-k" "Keep index" "--keep-index")
+      ("-u" "Include untracked files" "--include-untracked")
+      ("-a" "Include all files" "--all")))
 
     (merging
      (man-page "git-merge")


### PR DESCRIPTION
git in version 1.7.8 learned 2 new switches for stash command: `--include-untracked` and `-all` for including untracked files and untracked plus ignored files respectively.

As this is fairly new functionality I made adding those switches conditional, but the way I achieved probably it is not optimal and need improvement / rewriting.
