### PR TITLE
magit-wip-save: remove unneeded kludge

### DIFF
--- a/magit-wip.el
+++ b/magit-wip.el
@@ -142,10 +142,9 @@ ref."
                  (?f . ,(buffer-file-name))
                  (?g . ,top-dir))))
     (when (and top-dir (file-writable-p top-dir))
-      (save-excursion ; kludge see https://github.com/magit/magit/issues/441
-        (magit-run-git "wip" "save"
-                       (format-spec magit-wip-commit-message spec)
-                       "--editor" "--" name))
+      (magit-run-git "wip" "save"
+                     (format-spec magit-wip-commit-message spec)
+                     "--editor" "--" name)
       (when magit-wip-echo-area-message
         (message (format-spec magit-wip-echo-area-message spec))))))
 


### PR DESCRIPTION
(This is a duplicate of pull request #477. I needed to recreate it because I used the next branch for that pull request and I want to be able to use next properly again.)

(Also: Could someone please merge this soonish. I am sure this change won't cause any problems: I wrote (1) the function being modified (2) the kludge I now want removed and (3) the proper fix which makes the kludge unnecessary :-)

A proper fix for this issue (#441) has been merged.

> from the branch you target for final inclusion. This should always be either maint or master.

I suppose _always_ mean _except when it depends on commits already in next_ :-)
