### PR TITLE
Byte compile magit-wip.el & rebase-mode.el and remove redundant *.elc targets from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION=$(shell git describe --tags --dirty)
 EMACS=emacs
 PREFIX=/usr/local
 SYSCONFDIR=/etc
-ELS=magit.el magit-svn.el magit-topgit.el magit-stgit.el magit-key-mode.el magit-bisect.el
+ELS=magit.el magit-svn.el magit-topgit.el magit-stgit.el magit-key-mode.el magit-bisect.el magit-wip.el rebase-mode.el
 ELS_CONTRIB=contrib/magit-simple-keys.el contrib/magit-classic-theme.el
 ELCS=$(ELS:.el=.elc)
 ELCS_CONTRIB=$(ELS_CONTRIB:.el=.elc)


### PR DESCRIPTION
`make` does not compile `rebase-mode.el` and the recently added `magit-wip.el`.

In addition, `Makefile` has bunch of empty `*.elc` rules that are already covered by `%.elc` rule with is run by `core` for all files defined in `ELCS`. Said that, I removed them. 
