### PR TITLE
fontify most magit `with' and `define' macros

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -4,4 +4,5 @@
 ((emacs-lisp-mode
   (indent-tabs-mode)
   (tab-width . 8)
+  (eval . (require 'magit))
   (eval . (magit-maybe-add-font-lock-keywords))))

--- a/magit.el
+++ b/magit.el
@@ -6796,10 +6796,16 @@ This can be added to `magit-mode-hook' for example"
   :group 'magit
   :type 'boolean)
 
+;;;###autoload
 (defun magit-maybe-add-font-lock-keywords ()
   (when magit-add-font-lock-keywords
     (font-lock-add-keywords nil magit-font-lock-keywords)))
+
+;;;###autoload
 (put 'magit-maybe-add-font-lock-keywords 'safe-local-eval-function t)
+
+;;;###autoload
+(add-to-list 'safe-local-eval-forms '(require 'magit))
 
 (provide 'magit)
 


### PR DESCRIPTION
In libraries that are part of Magit automatically add font-lock keywords for macros like `magit-define-command` and `magit-with-section`.  This can be turned off by setting `magit-add-font-lock-keywords` to nil.
