### PR TITLE
Fix unquoted list in pkg definition, which breaks packages

### DIFF
--- a/magit-pkg.el.in
+++ b/magit-pkg.el.in
@@ -1,3 +1,3 @@
 (define-package "magit" "@VERSION@"
   "Control Git from Emacs."
-  ((cl-lib "0.2")))
+  '((cl-lib "0.2")))


### PR DESCRIPTION
The file is regular elisp, so the dependency list should be quoted.

See https://github.com/milkypostman/melpa/issues/600 for an example of what goes wrong given the unfixed code.
