### PR TITLE
git-am action --- apply mbox from within magit

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -217,6 +217,23 @@
       ("*" "Set unused" magit-rewrite-set-unused)
       ("." "Set used" magit-rewrite-set-used)))
 
+    (apply-mailbox
+     (man-page "git-am")
+     (actions
+      ("j" "Apply Mailbox" magit-apply-mailbox))
+     (switches
+      ("-s" "add a Signed-off-by line to the commit message" "--signoff")
+      ("-3" "allow fall back on 3way merging if needed" "--3way")
+      ("-k" "pass -k flag to git-mailinfo" "--keep")
+      ("-c" "strip everything before a scissors line" "--scissors")
+      ("-p" "pass it through git-apply" "-p")
+      ("-r" "override error message when patch failure occurs" "--resolvemsg")
+      ("-d" "lie about committer date" "--committer-date-is-author-date")
+      ("-D" "use current timestamp for author date" "--ignore-date")
+      ("-b" "pass -b flag to git-mailinfo" "--keep-non-patch"))
+     (arguments
+      ("=p" "format the patch(es) are in" "--patch-format")))
+
     (submodule
      (man-page "git-submodule")
      (actions


### PR DESCRIPTION
This patch defines the git-am action and the `magit-apply-mailbox'
function and binds them to "j" which is the _only_ remaining unbound
lower-case key.
