### PR TITLE
magit fails to build on Homebrew

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ magit-pkg.el: magit-pkg.el.in
 	sed -e s/@VERSION@/$(VERSION)/ < $< > $@
 
 50magit.el: $(ELS) magit.elc
-	$(BATCH) -eval "(progn (defvar generated-autoload-file nil) (let ((generated-autoload-file \"$(PWD)/50magit.el\") (make-backup-files nil)) (update-directory-autoloads \".\")))"
+	$(BATCH) -eval "(progn (defvar generated-autoload-file nil) (let ((generated-autoload-file \"$(CURDIR)/50magit.el\") (make-backup-files nil)) (update-directory-autoloads \".\")))"
 
 magit.elc: magit.el
 	sed -e "s/@GIT_DEV_VERSION@/$(VERSION)/" < magit.el > magit.tmp.el #NO_DIST


### PR DESCRIPTION
When installing magit HEAD via [Homebrew](http://github.com/mxcl/homebrew), the build fails when trying to install the 50magit.el file.

The problem is 50magit.el is built in $(PWD)/50magit.el where $(PWD) -- when building via Homebrew -- refers to the directory where the brew command was issued rather than the build directory.  Building the file in $(CURDIR) fixes the issue.

Building manually (e.g., `cd magit; make`) works fine because $(PWD) refers to the build directory as expected.

I initially reported this to the Homebrew devs (mxcl/homebrew#12453) but they feel it's an upstream issue.

Thanks.
