### PR TITLE
Add a running log of git command output.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2042,6 +2042,8 @@ function can be enriched by magit extension like magit-topgit and magit-svn"
 (defvar magit-process-client-buffer nil)
 (defvar magit-process-buffer-name "*magit-process*"
   "Buffer name for running git commands.")
+(defvar magit-process-log-buffer-name "*magit-process-log*"
+  "Buffer name for the running log of output from git commands.")
 
 (defun magit-run* (cmd-and-args
                    &optional logline noerase noerror nowait input)
@@ -2052,6 +2054,7 @@ function can be enriched by magit extension like magit-topgit and magit-svn"
         (args (cdr cmd-and-args))
         (dir default-directory)
         (buf (get-buffer-create magit-process-buffer-name))
+        (log-buf (get-buffer-create magit-process-log-buffer-name))
         (successp nil))
     (magit-set-mode-line-process
      (magit-process-indicator-from-command cmd-and-args))
@@ -2121,6 +2124,12 @@ function can be enriched by magit extension like magit-topgit and magit-svn"
                      (equal (apply 'process-file cmd nil buf nil args) 0))
                (magit-set-mode-line-process nil)
                (magit-need-refresh magit-process-client-buffer))))
+      ;; Append the contents of process-buffer to the log.
+      (with-current-buffer log-buf
+        (goto-char (point-max))
+        (insert "\n"))
+      (append-to-buffer log-buf (point-min) (point-max))
+      ;; Raise an error if the command failed.
       (or successp
           noerror
           (error


### PR DESCRIPTION
Wrong base branch. Closed and re-submitted (see comments).

As well as the magit-process buffer (showing the output of the most recent git command), it would be mightily useful if that output was also appended to a magit-process-log buffer, so that we could see things like the commit hash for the stash that we dropped a couple of commands ago, and then realised that we wanted back (for example :)

https://github.com/phil-s/magit/commit/6d0b67d57da8949bd424cf9450a2802da0c828fb

Branch phil-s/process-log (branched from maint) implements this.
