### PR TITLE
Magit-diff-working-tree fails if a filename conflicts with version name

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5051,7 +5051,7 @@ restore the window state that was saved before ediff was called."
       (magit-git-section 'diffbuf
                          (magit-rev-range-describe range "Changes")
                          'magit-wash-diffs
-                         "diff" (magit-diff-U-arg) args))))
+                         "diff" (magit-diff-U-arg) args "--"))))
 
 (define-derived-mode magit-diff-mode magit-mode "Magit Diff"
   "Mode for looking at a git diff.


### PR DESCRIPTION
The fix uses a "--" as a divider at the end of args to disambiguate.

I do use only small parts of magit - It might break something.

Thanks for magit!
