### PR TITLE
Handle symlinks in magit-filename

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5193,7 +5193,7 @@ the current git repository."
   (let ((topdir (expand-file-name
                  (magit-get-top-dir (or (file-name-directory filename)
                                         default-directory))))
-        (file (expand-file-name filename)))
+        (file (file-truename filename)))
     (when (and (not (string= topdir ""))
                ;; FILE must start with the git repository path
                (zerop (string-match-p (concat "\\`" topdir) file)))


### PR DESCRIPTION
The topdir is derived from `magit-get-top-dir`, which expands any
symlinks in the directory path, so file should use `file-truename` to do
the same instead of `expand-file-name`.
