### PR TITLE
Another fix for issue 557

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4453,7 +4453,7 @@ If there is no default remote, ask for one."
             magit-custom-options
             (list pull-remote)
             (when merge-branch
-               (list (format "%s:%s/%s" merge-branch branch-remote branch)))))))
+               (list (format "%s:refs/remotes/%s/%s" merge-branch branch-remote branch)))))))
 
 (eval-when-compile (require 'eshell))
 


### PR DESCRIPTION
The part specifying the destitnation as origin/master was not specific enough. It would create a local branch named origin/master instead finding refs/remotes/origin/master. I misunderstood what was said in `man git rev-parse`.
