### PR TITLE
magit-log-oneline-re: add missing statuses

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3600,7 +3600,7 @@ Evaluate (man \"git-check-ref-format\") for details")
    "\\)?"
    " ?"
    "\\(?:"
-   "\\([BG]\\)?"                                    ; gpg     (4)
+   "\\([BGUN]\\)?"                                  ; gpg     (4)
    "\\(\\[.*?\\]\\)"                                ; author  (5)
    "\\(\\[.*?\\]\\)"                                ; date    (6)
    "\\)?"


### PR DESCRIPTION
The regex was missing the values for the cases:
- "U" for a good, untrusted signature, and;
- "N" for no signature.

Without this, the log buffer in short mode and with
`magit-log-show-gpg-status` evaluating to true, would unconditionally
show the GPG signature status, author and relative date in the message
line as output by git.
