### PR TITLE
Add customize variable for default log range

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -324,6 +324,11 @@ Only considered when moving past the last entry with
   :group 'magit
   :type 'boolean)
 
+(defcustom magit-log-default-log-range "HEAD"
+  "Default range to be passed to `magit-log'"
+  :group 'magit
+  :type 'string)
+
 (defcustom magit-process-popup-time -1
   "Popup the process buffer if a command takes longer than this many seconds."
   :group 'magit
@@ -5839,7 +5844,7 @@ With a non numeric prefix ARG, show all entries"
   (interactive)
   (let* ((log-range (if ask-for-range
                         (magit-read-rev-range "Log" "HEAD")
-                      "HEAD"))
+                      magit-log-default-log-range))
          (topdir (magit-get-top-dir))
          (args (nconc (list (magit-rev-range-to-git log-range))
                       magit-custom-options


### PR DESCRIPTION
Using git log without specifying a range is very slow on some git
repositories (like the Linux kernel). It's tedious to have to specify
a custom range every time you need to look at the log. Add a customize
variable for the default log range that can be set to things like
"HEAD~100..HEAD".

Left uncustomized, this variable introduces no user-visible changes.
