### PR TITLE
Run magit-refresh-status-hook outside the macro creating the section

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3557,8 +3557,8 @@ FULLY-QUALIFIED-NAME is non-nil."
           (magit-insert-unstaged-changes
            (if staged "Unstaged changes:" "Changes:"))
           (magit-insert-staged-changes staged no-commit))
-        (magit-insert-unpushed-commits remote remote-branch)
-        (run-hooks 'magit-refresh-status-hook)))))
+        (magit-insert-unpushed-commits remote remote-branch))))
+  (run-hooks 'magit-refresh-status-hook))
 
 (defun magit-init (dir)
   "Initialize git repository in the DIR directory."


### PR DESCRIPTION
I need comment on this: moving the hook enable function in the hook to use section related function, to show and hide them for example (see http://stackoverflow.com/questions/12745311/scripting-magit-timing-problems/12769554#12769554 for an example of such use), but it remove to those function the possibilities to change the content of the section (but do we want that?)
