### PR TITLE
Unbreak status buffer with an ongoing rebase

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4253,10 +4253,11 @@ if FULLY-QUALIFIED-NAME is non-nil."
            "Merging"
            (mapconcat 'identity (mapcar 'magit-name-rev merge-heads) ", ")))
         (when rebase
-          (apply 'magit-insert-status-line
-                 "Rebasing"
-                 " onto %s (%s of %s); Press \"R\" to Abort, Skip, or Continue\n"
-                 rebase))
+          (magit-insert-status-line
+           "Rebasing"
+           (apply 'format
+                  "onto %s (%s of %s); Press \"R\" to Abort, Skip, or Continue"
+                  rebase)))
         (insert "\n")
         (magit-git-exit-code "update-index" "--refresh")
         (magit-insert-stashes)


### PR DESCRIPTION
The refactor that introduced `magit-insert-status-line` was calling it with too many parameters for the reabase section, as this part refactored using `apply` with the wrong function.
