### PR TITLE
Option to filter comments out of git commit messages

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4161,7 +4161,7 @@ option, falling back to something hairy if that is unset."
       (set (make-local-variable 'git-commit-font-lock-keywords)
            (mapcar (lambda (x)
                      (if (string= (substring (car x) 0 2) "\\`")
-                         `(,(format "\\`\\(\\(?:.*\n\\)*?%s\\|\\)\\(?:\\(?:[[:space:]]*\\|#.*\\)\n\\)*\\(.\\{,50\\}\\)\\(.*?\\)\\(?:\n\\(.*\\)\\)?$" magit-log-header-end)
+                         `(,(format "\\`\\(?:\\(?:.*\n\\)*?\\(%s\\)\\|\\)\\(?:\\(?:[[:space:]]*\\|#.*\\)\n\\)*\\(.\\{,50\\}\\)\\(.*?\\)\\(?:\n\\(.*\\)\\)?$" magit-log-header-end)
                            (1 'git-commit-comment-face)
                            (2 'git-commit-summary-face)
                            (3 'git-commit-overlong-summary-face)


### PR DESCRIPTION
Since I added a preference for adding comments to the log-edit buffer, I realized that these comments were not being deleted and were getting included in the commit message. This pull request implements a preference to clean comments from commit messages before committing them, by conditionally passing either `--cleanup=strip` or `--cleanup=whitespace` to `git commit`.

Fixes #361.

I also ensured that if you enable insertion of git-status comments, then comment-cleanup gets enabled too. This fixes the problem mentioned in my surpsied [comment](https://github.com/magit/magit/commit/d01bfcc3c47c3b14db612270d208d25dd756f90d#commitcomment-898163) on an earlier commit message.
