### PR TITLE
customizable display of options to magit commands

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -633,27 +633,60 @@ Return the point before the actions part, if any, nil otherwise."
 
 (defun magit-key-mode-generate (group)
   "Generate the key-group menu for GROUP."
-  (let ((opts (magit-key-mode-options-for-group group)))
+  (let* ((opts (magit-key-mode-options-for-group group))
+         (immediate (member group magit-immediate-commands))
+         (arg (if immediate 'options 'no-options)))
     (eval
-     `(defun ,(intern (concat "magit-key-mode-popup-" (symbol-name group))) nil
-        ,(concat "Key menu for " (symbol-name group))
-        (interactive)
-        (magit-key-mode
-         (quote ,group)
-         ;; As a tempory kludge it is okay to do this here.
-         ,(cl-case group
-            (logging
-             '(when magit-have-graph
-                (list "--graph")))
-            (diff-options
-             '(when (local-variable-p 'magit-diff-options)
-                magit-diff-options))))))))
+     `(defun ,(intern (concat "magit-key-mode-popup-" (symbol-name group)))
+        (&optional ,arg)
+        ,(if immediate
+             (format "Run %s.\nWith prefix argument show %s Key menu."
+                     group group)
+           (format "Key menu for %s.\nWith prefix argument run %s directly."
+                   group group))
+        (interactive "P")
+        (message "showing options %s" ,(if immediate arg `(not ,arg)))
+        (if ,(if immediate arg `(not ,arg))
+            ;; pop up the full menu
+            (magit-key-mode
+             (quote ,group)
+             ;; As a tempory kludge it is okay to do this here.
+             ,(cl-case group
+                (logging
+                 '(when magit-have-graph
+                    (list "--graph")))
+                (diff-options
+                 '(when (local-variable-p 'magit-diff-options)
+                    magit-diff-options))))
+          ;; execute the action with the same key binding directly
+          (let ((keys (this-command-keys)))
+            (call-interactively
+             (third (assoc (subseq keys (1- (length keys)))
+                           ',(cdr (assoc 'actions opts)))))))))))
 
 ;; create the interactive functions for the key mode popups (which are
 ;; applied in the top-level key maps)
-(mapc (lambda (g)
-        (magit-key-mode-generate (car g)))
-      magit-key-mode-groups)
+(defcustom magit-immediate-commands nil
+  "Actions listed here are run immediately instead of displaying options.
+The options for these commands may still be viewed by invoking
+the commands with a prefix argument.  Values should be keys from
+`magit-key-mode-groups'.  When this variable is set action
+functions will be automatically regenerated using
+`magit-key-mode-generate'."
+  :group 'git-commit
+  :type `(repeat
+          (choice
+           ,@(mapcar (lambda (g)
+                       `(const :tag ,(symbol-name (car g)) ,(car g)))
+                     magit-key-mode-groups)))
+  :initialize
+  (lambda (symbol value)
+    (let ((val (eval value)))
+      ;; set the value
+      (set-default symbol val)
+      ;; update group functions
+      (mapc (lambda (g) (magit-key-mode-generate (car g)))
+            magit-key-mode-groups))))
 
 (provide 'magit-key-mode)
 ;;; magit-key-mode.el ends here


### PR DESCRIPTION
Commands added to `magit-immediate-commands' are run immediately without
first displaying options.  All other magit commands are run as normal.
With a prefix argument these behavior are reversed, so members of
`magit-immediate-commands' displaying options and other commands run
immediately.

Whenever a command is immediately run, the action taken is that which is
bound to same keystroke as that used to invoke the command.

When `magit-immediate-commands' is set through the customization
interface, all related magit command functions are redefined with the
appropriate behavior, argument list and documentation.

Importantly, since `magit-immediate-commands' is initially set to nil
this commit has _no_ effect on default magit behavior.  It does however
make it easy for users to skip the option pane for specific commands.
