### PR TITLE
magit-commit-for-autosquash: new command

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -166,7 +166,13 @@
       ("r" "Reset" magit-bisect-reset)
       ("s" "Start" magit-bisect-start)
       ("u" "Run" magit-bisect-run)
-      ("v" "Visualize" magit-bisect-visualize))))
+      ("v" "Visualize" magit-bisect-visualize)))
+
+    (autosquash
+     (man-page "git-rebase")
+     (actions
+      ("'" "Fixup!" magit-fixup-for-autosquash)
+      ("s" "Squash!" magit-squash-for-autosquash))))
   "Holds the key, help, function mapping for the log-mode.
 If you modify this make sure you reset `magit-key-mode-key-maps'
 to nil.")

--- a/magit.texi
+++ b/magit.texi
@@ -356,6 +356,15 @@ Typing @kbd{C} will also pop up the change description buffer, but in
 addition, it will try to insert a ChangeLog-style entry for the change
 that point is in.
 
+You can create fixup! or squash! commits for the autosquash feature of
+@code{git-rebase} by typing @kbd{' '} or @kbd{' s}, respectively.  The
+created commit will be autosquashed to the commit at point or, if the commit
+at point is to be autosquashed, to the commit the commit at point will be
+squashed to.  If there are staged changes, the new commit is created out of
+those.  If there are no staged changes,
+@code{magit-commit-all-when-nothing-staged} determines what is done.  Magit
+will offer to set rebase.autosquash option if necessary.
+
 @node History
 @chapter History
 
@@ -741,6 +750,9 @@ commits.  You can finish editing the buffer and proceed with the rebase
 by pressing @kbd{C-c C-c}, which is bound to @code{server-edit} in
 this mode, and you can abort the rebase with @kbd{C-c C-k}, just like
 when editing a commit message in Magit.
+
+See @ref{Staging and Committing} for information about creating commits
+for the autosquash feature of @code{git-rebase}.
 
 @node Rewriting
 @chapter Rewriting


### PR DESCRIPTION
This command makes it possible to create fixup! commits for the autosquash feature of git-rebase. I've used it practically every day for quite some time now and hope it will make amending non-HEAD commits more convenient for others as well. It's of course beneficial to "pool" fixup commits but even if you make just one and apply it immediately, ' E C-x # is a rather quick way to do it (I have ideas to make that even easier but I think this is a reasonable first step).

I'll happily give my blessing for an improvement that also allows squash! commits to be created (with, for example, a prefix argument or so that ' ' creates a fixup! commit and ' s creates a squash! commit), but I've never needed those so whoever does gets to add that feature.
