### PR TITLE
magit-rev-diff-count: support git < 1.7.2

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1291,11 +1291,14 @@ non-nil, then autocompletion will offer directory names."
 (defun magit-rev-diff-count (a b)
   "Return the commits in A but not B and vice versa.
 Return a list of two integers: (A>B B>A)."
-  (mapcar 'string-to-number
-          (split-string (magit-git-string
-                         "rev-list" "--count" "--left-right"
-                         (concat a "..." b))
-                        "\t")))
+  ;; Kludge.  git < 1.7.2 does not support git rev-list --count
+  (let ((ac 0) (bc 0))
+    (dolist (commit (magit-git-lines "rev-list" "--left-right"
+                                     (concat a "..." b)))
+      (case (aref commit 0)
+        (?\< (incf ac))
+        (?\> (incf bc))))
+    (list ac bc)))
 
 (defun magit-name-rev (rev &optional no-trim)
   "Return a human-readable name for REV.


### PR DESCRIPTION
Fixes #690

But do we really want/have to support a version of git which will celebrate it's third birthday tomorrow?
