### PR TITLE
Update README instructions to reference package-install instead of install-package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ choosing.
 
 Then install Magit (and its run-time dependencies):
 
-<kbd>M-x install-package RET magit RET</kbd>
+<kbd>M-x package-install RET magit RET</kbd>
 
 Development
 ===========


### PR DESCRIPTION
Update README instructions to reference package-install instead of install-package when trying to install from ELPA.
