### PR TITLE
Fixes the implementation of magit-dired-jump

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6366,7 +6366,8 @@ With a prefix argument, visit in other window."
       ((hunk)
        (dired-jump other-window
                    (file-truename (magit-diff-item-file
-                                   (magit-hunk-item-diff item))))))))
+                                   (magit-hunk-item-diff item)))))
+      (nil (dired-jump other-window)))))
 
 (defun magit-visit-file-item (&optional other-window)
   "Visit current file associated with item.


### PR DESCRIPTION
The original implementation broke `C-x C-j`'s natural behavior. The
status buffer is naturally associated with the root of the git
directory. This natural behavior is reinstated for any location in the
buffer not associated with a more specific file.
