### PR TITLE
Add switch in fetching group to get tags

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -95,7 +95,8 @@ command-line).")
       ("a" "All" magit-remote-update)
       ("o" "Other" magit-fetch))
      (switches
-      ("-p" "Prune" "--prune")))
+      ("-p" "Prune" "--prune")
+      ("-t" "Fetch tags" "--tags")))
 
     (pushing
      (man-page "git-push")


### PR DESCRIPTION
Currently, there is no way to fetch tags in magit. This pull request works fine for getting tags of a specific origin but breaks when:

``` bash
git remote update --tags
```

`--tags` is not a valid argument to pass to git remote update.

Do you think we should special case the switch for `git remote update` (fetch all remotes)?
