### PR TITLE
refactor magit-section-case and related functions

### DIFF
--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -202,16 +202,16 @@
              (magit-mode-init dir 'magit-commit-mode
                               #'magit-stgit--refresh-patch-buffer patch))))))
 
-(magit-add-action (item info "visit")
+(magit-add-action-clauses (item info "visit")
   ((series)
    (magit-stgit--show-patch info)
    (pop-to-buffer magit-commit-buffer-name)))
 
-(magit-add-action (item info "apply")
+(magit-add-action-clauses (item info "apply")
   ((series)
    (magit-run magit-stgit-executable "goto" info)))
 
-(magit-add-action (item info "discard")
+(magit-add-action-clauses (item info "discard")
   ((series)
    (let ((patch (or magit-stgit--marked-patch info)))
      (if (yes-or-no-p (format "Delete patch '%s' in series? " patch))
@@ -226,7 +226,7 @@
             nil
           patch)))
 
-(magit-add-action (item info "mark")
+(magit-add-action-clauses (item info "mark")
   ((series)
    (magit-stgit--set-marked-patch info)
    (magit-refresh-all)))

--- a/magit-topgit.el
+++ b/magit-topgit.el
@@ -133,13 +133,13 @@
                         "Topics:" 'magit-topgit-wash-topics
                         "summary"))
 
-(magit-add-action (item info "discard")
+(magit-add-action-clauses (item info "discard")
   ((topic)
    (when (yes-or-no-p "Discard topic? ")
      (magit-run* (list magit-topgit-executable "delete" "-f" info)
                  nil nil nil t))))
 
-(magit-add-action (item info "visit")
+(magit-add-action-clauses (item info "visit")
   ((topic)
    (magit-checkout info)))
 

--- a/magit.el
+++ b/magit.el
@@ -1983,8 +1983,8 @@ section (see `magit-section-info').
   "Choose among action clauses depending on the current section.
 
 Like `magit-section-case' (which see) but if no CLAUSE succeeds
-try additional CLAUSES added with `magit-add-action'.  Return the
-value of BODY of the clause that succeeded.
+try additional CLAUSES added with `magit-add-action-clauses'.
+Return the value of BODY of the clause that succeeded.
 
 Each use of `magit-section-action' should use an unique OPNAME.
 
@@ -2013,8 +2013,8 @@ Each use of `magit-section-action' should use an unique OPNAME.
          (unless (eq ,value magit-section-action-success)
            ,value)))))
 
-(defmacro magit-add-action (head &rest clauses)
-  "Add additional clauses to a section action.
+(defmacro magit-add-action-clauses (head &rest clauses)
+  "Add additional clauses to the OPCODE section action.
 
 Add to the section action with the same OPNAME additional
 CLAUSES.  If none of the default clauses defined using


### PR DESCRIPTION
```
`magit-section-case' used to return t if a clause succeeds but the
value of it's body is nil.  This was due to internal needs; it allowed
`run-hook-with-args-until-sucess' to detect that a clause and therefor
the hook function succeeded.  However, while it was documented in the
doc-string, callers should not have to deal with this.

* `magit-section-case' and `magit-section-action' always return
  the value of the BODY now.  In other words they can return nil.
* `magit-section-case' doesn't need to know about OPCODE.
  Running the OPCODE hook is done in `magit-section-action' now.
* `magit-add-section' wrap each BODY so that `magit-section-action'
  can detect whether a CLAUSE succeeded.  Previously that was done
  in `magit-section-case' for *any* CLAUSE.
* Disallow a t/otherwise CLAUSE in `magit-section-action' as that
  would prevent the OPCODE hook from running.
* Replace uses of `magit-section-action' without OPCODE to use
  `magit-section-case' instead.
* Properly document functions.
* New function `magit-section-match'.
* Prettify some related functions.
```
