### PR TITLE
Add variable for default log range

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -324,6 +324,11 @@ Only considered when moving past the last entry with
   :group 'magit
   :type 'boolean)
 
+(defvar magit-log-default-log-range "HEAD"
+  "Default range to be passed to `magit-log'. This can be a
+string (like \"HEAD~100..HEAD\") or a function that returns a
+string.")
+
 (defcustom magit-process-popup-time -1
   "Popup the process buffer if a command takes longer than this many seconds."
   :group 'magit
@@ -5839,7 +5844,9 @@ With a non numeric prefix ARG, show all entries"
   (interactive)
   (let* ((log-range (if ask-for-range
                         (magit-read-rev-range "Log" "HEAD")
-                      "HEAD"))
+                      (if (functionp magit-log-default-log-range)
+                          (funcall magit-log-default-log-range)
+                        magit-log-default-log-range)))
          (topdir (magit-get-top-dir))
          (args (nconc (list (magit-rev-range-to-git log-range))
                       magit-custom-options


### PR DESCRIPTION
Using git log without specifying a range is very slow on some git
repositories (like the Linux kernel). It's tedious to have to specify
a custom range every time you need to look at the log. Add a variable
for the default log range that can be set to things like
"HEAD~100..HEAD", or to a function that returns a similar string.

Left unchanged, this variable introduces no user-visible changes.

Example usage of specifying a function that returns a range string:
https://github.com/mgalgs/.emacs.d/blob/f9ae63829d87a7b3842bc7d15563b633169ec613/magit-setup.el
