### PR TITLE
magit-cmd-output: do not corrupt output

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -879,13 +879,12 @@ Read `completing-read' documentation for the meaning of the argument"
   (insert (magit-cmd-output cmd args)))
 
 (defun magit-cmd-output (cmd args)
-  (let ((cmd-output (with-output-to-string
-                      (with-current-buffer standard-output
-                        (apply #'process-file
-                               cmd
-                               nil (list t nil) nil
-                               args)))))
-    (replace-regexp-in-string "\e\\[.*?m" "" cmd-output)))
+  (with-output-to-string
+    (with-current-buffer standard-output
+      (apply #'process-file
+             cmd
+             nil (list t nil) nil
+             args))))
 
 (defun magit-git-string (&rest args)
   (magit-trim-line (magit-git-output args)))


### PR DESCRIPTION
This fixes #544.  There is no reason why we would want to manipulate
git's output.  In the master and next branches something similar to
the code removed in this commit was used to have colorful graphs in
logs.  But doing it in `magit-cmd-output' was wrong and that has been
fixed in these branches also.

As I said in #620 this fixes the issue in maint and I will merge it tonight if nobody speaks up by then. And then merge into master and next, so nobody else has to take care of the merge conflicts.
