### PR TITLE
Expand symbolic links in magit-wip-save

### DIFF
--- a/magit-wip.el
+++ b/magit-wip.el
@@ -131,7 +131,7 @@ ref."
 
 (defun magit-wip-save ()
   (let* ((top-dir (magit-get-top-dir default-directory))
-         (name (buffer-file-name))
+         (name (file-truename (buffer-file-name)))
          (spec `((?r . ,(file-relative-name name top-dir))
                  (?f . ,(buffer-file-name))
                  (?g . ,top-dir))))


### PR DESCRIPTION
When saving a file which is symbolic linked to a git repository,
magit-wip-save fails with error saying that the file is outside
of the repository.  This change fix the problem.
