### PR TITLE
Remote remote branch deletion in log buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3772,7 +3772,7 @@ If the branch is the current one, offers to switch to `master' first.
 With prefix, forces the removal even if it hasn't been merged.
 Works with local or remote branches.
 \('git branch [-d|-D] BRANCH' or 'git push <remote-part-of-BRANCH> :refs/heads/BRANCH')."
-  (interactive (list (magit-read-rev "Branch to delete" (magit-default-rev))
+  (interactive (list (magit-read-rev "Branch to delete" (magit-default-rev 'notrim))
                      current-prefix-arg))
   (let* ((remote (magit-remote-part-of-branch branch))
          (is-current (string= branch (magit-get-current-branch)))


### PR DESCRIPTION
I noticed that `magit-delete-branch` was unable to delete remote branches, so I fixed it. I'm not sure if my fix is ideal, since I'm not too familiar with the magit internals, but it works for me.
