### PR TITLE
`magit-interactive-rebase': fully rely on `magit-guess-branch'

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5088,18 +5088,13 @@ Return nil if there is no rebase in progress."
                    magit-uninteresting-refs))))
       (magit-run-git "rebase" (magit-rev-to-git rev)))))
 
-(defun magit-interactive-rebase ()
+(defun magit-interactive-rebase (rev)
   "Start a git rebase -i session, old school-style."
-  (interactive)
-  (let* ((section (get-text-property (point) 'magit-section))
-         (commit (and (member 'commit (magit-section-context-type section))
-                      (magit-section-info section))))
-    (magit-with-git-editor-setup magit-server-window-for-rebase
-      (magit-run-git-async "rebase" "-i"
-                           (if commit
-                               (concat commit "^")
-                             (magit-read-rev "Interactively rebase to"
-                                             (magit-guess-branch)))))))
+  (interactive
+   (list (magit-read-rev "Interactively rebase to"
+                         (magit-guess-branch))))
+  (magit-with-git-editor-setup magit-server-window-for-rebase
+    (magit-run-git-async "rebase" "-i" (magit-rev-to-git rev))))
 
 ;;;; Reset
 


### PR DESCRIPTION
`magit-interactive-rebase' first tried to find a commit at point itself
before falling back`magit-guess-branch', which already provides that
functionality.  Also, if it _did_ find a commit at point, it would
instantly (i.e. without confirmation) use that commit's first _parent_
as base, instead of the commit itself.

Now we no longer try to do `magit-guess-branch's job, and _always_ ask
for confirmation.  Using the commit's first _parent_ as base is of
course still possible, by completing the first match and then inputting
"^ [RET]".

Signed-off-by: Pieter Praet pieter@praet.org
