### PR TITLE
tests/run-tests.el: add /path/to/magit/../{mocker,cl-lib} to load-path

### DIFF
--- a/tests/run-test.el
+++ b/tests/run-test.el
@@ -12,7 +12,9 @@
   (mapc (lambda (p)
           (when (file-directory-p p)
             (add-to-list 'load-path p)))
-        (list (expand-file-name (convert-standard-filename "lib/mocker") root-dir)
+        (list (expand-file-name "mocker" sitelisp)
+              (expand-file-name "cl-lib" sitelisp)
+              (expand-file-name (convert-standard-filename "lib/mocker") root-dir)
               (expand-file-name (convert-standard-filename "lib/cl-lib") root-dir)))
 
   ;; Use `ert' from github when this Emacs does not have it


### PR DESCRIPTION
It is quite reasonable to expect the directories containing the
dependencies to be located in the same directory as the magit
directory is located in.  At least this is the case when manually
installing each package as a subdirectory of some "site-lisp"
directory.  Or when using submodules as I do.

In the first commit I just sanitized tests/run-tests.el a bit.

I can apply similar changes to the master and maint branches if you want me too.
