### PR TITLE
include branch spec in delete confirmation message

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6047,8 +6047,8 @@ written to .git/info/exclude."
        (magit-run-git "stash" "drop" info)))
     ((branch)
      (when (yes-or-no-p (if current-prefix-arg
-                            "Force delete branch?"
-                          "Delete branch? "))
+                            (concat "Force delete branch [" info "]? ")
+                          (concat "Delete branch [" info "]? ")))
        (magit-delete-branch info current-prefix-arg)))
     ((remote)
      (when (yes-or-no-p "Remove remote? ")


### PR DESCRIPTION
Provide the user with slightly more confirmation that they're deleting the branch they intended. This is useful particularly when cleaning up stale branches via the Branch Manager.
