### PR TITLE
Fix default-directory issue with magit-grep.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6952,14 +6952,14 @@ This can be added to `magit-mode-hook' for example"
                      (read-string "git grep: "
                                   (shell-quote-argument (grep-tag-default))))))
     (with-current-buffer (generate-new-buffer "*Magit Grep*")
-      (let ((default-directory (magit-get-top-dir)))
-        (insert magit-git-executable " "
-                (mapconcat 'identity magit-git-standard-options " ")
-                " grep -n "
-                (shell-quote-argument pattern) "\n\n")
-        (magit-git-insert (list "grep" "--line-number" pattern))
-        (grep-mode)
-        (pop-to-buffer (current-buffer))))))
+      (setq default-directory (magit-get-top-dir))
+      (insert magit-git-executable " "
+              (mapconcat 'identity magit-git-standard-options " ")
+              " grep -n "
+              (shell-quote-argument pattern) "\n\n")
+      (magit-git-insert (list "grep" "--line-number" pattern))
+      (grep-mode)
+      (pop-to-buffer (current-buffer)))))
 
 (defconst magit-font-lock-keywords
   (eval-when-compile


### PR DESCRIPTION
As of now, magit-grep doesn't set the default-directory variable
correctly when creating the _Magit Grep_ buffer.  This is especially
problematic if the user tries to use the file name / line number pair as
a link.
