### PR TITLE
Add --branches/--remotes support to logging

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -68,6 +68,7 @@ command-line).")
       ("-pr" "Pickaxe regex" "--pickaxe-regex")
       ("-n" "Name only" "--name-only")
       ("-am" "All match" "--all-match")
+      ("-ab" "All branches" "--branches")
       ("-al" "All" "--all"))
      (arguments
       ("=r" "Relative" "--relative=" read-directory-name)


### PR DESCRIPTION
This PR introduces `=b`/`=R` keybinds to specify `--branches`/`--remotes` git log options.

To make it work, I removed `shell-quote-argument` from `magit-key-mode-command`.  I am not 100% sure this is safe, but at least there are some cases this does the wrong thing.  For example, `l =g .* RET` matches only commits which contain `*` in its message, which is wrong.
