### PR TITLE
Run git init with no argument in the correct directory

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3362,7 +3362,7 @@ FULLY-QUALIFIED-NAME is non-nil."
 (defun magit-init (dir)
   "Initialize git repository in the DIR directory."
   (interactive (list (read-directory-name "Directory for Git repository: ")))
-  (let* ((dir (expand-file-name dir))
+  (let* ((dir (file-name-as-directory (expand-file-name dir)))
          (topdir (magit-get-top-dir dir)))
     (when (or (not topdir)
               (yes-or-no-p
@@ -3374,7 +3374,8 @@ FULLY-QUALIFIED-NAME is non-nil."
       (unless (file-directory-p dir)
         (and (y-or-n-p (format "Directory %s does not exists.  Create it? " dir))
              (make-directory dir)))
-      (magit-run* (list magit-git-executable "init" dir)))))
+      (let ((default-directory dir))
+        (magit-run* (list magit-git-executable "init"))))))
 
 (define-derived-mode magit-status-mode magit-mode "Magit"
   "Mode for looking at git status.


### PR DESCRIPTION
When run in the correct directory, git init don't need an argument,
giving this argument make git fail when the repository is
remote (through tramp)

This mostly revert b6354459044768a7d42bc05da7549440ab0e8015, so I don't push it yet, because I don't know what this older commit was supposed to fix.
