### PR TITLE
minor correction to rewrite section of magit gh-pages

### DIFF
--- a/magit.html
+++ b/magit.html
@@ -909,7 +909,7 @@ keeping information from the status buffer.
 
    <p>If you rather wish to start over, type <kbd>r a</kbd>.  This will abort the
 rewriting, resetting the current head back to the value it had before
-the rewrite was started with <kbd>r s</kbd>.
+the rewrite was started with <kbd>r b</kbd>.
 
    <p>Typing <kbd>r f</kbd> will <em>finish</em> the rewrite: it will apply all
 unused commits one after the other, as if you would us <kbd>A</kbd> with


### PR DESCRIPTION
The key binding used to begin a rewrite is incorrectly listed as 'r s' which stops a rewrite, so fixed it so it reads 'r b' for begin rewrite.
