### PR TITLE
Make .gitignore ignore the `dir` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 /magit-pkg.el
 magit.spec
 50magit.el
+/dir


### PR DESCRIPTION
This file was added to help with Info - but it causes submodules to appear dirty if Make has been run.

This causes Git to ignore the generated file.
