### PR TITLE
Add "Interactive Rebasing" texinfo node

### DIFF
--- a/magit.texi
+++ b/magit.texi
@@ -52,6 +52,7 @@ maintain compatibility are still welcome.
 * Wazzup::
 * Merging::
 * Rebasing::
+* Interactive Rebasing::
 * Rewriting::
 * Pushing and Pulling::
 * Bisecting::


### PR DESCRIPTION
I added a node to `magit.texi` that documents `magit-interactive-rebase` and `rebase-mode`. I don't really know anything about TexInfo, so I just cargo-culted all the commands and I haven't tested to see if the file is syntactically correct. Feel free to edit for syntactic correctness, factual correctness, and writing style in order to make it fit with the rest of the manual. (Or tell me what you want changed and I'll do it.)

This should fix #443.
