### PR TITLE
`magit-interactive-rebase': use commit at point

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5039,10 +5039,9 @@ Return nil if there is no rebase in progress."
                       (magit-section-info section))))
     (magit-with-git-editor-setup magit-server-window-for-rebase
       (magit-run-git-async "rebase" "-i"
-                           (if commit
-                               (concat commit "^")
-                             (magit-read-rev "Interactively rebase to"
-                                             (magit-guess-branch)))))))
+                           (or commit
+                               (magit-read-rev "Interactively rebase to"
+                                               (magit-guess-branch)))))))
 
 ;;;; Reset
 


### PR DESCRIPTION
When calling `magit-interactive-rebase' with point at a commit,
one would expect _that_ commit to be used as upstream HEAD instead
of its first parent.

See commit 63b7adc7.

Signed-off-by: Pieter Praet pieter@praet.org
