### PR TITLE
Remove requirement on a graphical environment.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1330,8 +1330,6 @@ server if necessary."
 (defun magit-assert-emacsclient (action)
   (unless magit-emacsclient-executable
     (error "Cannot %s when `magit-emacsclient-executable' is nil" action))
-  (unless (cl-find-if #'display-graphic-p (terminal-list))
-    (error "Cannot %s when no window system is available" action))
   (when (and (fboundp 'tramp-tramp-file-p)
              (tramp-tramp-file-p default-directory))
     (error "Cannot %s when accessing repository using tramp" action)))


### PR DESCRIPTION
There is no need to require a graphical environment when using emacsclient. I have tested this and it works fine.
