### PR TITLE
Give a specific name to magic-key buffers according to group used.

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -374,9 +374,6 @@ command that's eventually invoked.")
   (interactive)
   (kill-buffer magit-key-mode-last-buffer))
 
-(defvar magit-log-mode-window-conf nil
-  "Pre-popup window configuration.")
-
 (defun magit-key-mode (for-group &optional original-opts)
   "Mode for magit key selection.
 All commands, switches and options can be toggled/actioned with


### PR DESCRIPTION
(magit-key-mode-buf-name): Now a format string.
(magit-key-mode-last-buffer): New internal var.
(magit-key-mode): Create a new buffer name specifying the group in use.
(magit-key-mode-kill-buffer): Kill magit-key-mode-last-buffer.
