### PR TITLE
Fixes to make install rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CPBIN ?= install -p -m 755
 MKDIR ?= install -p -m 755 -d
 
 MAKEINFO     ?= makeinfo
-INSTALL_INFO ?= ginstall-info
+INSTALL_INFO ?= install-info
 
 EMACS ?= emacs
 BATCH  = $(EMACS) $(EFLAGS) -batch -Q -L .


### PR DESCRIPTION
Hey,

I propose the following two changes to the Makefile and specifically its install rules. One commit fixes a bug, the other one is a proposed change on the name of the install-info executable.

Cheers
Bastian
