### PR TITLE
Honor git commit.template config setting.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5972,6 +5972,18 @@ layer. This can be added to `magit-mode-hook' for example"
                  (not (eq sym 'magit-wip-save-mode)))
         (funcall sym 1)))))
 
+(defun magit-insert-commit-template ()
+  "Insert git commit templates into the magit-edit-log buffer."
+  (let* (magit-config-commit-template (magit-get "commit.template")
+                                      (magit-commit-template
+                                       (expand-file-name (concat (magit-git-dir) "../" (magit-get "commit.template")))))
+    (when (and (file-exists-p magit-commit-template) (not (file-accessible-directory-p magit-commit-template)))
+      (magit-log-edit-append (with-temp-buffer
+                               (insert-file-contents magit-commit-template)
+                               (buffer-string))) (goto-char (point-min)))))
+
+(add-hook 'magit-log-edit-mode-hook 'magit-insert-commit-template)
+
 (provide 'magit)
 
 ;; rest of magit core


### PR DESCRIPTION
Add a hook to `magit-log-edit-mode` to insert the contents of the
`commit.template` file if configured.  This appears to match the
behavior of git from the command line.
As far as I can tell, git does the following:
If the `commit.template` is configured in a `.git/config`, treat a relative
path as relative to the top directory of the repo.
If it is a global config (`~/.gitconfig`) or an absolute path, use that path.

Using this, every time I open magit-edit-log, I get this I'm not sure
about that, but it's hidden in `*Messages*`:

```
Buffer `*magit-edit-log*' not visiting a file
```
