### PR TITLE
Add '--date-order' option switch for 'magit-log'

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -61,6 +61,7 @@ command-line).")
       ("rh" "Ranged reflog" magit-reflog-ranged))
      (switches
       ("-m" "Only merge commits" "--merges")
+      ("-do" "Date Order" "--date-order")
       ("-f" "First parent" "--first-parent")
       ("-i" "Case insensitive patterns" "-i")
       ("-pr" "Pickaxe regex" "--pickaxe-regex")


### PR DESCRIPTION
add `-do` switch to magit-key-mode 'logging.
show log in chronological order.
