### PR TITLE
fix bug: 'magit-read-rev-range' doesn't work

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1480,10 +1480,7 @@ PROMPT and UNINTERESTING are passed to `magit-read-rev'."
     (save-match-data
       (if (string-match "^\\(.+\\)\\.\\.\\(.+\\)$" beg)
           (cons (match-string 1 beg) (match-string 2 beg))
-        (cons beg (magit-completing-read (format "%s end op" op)
-                                         nil nil nil
-                                         'magit-read-rev-history
-                                         def-end))))))
+        (cons beg (magit-read-rev (format "%s end op: " op)))))))
 
 (defun magit-rev-to-git (rev)
   (or rev


### PR DESCRIPTION
Function 'magit-read-rev-range' returns an Error 'wrong-type-argument', always.
It calls 'magit-completing-read' with wrong arguments.
I fixed this. changed read-function from 'magit-completing-read' to 'magit-read-rev'.
with this change, completion works.
