### PR TITLE
dir file for auto install of info pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ELCS=$(ELS:.el=.elc)
 ELCS_CONTRIB=$(ELS_CONTRIB:.el=.elc)
 DIST_FILES=$(ELS) Makefile magit.texi magit.info README.md magit.spec.in magit-pkg.el.in
 DIST_FILES_CONTRIB=$(ELS_CONTRIB) contrib/magit
-ELPA_FILES=$(ELS) magit.info magit-pkg.el
+ELPA_FILES=$(ELS) magit.info dir magit-pkg.el
 
 .PHONY=install
 
@@ -24,7 +24,7 @@ all: core docs contrib
 
 core: $(ELCS) magit.spec magit-pkg.el 50magit.el
 
-docs: magit.info
+docs: dir
 
 contrib: $(ELCS_CONTRIB)
 
@@ -42,7 +42,12 @@ magit.elc: magit.el
 	$(BATCH) --eval '(byte-compile-file "magit.tmp.el")' #NO_DIST
 	mv magit.tmp.elc magit.elc #NO_DIST
 	rm magit.tmp.el #NO_DIST
+
+dir: magit.info
+	install-info --dir=dir magit.info
+
 magit.info:
+	makeinfo magit.texi 
 
 dist: magit-$(VERSION).tar.gz
 


### PR DESCRIPTION
Here's a change to make the info properly install. 

According to the package spec you need to generate a dir file for info manuals, the dir file is then merged in by the packaging system.

It does work.

I guess availability of the info tools is an issue, I was not sure how the info was being generated from the texi - was it a default rule or something?
