### PR TITLE
`magit-guess-branch': use new func `magit-get-previous-branch'

### DIFF
--- a/magit-compat.el
+++ b/magit-compat.el
@@ -165,13 +165,11 @@ Return values:
 (defvar-local magit-have-graph 'unset)
 (defvar-local magit-have-decorate 'unset)
 (defvar-local magit-have-abbrev 'unset)
-(defvar-local magit-have-grep-reflog 'unset)
 (defvar-local magit-have-revlist-count 'unset)
 
 (put 'magit-have-graph 'permanent-local t)
 (put 'magit-have-decorate 'permanent-local t)
 (put 'magit-have-abbrev 'permanent-local t)
-(put 'magit-have-grep-reflog 'permanent-local t)
 (put 'magit-have-revlist-count 'permanent-local t)
 
 (defun magit-configure-have-graph ()
@@ -188,12 +186,6 @@ Return values:
   (when (eq magit-have-abbrev 'unset)
     (setq magit-have-abbrev
           (= 0 (magit-git-exit-code "log" "--no-abbrev-commit" "-n" "0")))))
-
-(defun magit-configure-have-grep-reflog ()
-  (when (eq magit-have-grep-reflog 'unset)
-    (setq magit-have-grep-reflog
-          (= 0 (magit-git-exit-code
-                "log" "--walk-reflogs" "--grep-reflog" "." "-n" "0")))))
 
 (defun magit-configure-have-revlist-count ()
   (when (eq magit-have-revlist-count 'unset)

--- a/magit.el
+++ b/magit.el
@@ -1287,6 +1287,11 @@ the current git repository."
     (when (and head (string-match "^refs/heads/" head))
       (substring head 11))))
 
+(defun magit-get-previous-branch ()
+  "Return the refname of the previously checked out branch.
+Return nil if the previously checked out branch no longer exists."
+  (magit-name-rev (magit-git-string "rev-parse" "--verify" "@{-1}")))
+
 (defun magit-get-current-tag (&optional with-distance-p)
   "Return the closest tag reachable from \"HEAD\".
 
@@ -4985,20 +4990,7 @@ If no branch is found near the cursor return nil."
            ((wazzup)
             info)
            (t
-            (magit-configure-have-grep-reflog)
-            (let ((lines
-                   (if magit-have-grep-reflog
-                       (magit-git-lines "log"
-                                        "--pretty=oneline" "--max-count=1"
-                                        "--walk-reflogs" "--grep-reflog"
-                                        "moving from")
-                     (magit-git-lines "reflog"))))
-              (while (and lines
-                          (not (string-match "moving from \\([^\s\t]+?\\) to"
-                                             (car lines))))
-                (setq lines (cdr lines)))
-              (when lines
-                (match-string 1 (car lines))))))))
+            (magit-get-previous-branch)))))
     (when (stringp branch)
       branch)))
 


### PR DESCRIPTION
Instead of depending on git-log(1)'s "--grep-reflog" flag (which
was only added in Git v1.8.0 [1]) and potentially doing a whole
bunch of string matching, use git-rev-parse(1) with the @{-N}
construct, which is supported since Git v1.6.2 [2].

As an added benefit, we now return nil instead of an invalid
refname when the previously checked out branch no longer exists.

[1] git/git@72fd13f7
[2] git/git@d18ba221

Signed-off-by: Pieter Praet pieter@praet.org
