### PR TITLE
`magit-quote-curly-braces': fix case-insensitive matching

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -171,7 +171,7 @@ will stop working at all."
 
 (defcustom magit-quote-curly-braces
   (and (eq system-type 'windows-nt)
-       (let ((case-fold t))
+       (let ((case-fold-search t))
          (string-match-p "cygwin" magit-git-executable))
        t)
   "Whether curly braces should be quoted when calling git.


### PR DESCRIPTION
To make searching and matching case-insensitive, we have to set
`case-fold-search' (as opposed to`case-fold', which is a
non-existent variable) to t.  I'm guessing this went unnoticed
because `case-fold-search' is set to t by default.

Signed-off-by: Pieter Praet pieter@praet.org
