### PR TITLE
Add view file at commit from magit-blame-mode.

### DIFF
--- a/magit-blame.el
+++ b/magit-blame.el
@@ -32,6 +32,7 @@
 ;;; Code:
 
 (eval-when-compile (require 'cl))
+(eval-when-compile (require 'view))
 (require 'magit)
 
 (defface magit-blame-header


### PR DESCRIPTION
magit-blame-view-file-at-commit shows the current file as it was at commit
from current position.

v is bound to magit-blame-view-file-at-commit.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>
