### PR TITLE
Add a hook per magit-key-mode group

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -629,11 +629,20 @@ Return the point before the actions part, if any, nil otherwise."
 
 (defun magit-key-mode-generate (group)
   "Generate the key-group menu for GROUP."
-  (let ((opts (magit-key-mode-options-for-group group)))
+  (let* ((opts (magit-key-mode-options-for-group group))
+         (name (concat "magit-key-mode-popup-" (symbol-name group)))
+         (name-hook (concat name "-hook")))
     (eval
-     `(defun ,(intern (concat "magit-key-mode-popup-" (symbol-name group))) nil
+     `(defcustom ,(intern name-hook)
+        '()
+        ,(concat "List of functions to be called when displaying magit popup key for group " (symbol-name group))
+        :group 'magit
+        :type 'hook))
+    (eval
+     `(defun ,(intern name) nil
         ,(concat "Key menu for " (symbol-name group))
         (interactive)
+        (run-hooks ',(intern name-hook))
         (magit-key-mode
          (quote ,group)
          ;; As a tempory kludge it is okay to do this here.


### PR DESCRIPTION
This adds a hook per magit-key-mode group, and executes it before
displaying the key-popup.

Example:

``` lisp
(defun my-magit-display-staged-diff ()
  "Expand staging section"
  (with-local-quit
    (magit-jump-to-staged)
    (magit-expand-section)
    (recenter 0)))
(add-hook 'magit-key-mode-popup-committing-hook 'my-magit-display-staged-diff)
```

This is especially useful to replace deleted magit-log-edit-mode-hook: in git-commit-mode buffer it's too late: "git is already running".
