### PR TITLE
use cl-find-if instead of depending on implicit block

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2563,12 +2563,13 @@ Please see the manual for a complete description of Magit.
 
 (defun magit-find-buffer (submode &optional dir)
   (let ((topdir (magit-get-top-dir (or dir default-directory))))
-    (dolist (buf (buffer-list))
-      (if (with-current-buffer buf
-            (and (eq major-mode submode)
-                 default-directory
-                 (equal (expand-file-name default-directory) topdir)))
-          (cl-return buf)))))
+    (cl-find-if (lambda (buf)
+                  (with-current-buffer buf
+                    (and (eq major-mode submode)
+                         default-directory
+                         (equal (expand-file-name default-directory)
+                                topdir))))
+                (buffer-list))))
 
 (defun magit-find-status-buffer (&optional dir)
   (magit-find-buffer 'magit-status-mode dir))


### PR DESCRIPTION
On Emacs-24.2.93 that block does not exist for some reason, causing an error.

You only merged the first commit from #568. Why? The second commit was pushed later, maybe you had already fetched the branch and missed that I added a second commit.

Here is a new pull request with just that commit.
