### PR TITLE
Makefile: use $(RMDIR) in magit-$(VERSION).tar{,.gz} targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ magit-$(VERSION).tar.gz: $(DIST_FILES)
 	$(CP) $(DIST_FILES) magit-$(VERSION)
 	$(CPBIN) $(DIST_FILES_BIN) magit-$(VERSION)/bin
 	tar -cvz --mtime=./magit-$(VERSION) -f magit-$(VERSION).tar.gz magit-$(VERSION)
-	$(RM) magit-$(VERSION)
+	$(RMDIR) magit-$(VERSION)
 
 .PHONY: marmalade
 marmalade: magit-$(VERSION).tar
@@ -219,4 +219,4 @@ magit-$(VERSION).tar: $(ELPA_FILES) magit-pkg.el
 	$(CP) $(ELPA_FILES) magit-$(VERSION)
 	$(CP) magit-pkg.el magit-$(VERSION)
 	tar -cv --mtime=./magit-$(VERSION) -f magit-$(VERSION).tar magit-$(VERSION)
-	$(RM) magit-$(VERSION)
+	$(RMDIR) magit-$(VERSION)


### PR DESCRIPTION
The "magit-$(VERSION).tar.gz" and "magit-$(VERSION).tar" targets should
remove the "magit-$(VERSION)" directory use $(RMDIR) instead of $(RM).

See commits d8c95a9d and 04e65579.

Signed-off-by: Pieter Praet pieter@praet.org
