### PR TITLE
magit.el: add `vc-follow-symlinks' to 'magit customization group

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -137,6 +137,8 @@ deep."
   :group 'magit
   :type 'integer)
 
+(custom-add-to-group 'magit 'vc-follow-symlinks 'custom-variable)
+
 (defcustom magit-set-upstream-on-push nil
   "Whether `magit-push' may use --set-upstream when pushing a branch.
 This only applies if the branch does not have an upstream set yet.


### PR DESCRIPTION
Make users aware of `vc-follow-symlinks's existence, and the fact
that it's relevant to Magit.

Signed-off-by: Pieter Praet pieter@praet.org
