### PR TITLE
Avoid using flet which doesn't work because cl is not required.

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -316,25 +316,25 @@ Put it in `magit-key-mode-key-maps' for fast lookup."
                                  (interactive)
                                  (magit-key-mode-help ',for-group)))
 
-    (flet ((defkey (k action)
-             (when (and (lookup-key map (car k))
-                        (not (numberp (lookup-key map (car k)))))
-               (message "Warning: overriding binding for `%s' in %S"
-                        (car k) for-group)
-               (ding)
-               (sit-for 2))
-             (define-key map (car k)
-               `(lambda () (interactive) ,action))))
+    (let ((defkey #'(lambda (k action)
+                      (when (and (lookup-key map (car k))
+                                 (not (numberp (lookup-key map (car k)))))
+                        (message "Warning: overriding binding for `%s' in %S"
+                                 (car k) for-group)
+                        (ding)
+                        (sit-for 2))
+                      (define-key map (car k)
+                        `(lambda () (interactive) ,action)))))
       (when actions
         (dolist (k actions)
-          (defkey k `(magit-key-mode-command ',(nth 2 k)))))
+          (funcall defkey k `(magit-key-mode-command ',(nth 2 k)))))
       (when switches
         (dolist (k switches)
-          (defkey k `(magit-key-mode-add-option ',for-group ,(nth 2 k)))))
+          (funcall defkey k `(magit-key-mode-add-option ',for-group ,(nth 2 k)))))
       (when arguments
         (dolist (k arguments)
-          (defkey k `(magit-key-mode-add-argument
-                      ',for-group ,(nth 2 k) ',(nth 3 k))))))
+          (funcall defkey k `(magit-key-mode-add-argument
+                              ',for-group ,(nth 2 k) ',(nth 3 k))))))
 
     (push (cons for-group map) magit-key-mode-key-maps)
     map))


### PR DESCRIPTION
defkey is not working because cl is not required.
Actually best practice is to avoid using flet by using either lambda or requiring cl-lib and use cl-flet with lexical-bindings enabled.
