### PR TITLE
author information vanishes with multiple log buffers

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3606,12 +3606,19 @@ must return a string which will represent the log line.")
 
 (defvar magit-log-author-date-string-length nil
   "only use in `*magit-log*' buffer.")
+(make-variable-buffer-local 'magit-log-author-date-string-length)
+
 (defvar magit-log-author-string-length nil
   "only use in `*magit-log*' buffer.")
+(make-variable-buffer-local 'magit-log-author-string-length)
+
 (defvar magit-log-date-string-length nil
   "only use in `*magit-log*' buffer.")
+(make-variable-buffer-local 'magit-log-date-string-length)
+
 (defvar magit-log-author-date-overlay nil
   "only use in `*magit-log*' buffer.")
+(make-variable-buffer-local 'magit-log-author-date-overlay)
 
 (defun magit-log-make-author-date-overlay (author date)
   (let ((overlay (make-overlay (point) (point))))
@@ -3678,10 +3685,10 @@ must return a string which will represent the log line.")
                             magit-log-author-date-string-length)))
 
 (defun magit-log-initialize-author-date-overlay ()
-  (when (equal magit-log-buffer-name (buffer-name))
-    (set (make-local-variable 'magit-log-author-date-string-length) 0)
-    (set (make-local-variable 'magit-log-author-string-length) 0)
-    (set (make-local-variable 'magit-log-date-string-length) 0)
+  (when (derived-mode-p 'magit-log-mode)
+    (setq magit-log-author-date-string-length 0)
+    (setq magit-log-author-string-length 0)
+    (setq magit-log-date-string-length 0)
     (when magit-log-author-date-overlay
       (mapc #'delete-overlay magit-log-author-date-overlay)
       (setq magit-log-author-date-overlay nil)


### PR DESCRIPTION
I often want to have multiple log buffers open at the same time (e.g. in order to compare history for different branches/repositories). This used to work in the past by first creating a log buffer (e.g. "l l"), renaming it to something else and then opening another one.

In today's "next" branch this still works. The bug, however, is that the buffer opened first loses its author information (the right-side column) as soon as the next log buffer is created. It seems that there can only be a single author column across all of Emacs' open magit buffers. There's even an error message `(wrong-type-argument window-live-p nil)` which, according to the backtrace, has something to do with the log buffer not being in an expected state.

All of this makes having multiple log buffers open at the same time pretty much impossible (a shame!).

How to reproduce:
1. Start magit on a repository.
2. Open a log buffer, e.g. `l l`.
3. Rename the buffer with `M-x rename-buffer`.
4. Go back to magit and try to open another log buffer with `l l`.
