### PR TITLE
Fix magit-decode-git-path for paths with backslash

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1377,7 +1377,8 @@ server if necessary."
                     "\\\\[^0-7]"
                     (lambda (match)
                       (string (read (concat "?" match))))
-                    (substring path 1 -1)))
+                    (substring path 1 -1)
+                    t t))
     (let* (strings
            bytes
            (merge (lambda ()


### PR DESCRIPTION
Fixes the following bug :

``` emacs-lisp
(magit-decode-git-path "\"foo\\\\bar\"")
```

must be decoded properly, and not give an error.
