### PR TITLE
INSTALL.md: add link label def for `git-{commit,rebase}-mode'

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -184,6 +184,7 @@ Add the above lines to your init file (`~/.emacs.el` or
 [git-wip]: https://github.com/bartman/git-wip
 [git]: http://git-scm.com
 [gitflow]: https://github.com/nvie/gitflow
+[git-modes]: https://github.com/magit/git-modes
 [marmalade]: http://marmalade-repo.org
 [melpa]: http://melpa.milkbox.net
 [stgit]: http://www.procode.org/stgit


### PR DESCRIPTION
Commit e2f9c456 added reference links for `git-commit-mode' and
`git-rebase-mode', but forgot to add the link label definition.

Signed-off-by: Pieter Praet pieter@praet.org
