### PR TITLE
Add "--color" into magit-log mode

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -875,7 +875,11 @@ Does not follow symlinks."
                                cmd
                                nil (list t nil) nil
                                args)))))
-    (replace-regexp-in-string "\e\\[.*?m" "" cmd-output)))
+;;    (replace-regexp-in-string "\e\\[.*?m" "" cmd-output)))
+;; Instead of stripping out all control sequences translate
+;; color sequences into text properties (still discards non-color
+;; control sequnces)
+    (ansi-color-apply cmd-output)))
 
 (defun magit-git-string (&rest args)
   (magit-trim-line (magit-git-output args)))
@@ -3190,8 +3194,13 @@ must return a string which will represent the log line.")
          (propertize sha1 'face 'magit-log-sha1)
        (insert-char ? magit-sha1-abbrev-length))
      " "
-     (when graph
-       (propertize graph 'face 'magit-log-graph))
+;;          (when graph
+;;       (propertize graph 'face 'magit-log-graph)
+;;       )
+;; Pass through the ansi-color translated (colorized) graph
+;; rather than propertize with magit-log-graph. It would be nicer
+;; to provide optional mechanism to override using magit-log-graph 
+     graph
      string-refs
      (when message
        (propertize message 'face 'magit-log-message)))))
@@ -4908,6 +4917,7 @@ With a non numeric prefix ARG, show all entries"
                      (t nil))
              ,@(if magit-have-decorate (list "--decorate=full"))
              ,@(if magit-have-graph (list "--graph"))
+             ,"--color"
              ,@args
              "--"))))
 


### PR DESCRIPTION
I wanted magit-log to be a little clearer when there were branch lines that cross through each other in magit-log.  Since "git log" already supports colored branch lines, I looked into how I could take advantage of it.

This change uses the build in ansi-color.el's ansi-color-apply to translate "git log --color"'s color control sequences into text properties so they can be displayed with color in the magit-log buffer.

While it works, this change doesn't feel "complete", for example I left magit-log-graph orphaned and it would be nice if it was still available for use.  Also, I'm not confident that the ansi-color-apply usage here is idiomatic or covers all scenarios (I tested with a couple.. light and dark background).  I think this being my first attempt at tinkering with elisp would have something to do with it.  Any feedback about this change (or the process.. felt a little weird to submit this as a pull request) would be super welcome.   Thanks.
