### PR TITLE
Fix magit-save-buffers when called from magit-status

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3631,7 +3631,6 @@ user input."
                              4))
                        (or (magit-get-top-dir default-directory)
                            (magit-read-top-dir nil)))))
-  (magit-save-some-buffers)
   (let ((topdir (magit-get-top-dir dir)))
     (unless topdir
       (when (y-or-n-p (format "There is no Git repository in %S.  Create one? "
@@ -3639,6 +3638,8 @@ user input."
         (magit-init dir)
         (setq topdir (magit-get-top-dir dir))))
     (when topdir
+      (let ((default-directory topdir))
+        (magit-save-some-buffers))
       (let ((buf (or (magit-find-status-buffer topdir)
                      (generate-new-buffer
                       (concat "*magit: "


### PR DESCRIPTION
Make magit-save-buffers on magit-status use the directory we are opening, not the default directory of the buffer we are visiting when called.

This comes into play when using `magit-save-buffers-predicate-tree-only`, because you can get spurious save requests since we don't actually check the buffer paths with respect to the git directory, but instead we check relative to whatever default directory the current buffer had when magit-status was called.
