### PR TITLE
Detect if git asks for username and ask the user for it.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2154,7 +2154,8 @@ function can be enriched by magit extension like magit-topgit and magit-svn"
   "Checks if git/ssh asks for a password and ask the user for it."
   (let (ask)
     (cond ((or (string-match "^Enter passphrase for key '\\\(.*\\\)': $" string)
-               (string-match "^\\\(.*\\\)'s password:" string))
+               (string-match "^\\\(.*\\\)'s password:" string)
+               (string-match "^Password for '\\\(.*\\\)':" string))
            (setq ask (format "Password for '%s': " (match-string 1 string))))
           ((string-match "^[pP]assword:" string)
            (setq ask "Password:")))


### PR DESCRIPTION
If http is used as protocol (e.g. the new default on github) then git
might ask for a username during push operations. Currently this
results in the process hanging. This patch adds a `magit-username'
function similar to`magit-password' and modifies
`magit-process-filter' to call the function.

Signed-off-by: Rüdiger Sonderfeld ruediger@c-plusplus.de
