### PR TITLE
Simplify test for mocker library.

### DIFF
--- a/tests/magit-tests.el
+++ b/tests/magit-tests.el
@@ -3,7 +3,7 @@
   (require 'cl))
 
 (eval-when-compile
-  (when (null (ignore-errors (require 'mocker)))
+  (when (require 'mocker nil t)
     (defmacro* mocker-let (specs &body body)
       (error "Skipping tests, mocker.el is not available"))))
 


### PR DESCRIPTION
Rather than using `null` and `ignore-errors`, passing non-nil to the
third argument (NOERROR) of `require` accomplishes the same thing.
