### PR TITLE
magit-guess-branch: fix recently introduced bug

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3899,7 +3899,8 @@ With prefix, forces the move even if NEW already exists.
     ((commit) (magit-name-rev (substring info 0 magit-sha1-abbrev-length)))
     ((wazzup) info)
     (t (let ((lines (magit-git-lines "reflog")))
-         (while (not (string-match "moving from \\(.+?\\) to" (car lines)))
+         (while (and lines (not (string-match "moving from \\(.+?\\) to"
+                                              (car lines))))
            (setq lines (cdr lines)))
          (when lines
            (match-string 1 (car lines)))))))


### PR DESCRIPTION
Previously the while loop did not check for the end of the processed
list causing an error when trying to use the car of an empty list as
a string.
