### PR TITLE
Fix branch-manager status 'ahead' color-label

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6399,8 +6399,7 @@ These are the branch names with the remote name stripped."
                    (if ahead
                        (concat "ahead "
                                (propertize ahead
-                                           'face (if current
-                                                     'magit-branch))
+                                           'face 'magit-log-head-label-local)
                                (if behind
                                    ", "
                                  ""))


### PR DESCRIPTION
branch-manager information '[ahead `*`]' was not labeling.
