### PR TITLE
`magit-process-yes-or-no-prompt-regexp': robustify regexp

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -334,7 +334,7 @@ If t, use ptys: this enables magit to prompt for passphrases when needed."
                  (const :tag "pty" t)))
 
 (defcustom magit-process-yes-or-no-prompt-regexp
-  " [\[(]\\([Yy]\\(?:es\\)?\\)[/|]\\([Nn]o?\\)[\])]\\? ?$"
+   " [\[(]\\([Yy]\\(?:es\\)?\\)[/|]\\([Nn]o?\\)[\])] ?[?:] ?$"
   "Regexp matching Yes-or-No prompts of git and its subprocesses."
   :group 'magit
   :type 'regexp)


### PR DESCRIPTION
It only needs to match ssh(1)'s "Are you sure you want to continue
connecting (yes/no)?" prompt for the time being, but it doesn't hurt
to make it a bit more receptive:  Make it also match an optional space
after the closing square bracket or paren, and maybe a colon instead
of a question mark at the end.

Signed-off-by: Pieter Praet pieter@praet.org
