### PR TITLE
Unifies the naming of magit buffers

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -6,7 +6,7 @@
   "This will be filled lazily with proper `define-key' built
   keymaps as they're requested.")
 
-(defvar magit-key-mode-buf-name "*magit-key:%s*"
+(defvar magit-key-mode-buf-name "*magit-key: %s*"
   "Format string to create the name of the magit-key buffer.")
 
 (defvar magit-key-mode-last-buffer nil


### PR DESCRIPTION
Adds a space between 'magit-key:' and the name of the command.
This is more consistent with the way the status buffers are named.
