### PR TITLE
Pressing "M" shows "Branch manager" instead of "Remote manager"

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -90,7 +90,7 @@
     (remoting
      (man-page "git-remote")
      (actions
-      ("v" "Branch manager" magit-branch-manager)
+      ("v" "Remote manager" magit-branch-manager)
       ("a" "Add" magit-add-remote)
       ("r" "Rename" magit-rename-remote)
       ("k" "Remove" magit-remove-remote)))


### PR DESCRIPTION
Even though the branch manager is actually displayed, it always
confused me that "Branch manager" is shown when I asked for the
"Remote manager".

Signed-off-by: Damien Cassou damien.cassou@gmail.com
