### PR TITLE
only push to branch.b.merge when pushing to branch.b.remote

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4238,7 +4238,8 @@ ask user instead.
 With \\[universal-argument] \\[universal-argument] as prefix, \
 also prompt user for the remote branch;
 otherwise, try to use the branch.<name>.merge git-config(1)
-option, falling back to something hairy if that is unset."
+option, falling back to something hairy if that is unset,
+or not pushing to branch.<name>.remote."
   (interactive)
   (let* ((branch (or (magit-get-current-branch)
                      (error "Don't push a detached head.  That's gross")))
@@ -4252,7 +4253,8 @@ option, falling back to something hairy if that is unset."
          (ref-branch (or (and (>= (prefix-numeric-value current-prefix-arg) 16)
                               (magit-read-remote-branch
                                push-remote (format "Push %s as branch" branch)))
-                         (magit-get "branch" branch "merge"))))
+                         (and (equal branch-remote push-remote)
+                              (magit-get "branch" branch "merge")))))
     (if (and (not ref-branch)
              (eq magit-set-upstream-on-push 'refuse))
         (error "Not pushing since no upstream has been set.")


### PR DESCRIPTION
Previously given this configuration:

```
[remote "origin"]
    url = git://github.com/magit/magit.git
    fetch = +refs/heads/*:refs/remotes/origin/*
[remote "myremote"]
    url = git@github.com:tarsius/magit.git
    fetch = +refs/heads/*:refs/remotes/myremote/*
[branch "a-feature-branch"]
    remote = origin
    merge = refs/heads/next
```

and `a-feature-branch` checked out

```
C-u P P myremote
```

would push to:

```
myremote/next
```

which goes completely against what I am used to from plain git.  It also doesn't make any sense since `branch.<branch>.merge` is only meaningful when pushing to `branch.<branch>.remote`.  With my change the branch is pushed to `myremote/a-feature-branch`, which `magit-push`s doc-string calls "falling back to something hairy" but I find that behavior to be quite reasonable.
