### PR TITLE
magit.el: fix keybinding for toggle-gpgsign

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4704,7 +4704,7 @@ option, falling back to something hairy if that is unset."
     (define-key map (kbd "C-x #") 'magit-log-edit-commit)
     (define-key map (kbd "C-c C-a") 'magit-log-edit-toggle-amending)
     (define-key map (kbd "C-c C-s") 'magit-log-edit-toggle-signoff)
-    (define-key map (kbd "C-c C-S") 'magit-log-edit-toggle-gpgsign)
+    (define-key map (kbd "C-c C-v") 'magit-log-edit-toggle-gpgsign)
     (define-key map (kbd "C-c C-t") 'magit-log-edit-toggle-author)
     (define-key map (kbd "C-c C-e") 'magit-log-edit-toggle-allow-empty)
     (define-key map (kbd "M-p") 'log-edit-previous-comment)


### PR DESCRIPTION
6fad2b11 (introduce commit filed for GPG signature, 2013-03-17)
introduced magit-log-edit-toggle-gpgsign and bound it to "C-c C-S",
without realizing that it's equivalent to "C-c C-s", the keybinding
for magit-log-edit-toggle-signoff.  As a result, it's impossible to
toggle signoff with a keybinding now.  Fix this by changing the
keybinding for toggling gpgsign to "C-c C-g".

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
