### PR TITLE
Resurrect the staged version of a file

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6248,7 +6248,8 @@ written to .git/info/exclude."
         (file (magit-diff-item-file diff)))
     (cond ((eq kind 'deleted)
            (when (yes-or-no-p (format "Resurrect %s? " file))
-             (magit-run-git "reset" "-q" "--" file)
+             (when stagedp
+               (magit-run-git "reset" "-q" "--" file))
              (magit-run-git "checkout" "--" file)))
           ((eq kind 'new)
            (when (yes-or-no-p (format "Delete %s? " file))


### PR DESCRIPTION
'k' on deleted file in the "Unstaged changes" section use to first reset
all change on the staged version and then checkout the file as in the
last commit. This can lead to data lost if one have already staged some
change, then deleted the file then try to resurrect the just deleted
file.

It less surprising if we resurrect the staged version of a file when it
is different from the committed version.
