### PR TITLE
Move 'unpulled' section down in status buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4336,11 +4336,11 @@ if FULLY-QUALIFIED-NAME is non-nil."
         (magit-insert-untracked-files)
         (magit-insert-pending-changes)
         (magit-insert-pending-commits)
-        (magit-insert-unpulled-commits remote remote-branch)
         (let ((staged (or no-commit (magit-anything-staged-p))))
           (magit-insert-unstaged-changes
            (if staged "Unstaged changes:" "Changes:"))
           (magit-insert-staged-changes staged no-commit))
+        (magit-insert-unpulled-commits remote remote-branch)
         (magit-insert-unpushed-commits remote remote-branch))))
   (run-hooks 'magit-refresh-status-hook))
 


### PR DESCRIPTION
At the moment 'unpulled' sits between 'untracked files' and
'changes'. This makes working in a non-clean repository pretty awkward
if the list of unpulled changes is longer than one or two commits as
it splits the important information that a user needs when working on
an unclean repository: untracked files and changes.

This change moves 'unpulled commits' right above 'unpushed
commits'. That way both will keep their relative order, and 'untracked
files' and 'changes' are close together. For a clean repository the
order is not even changed.
