### PR TITLE
Make z do the same as in other temporary buffers for the magit-branches buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -675,6 +675,7 @@ operation after commit).")
     (define-key map (kbd "r") 'magit-move-item)
     (define-key map (kbd "k") 'magit-discard-item)
     (define-key map (kbd "T") 'magit-change-what-branch-tracks)
+    (define-key map (kbd "z") 'kill-this-buffer)
     map))
 
 (defvar magit-bug-report-url


### PR DESCRIPTION
This is OK in _magit-branches_ only, because "z" is not bound here.
