### PR TITLE
`magit-key-mode-groups': 'committing': fix parens

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -180,8 +180,8 @@
       ("-A" "Stage all modified and deleted files" "--all")
       ("-e" "Allow empty commit" "--allow-empty")
       ("-n" "Bypass git hooks" "--no-verify")
-      ("-s" "Add Signed-off-by line" "--signoff"))
-      ("-S" "Sign using gpg" "--gpg-sign"))
+      ("-s" "Add Signed-off-by line" "--signoff")
+      ("-S" "Sign using gpg" "--gpg-sign")))
 
     (merging
      (man-page "git-merge")


### PR DESCRIPTION
Commit b0954e50 moved the "--gpg-sign" flag from 'arguments'
to 'switches', but didn't properly adjust the parentheses.

Signed-off-by: Pieter Praet pieter@praet.org
