### PR TITLE
don't partially apply a hunk with zero context

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2841,6 +2841,9 @@ member of ARGS, or to the working file otherwise."
       (setq args (cons "--unidiff-zero" args)))
     (when reverse
       (setq args (cons "--reverse" args)))
+    (when (and use-region zero-context)
+      (error (concat "Not enough context to partially apply hunk.  "
+                     "Use `+' to increase context.")))
     (with-magit-tmp-buffer tmp
       (if use-region
           (magit-insert-hunk-item-region-patch


### PR DESCRIPTION
The endpoint of this sequence is generating an error when partially applying a hunk with no context, since I've found that operation to give mostly unexpected results.  On the way, a few other things got done to `magit-apply-hunk-item*`:
- added some documentation.
- callers no longer have to set the REVERSE argument to `t` **and** add `--reverse` to the git arguments they pass in.  Instead, `magit-apply-hunk-item*` automatically adds `--reverse` to ARGS whenever REVERSE is non-`nil`.
- introduced some local variables.

This is a piece of pull request #310 that I submitted earlier.  After some discussion, this subset seems mostly agreed on.  Thanks in advance for any feedback.
