### PR TITLE
Use formatted reference name as target for rebasing

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1571,7 +1571,7 @@ according to option `magit-remote-ref-format'."
                   (qualified match)
                   ((string-match "^refs/remotes/" match)
                    (if pretty
-                       (substring match (+ 14 (length match)))
+                       (magit-format-ref match)
                      (substring match 13)))
                   (t match))))))))
 


### PR DESCRIPTION
Argument `pretty` is supposed to respect `magit-remote-ref-format`. In it's current state this throws an argument out of range error from substring.
