### PR TITLE
`magit-remove-conflicts': `delete-dups' from ALIST before populating hash table

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4676,6 +4676,7 @@ non-nil, then autocompletion will offer directory names."
 
 (defun magit-remove-conflicts (alist)
   (let ((dict (make-hash-table :test 'equal))
+        (alist (delete-dups alist))
         (result nil))
     (dolist (a alist)
       (puthash (car a) (cons (cdr a) (gethash (car a) dict))


### PR DESCRIPTION
When a member of `magit-repo-dirs' is a parent/child/duplicate of one of
the other members, ALIST will contain duplicate key-value mappings, and
because of the way`magit-remove-conflicts' tries to uniquify the keys,
it will keep recursing on those associations until their keys are the
canonical path to the repo, after which it blows up because it can no
longer extract a higher-level directory to prefix them with.

Fixes #811 and #311.

Signed-off-by: Pieter Praet pieter@praet.org
