### PR TITLE
set $GIT_EDITOR from scratch, add client-less fallback

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5474,16 +5474,15 @@ With a prefix argument amend to the commit at HEAD instead.
                      magit-server-window-for-commit
                    'switch-to-buffer)
                  (current-buffer))
-        (setq-local git-commit-commit-function
-                    (apply-partially
-                     (lambda (default-directory subcmd args)
-                       (save-buffer)
-                       (kill-buffer)
-                       (apply 'magit-run-git subcmd args))
-                     topdir subcmd
-                     `("--cleanup=strip"
-                       ,(concat "--file=" (buffer-file-name))
-                       ,@args)))))))
+        (add-hook 'git-commit-commit-hook
+                  (apply-partially
+                   (lambda (default-directory args)
+                     (magit-run-git* args))
+                   topdir `(,subcmd
+                            ,"--cleanup=strip"
+                            ,(concat "--file=" file)
+                            ,@args))
+                  nil t)))))
 
 ;;;; Tagging
 


### PR DESCRIPTION
Add new variable `magit-emacsclient-executable`.  Its default value is
set by searching for an executable in the same directory the executable
of the running Emacs instance is located in or if it cannot be found
there anywhere on `exec-path`.  This should virtually always return
something usable.  If it doesn`t then something is seriously wrong with
the Emacs installation.

We first limit the search to the directory containing the invoked Emacs
executable because multiple Emacs version might be installed and the
emacsclient earliest on the `exec-path` might not be compatible with
the running Emacs.

No longer base the $GIT_EDITOR that is eventually used by Magit when
calling git on $GIT_EDITOR or $EDITOR as set in the environment of the
running Emacs.  Instead of detecting and fixing bad values optained that
way always set $GIT_EDITOR from scratch.

Add alternative code paths to `magit-commit` and `magit-tag` that do not
require a working client/server interaction.  When using tramp and when
no window system is available also use these fallbacks.

This can still be improved a lot.  But at least we are no longer set on
a path that forces us add one kludge after another on top of the
existing kludges.

`magit-interactive-rebase` most likely cannot be implemented without the
use of emacsclient so that command now refuses to run if the client
cannot be used.

Remove `magit-git-editor` in favor of `magit-emacsclient-excecutable`.
Rename `magit-with-git-editor` to `magit-with-emacsclient`.
Add `magit-use-emacsclient-p` and `magit-assert-emacsclient`.
