### PR TITLE
Move to the right column when visiting hunks

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5469,14 +5469,17 @@ With a prefix argument, visit in other window."
                file)))))
     ((hunk)
      (let ((file (magit-diff-item-file (magit-hunk-item-diff item)))
-           (line (magit-hunk-item-target-line item)))
+           (line (magit-hunk-item-target-line item))
+           (column (current-column)))
        (if (not (file-exists-p file))
            (error "Can't visit deleted file: %s" file))
        (funcall
         (if other-window 'find-file-other-window 'find-file)
         file)
        (goto-char (point-min))
-       (forward-line (1- line))))))
+       (forward-line (1- line))
+       (when (> column 0)
+         (move-to-column (1- column)))))))
 
 (defun magit-visit-item (&optional other-window)
   "Visit current item.


### PR DESCRIPTION
Unlike regular diff-mode, Magit loses the column when visiting hunks,
which is very annoying. So compute the destination column and move point
there in the destination buffer.
