### PR TITLE
Fix return value of `magit-ref-exists-p'

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1632,7 +1632,7 @@ Otherwise, return nil."
   (magit-get-remote (magit-get-current-branch)))
 
 (defun magit-ref-exists-p (ref)
-  (magit-git-success "show-ref" "--verify" ref) 0)
+  (magit-git-success "show-ref" "--verify" ref))
 
 (defun magit-rev-parse (ref)
   "Return the SHA hash for REF."


### PR DESCRIPTION
It causes new branch cannot be created in branch manager.
