### PR TITLE
Add an action to abort a merge

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -163,7 +163,8 @@ command-line).")
     (merging
      (man-page "git-merge")
      (actions
-      ("m" "Merge" magit-manual-merge))
+      ("m" "Merge" magit-manual-merge)
+      ("a" "Abort" magit-merge-abort))
      (switches
       ("-ff" "Fast-forward only" "--ff-only")
       ("-nf" "No fast-forward" "--no-ff")

--- a/magit.el
+++ b/magit.el
@@ -4728,6 +4728,15 @@ With a prefix-arg, the merge will be squashed.
          (magit-rev-to-git revision)
          magit-custom-options))
 
+(defun magit-merge-abort ()
+  "Abort current merge operation."
+  (interactive)
+  (let ((merge-heads (magit-file-lines (concat (magit-git-dir) "MERGE_HEAD"))))
+    (unless merge-heads
+      (error "No merge in progress"))
+    (when (yes-or-no-p "Abort merge? ")
+      (magit-run-git "merge" "--abort"))))
+
 ;;; Rebasing
 
 (defun magit-rebase-info ()


### PR DESCRIPTION
Permit to abort a merge, like you can abort a rebase.
- magit-key-mode.el (magit-key-mode-groups): Add binding to abort a merge.
- magit.el (magit-merge-abort): New command to abort a merge.
