### PR TITLE
Allow to change method for exec git command

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3797,13 +3797,17 @@ member of ARGS, or to the working file otherwise."
 ;; the parser too easily
 (defvar magit-git-log-options
   (list
-   "--pretty=format:* %h %s"
+   (if magit-use-shell-command
+       "--pretty=format:\"* %h %s\""
+     "--pretty=format:* %h %s")
    (format "--abbrev=%d" magit-sha1-abbrev-length)))
 ;; --decorate=full otherwise some ref prefixes are stripped
 ;;  '("--pretty=format:* %H%d %s" "--decorate=full"))
 
 (defvar magit-git-reflog-options
-  (list "--pretty=format:* \C-?%h\C-?%gs"
+  (list (if magit-use-shell-command
+            "--pretty=format:\"* \C-?%h\C-?%gs\""
+          "--pretty=format:* \C-?%h\C-?%gs")
         (format "--abbrev=%d" magit-sha1-abbrev-length)))
 
 (defconst magit-unpushed-or-unpulled-commit-re
@@ -4596,7 +4600,7 @@ if FULLY-QUALIFIED-NAME is non-nil."
              (remote-rebase (and branch (magit-get-boolean "branch" branch "rebase")))
              (remote-branch (or (and branch (magit-remote-branch-for branch)) branch))
              (remote-string (magit-remote-string remote remote-branch remote-rebase))
-             (head (magit-format-commit "HEAD" "%h %s"))
+             (head (magit-format-commit "HEAD" (if magit-use-shell-command "\"%h %s\"" "%h %s")))
              (no-commit (not head))
              (merge-heads (magit-file-lines (magit-git-dir "MERGE_HEAD")))
              (rebase (magit-rebase-info)))
@@ -5237,9 +5241,13 @@ With two prefix args, remove ignored files as well."
               (magit-set-section-info commit)
               (insert (magit-git-string
                        "log" "--max-count=1"
-                       (if used
-                           "--pretty=format:. %s"
-                         "--pretty=format:* %s")
+                       (if magit-use-shell-command
+                           (if used
+                               "--pretty=format:\". %s\""
+                             "--pretty=format:\"* %s\"")
+                         (if used
+                             "--pretty=format:. %s"
+                           "--pretty=format:* %s"))
                        commit "--")
                       "\n")))))
       (insert "\n"))))
@@ -5904,7 +5912,9 @@ With a non numeric prefix ARG, show all entries"
                           (when magit-log-show-gpg-status
                             (list "--show-signature"))))
                  (oneline
-                  (list (concat "--pretty=format:%h%d "
+                  (list (concat (if magit-use-shell-command 
+                                    "--pretty=format\":%h%d \""
+                                  "--pretty=format:%h%d ")
                                 (and magit-log-show-gpg-status "%G?")
                                 "[%an][%ar]%s")))
                  (t nil))


### PR DESCRIPTION
- Add variable magit-use-shell-command
  change process-file to shell-command-to-string
- this patch improve performance in Windows
- some nvironment(ex.Windows & gnu-pack emacs) too slow default process-file.
  and shell-command-to-string faster than process-file.
  this patch allow to change it.
