### PR TITLE
magit-key-mode: don't delete other windows to show menu

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -370,7 +370,6 @@ highlighted before the description."
         (current-window-configuration))
   ;; setup the mode, draw the buffer
   (let ((buf (get-buffer-create magit-key-mode-buf-name)))
-    (delete-other-windows)
     (split-window-vertically)
     (other-window 1)
     (switch-to-buffer buf)


### PR DESCRIPTION
delete-other-windows was introduced by e04f27d8, but there's no clear rationale for it.  Why mess with the existing splits when popping up a menu?
