### PR TITLE
`magit-create-branch': simplify

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -438,16 +438,6 @@ case the selected window is used."
                 (function-item magit-builtin-completing-read)
                 (function :tag "Other")))
 
-(defcustom magit-create-branch-behaviour 'at-head
-  "Where magit will create a new branch if not supplied a branchname or ref.
-
-The value 'at-head means a new branch will be created at the tip
-of your current branch, while the value 'at-point means magit
-will try to find a valid reference at point..."
-  :group 'magit
-  :type '(choice (const :tag "at HEAD" at-head)
-                 (const :tag "at point" at-point)))
-
 (defcustom magit-status-buffer-switch-function 'pop-to-buffer
   "Function for `magit-status' to use for switching to the status buffer.
 
@@ -4921,21 +4911,15 @@ If REVISION is a remote branch, offer to create a local tracking branch.
     (magit-save-some-buffers)
     (magit-run-git "checkout" (magit-rev-to-git revision))))
 
-(defun magit-read-create-branch-args ()
-  (let ((cur-branch (magit-get-current-branch))
-        (cur-point (magit-default-rev)))
-    (list (read-string "Create branch: ")
-          (magit-read-rev
-           "Parent"
-           (cond ((eq magit-create-branch-behaviour 'at-point) cur-point)
-                 ((eq magit-create-branch-behaviour 'at-head) cur-branch)
-                 (t cur-branch))))))
-
 (magit-define-command create-branch (branch parent)
   "Switch 'HEAD' to new BRANCH at revision PARENT and update working tree.
 Fails if working tree or staging area contain uncommitted changes.
 \('git checkout -b BRANCH REVISION')."
-  (interactive (magit-read-create-branch-args))
+  (interactive
+   (list (read-string "Create branch: ")
+         (magit-read-rev "Parent" (or (magit-name-rev
+                                       (magit-commit-at-point 'noerror))
+                                      (magit-get-current-branch)))))
   (when (and branch (not (string= branch ""))
              parent)
     (magit-save-some-buffers)


### PR DESCRIPTION
I added the `magit-create-branch-behaviour' option back in 2011
(commit 3cf57646), but made the horrible mistake of leaving the
original behavior ("create branch at HEAD") the default.
See e.g. this thread [1] from February 2013 on the ML.

Instead of making 'at-point the default, let's just get rid of
the option altogether and always try to find a rev at point first.

Note that I'm intentionally _not_ using `magit-default-rev', as
that uses`magit-guess-branch', which is very likely to offer
the _previous_ value of HEAD instead of the current one.

[1] mid:"87k3q9pm73.fsf@debian.org"

Signed-off-by: Pieter Praet pieter@praet.org
