### PR TITLE
`magit-refresh-commit-buffer': pass `magit-diff-options' to git-log(1)

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4207,6 +4207,7 @@ insert a line to tell how to insert more of them"
            `(,@(and magit-have-abbrev   (list "--no-abbrev-commit"))
              ,@(and magit-have-decorate (list "--decorate=full"))
              ,@(and magit-show-diffstat (list "--stat"))
+             ,@magit-diff-options
              "--cc"
              "-p" ,commit))))
 


### PR DESCRIPTION
Take custom diff options into account when using `magit-show-commit'.

See commit a233bd4d.

Signed-off-by: Pieter Praet pieter@praet.org
