### PR TITLE
in status buffer show when pull uses rebase

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3448,13 +3448,16 @@ FULLY-QUALIFIED-NAME is non-nil."
 
 (defvar magit-remote-string-hook nil)
 
-(defun magit-remote-string (remote remote-branch)
+(defun magit-remote-string (remote remote-branch remote-rebase)
   (cond
    ((string= "." remote)
-    (format "branch %s"
-            (propertize remote-branch 'face 'magit-branch)))
+    (concat
+     (when remote-rebase "onto ")
+     "branch"
+     (propertize remote-branch 'face 'magit-branch)))
    (remote
     (concat
+     (when remote-rebase "onto ")
      (propertize remote-branch 'face 'magit-branch)
      " @ "
      remote
@@ -3471,8 +3474,9 @@ FULLY-QUALIFIED-NAME is non-nil."
     (magit-with-section 'status nil
       (let* ((branch (magit-get-current-branch))
              (remote (and branch (magit-get "branch" branch "remote")))
+             (remote-rebase (and branch (magit-get-boolean "branch" branch "rebase")))
              (remote-branch (or (and branch (magit-remote-branch-for branch)) branch))
-             (remote-string (magit-remote-string remote remote-branch))
+             (remote-string (magit-remote-string remote remote-branch remote-rebase))
              (head (magit-git-string
                     "log"
                     "--max-count=1"


### PR DESCRIPTION
On the `Remote:` line insert string `onto` before the remote branch name if `branch.$localbranch.rebase` is true. Some indicator could be added to the `Local:` line instead. I don't really care how this information is displayed, just that it is.

Ps: Sorry for asking for merge into wrong branch first... again. I should ensure that the browser window is wide enough for me to see the `Change Commits` button... or just remember that github defaults to `master` instead of trying to guess the most reasonable branch.

Pps: Does anybody know a way to change the "into" branch of a github pull request?
