### PR TITLE
check for 'Enter passphrase: ' prompt in magit-process-password-prompt

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2505,7 +2505,9 @@ magit-topgit and magit-svn"
            (setq ask "Password:"))
           ;; See http://www.yubico.com.
           ((string-match "^Yubikey for .*: $" string)
-           (setq ask "Yubikey: " )))
+           (setq ask "Yubikey: " ))
+          ((string-match "Enter passphrase: " string)
+           (setq ask "Enter passphrase: " )))
     (when ask
       (process-send-string proc (concat (read-passwd ask nil) "\n")))))
 


### PR DESCRIPTION
when signing commits with gnupg, gnupg asks for the passphrase with
the following string

Enter passphrase:

so i added a check for this to magit-process-password-prompt.
