### PR TITLE
`magit-commit': fully expand "Staged changes" section

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5486,7 +5486,7 @@ With a prefix argument amend to the commit at HEAD instead.
     (when (and magit-expand-staged-on-commit
                (derived-mode-p 'magit-status-mode))
       (magit-jump-to-staged)
-      (magit-expand-section)
+      (magit-show-level 4 nil)
       (recenter 0))
     (magit-commit-internal "commit" magit-custom-options)))
 


### PR DESCRIPTION
Commit 64225dbc added support for auto-expanding the "Staged changes"
section when committing, but did so using `magit-expand-section' which
only expands the current section, not its subsections, so when
individual chunks were collapsed, they remained in that state.

Use `magit-show-level' instead.

Signed-off-by: Pieter Praet pieter@praet.org
