### PR TITLE
Fix regression that caused status buffer to be refreshed twice.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2693,7 +2693,7 @@ Please see the manual for a complete description of Magit.
           (funcall func)
         (when magit-refresh-needing-buffers
           (magit-revert-buffers dir)
-          (dolist (b (if (memq status-buffer magit-refresh-needing-buffers)
+          (dolist (b (if (not (memq status-buffer magit-refresh-needing-buffers))
                          (cons status-buffer magit-refresh-needing-buffers)
                        magit-refresh-needing-buffers))
             (magit-refresh-buffer b)))))))


### PR DESCRIPTION
This was introduced in 361f2d60: a manual conversion of `cl-adjoin'
missed a negation.
