### PR TITLE
Fix git author env next

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4560,6 +4560,14 @@ continue it.
         (magit-log-edit-toggle-amending))
       (when empty-p
         (magit-log-edit-toggle-allow-empty))
+      (let ((author-email (or (getenv "GIT_AUTHOR_EMAIL") ""))
+            (author-name (or (getenv "GIT_AUTHOR_NAME") ""))
+            (author-date (or (getenv "GIT_AUTHOR_DATE") "")))
+        (if (not (string= author-email ""))
+            (magit-log-edit-set-field 'author (format "%s <%s>%s"
+                                                      (if (string= "" author-name) author-email author-name)
+                                                      author-email
+                                                      (if (string= "" author-date) "" (format ", %s") author-date)))))
       (magit-pop-to-log-edit "commit"))))
 
 (defun magit-add-log ()


### PR DESCRIPTION
This branch includes two fixes that deal with the "Author:" field in commit buffers.

The first commit clears the environment variables `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL` and `GIT_AUTHOR_DATE` after the commit (they're set to the values they had before the commit -- and especially before the "Author:" field was parsed). Otherwise all subsequent commits will use the same values, even if no "Author:" field is found in the buffer. This is because environment variables are global to Emacs and not buffer or frame local.

For me this meant having to re-write roughly 60 commits due to wrong author information.

The second commit adds the "Author:" field to a commit buffer if the environment variable `GIT_AUTHOR_EMAIL` is set. This can happen in two cases: 1) It was set before Emacs has started. 2) It is set by magit and due to errors or bugs it stays set after a commit. This is more a reminder for the user so that he can act accordingly.

This time the request is for next, not master.
