### PR TITLE
Color log

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -83,6 +83,7 @@
 (require 'log-edit)
 (require 'easymenu)
 (require 'diff-mode)
+(require 'ansi-color)
 
 ;; Silences byte-compiler warnings
 (eval-and-compile


### PR DESCRIPTION
Cleaned up pull request #462.

The magit code base does not use the color output of magit anywhere but for the log.
The `--color` flag was already given for log but the color information was stripped down by `magit-cmd-output`.
This pull request does not seem to break anything and it does improve readability.
