### PR TITLE
Default branch to the latest visited branch

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3891,7 +3891,7 @@ With prefix, forces the move even if NEW already exists.
     ((commit) (magit-name-rev (substring info 0 magit-sha1-abbrev-length)))
     ((wazzup) info)
     (t (let ((lines (magit-git-lines "reflog")))
-         (while (not (string-match "moving from \\(.*\\) to" (car lines)))
+         (while (not (string-match "moving from \\(.+?\\) to" (car lines)))
            (setq lines (cdr lines)))
          (when lines
            (match-string 1 (car lines)))))))


### PR DESCRIPTION
when point is not into a commit/branch, suggest last visited branch as branch name (useful for merges,rebases,checkouts, etc)

If you think an auxiliary function would be better, please say so, and I'll change it.

Thanks! 
