### PR TITLE
Add author and date to log #384

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3316,9 +3316,9 @@ insert a line to tell how to insert more of them"
      ((looking-at line-re)
       (let ((chart (match-string 1))
             (sha1 (match-string 2))
-            (author (match-string 4))
+            (author (when (not (eq style 'long)) (match-string 4)))
             (date (match-string 5))
-            (msg (match-string 6))
+            (msg  (match-string (if (eq style 'long) 4 6)))
             (refs (when (match-string 3)
                     (delq nil
                           (mapcar


### PR DESCRIPTION
This commit adds the commit date and author to the log view. This should resolve issue #384. I'm not overly familiar with elisp or the magit code base: if you're interested in the patch, let me know if you want me to change or fix anything.

This is how it looks:

![Screen Shot 2013-01-26 at 17 33 57](https://f.cloud.github.com/assets/150883/100017/4b59b99e-67df-11e2-89b2-5bfc0d243d49.png)

Thanks,

Greg
