### PR TITLE
Auto advance to next line after selecting an action

### DIFF
--- a/rebase-mode.el
+++ b/rebase-mode.el
@@ -26,9 +26,20 @@
 
 (require 'server)
 
+(defgroup rebase-mode nil
+  "Customize Rebase Mode"
+  :group 'tools)
+
+(defcustom rebase-mode-auto-advance nil
+  "If non-nil, moves point forward a line after running an
+action (e.g. pick, edit, etc)."
+  :group 'rebase-mode
+  :type 'boolean)
+
 (defgroup rebase-mode-faces nil
   "Customize Rebase Mode faces"
-  :group 'faces)
+  :group 'faces
+  :group 'rebase-mode)
 
 (defface rebase-mode-killed-action-face
   '((((class color))
@@ -162,7 +173,9 @@ that of CHANGE-TO."
       (goto-char (point-at-bol))
       (delete-region (point) (progn (forward-word 1) (point)))
       (insert change-to)
-      (goto-char start))))
+      (goto-char start)
+      (when rebase-mode-auto-advance
+        (forward-line)))))
 
 (defun rebase-mode-looking-at-action ()
   "Return non-nil if looking at an action line."


### PR DESCRIPTION
This pull request contains two commits:
1. Minor refactor (put a -faces suffix on the existing rebase-mode customize group)
2. Auto-advance to the next line after choosing an action for a given line (with associated option to toggle). This cuts out one keystroke (`n`, to go to the next line in the rebase-todo list) for the common case of moving to the next line after selecting an action.
