### PR TITLE
commit: add -v for verbose option

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -192,6 +192,7 @@
       ("-r" "Replace the tip of current branch" "--amend")
       ("-a" "Stage all modified and deleted files" "--all")
       ("-e" "Allow empty commit" "--allow-empty")
+      ("-v" "Show diff of changes to be committed" "--verbose")
       ("-n" "Bypass git hooks" "--no-verify")
       ("-s" "Add Signed-off-by line" "--signoff")
       ("-S" "Sign using gpg" "--gpg-sign")))


### PR DESCRIPTION
Add a -v option which allows you to invoke git-commit with --verbose. I
always do this because inevitably I'll forget some of the finer points
of the patch I'm about to commit, and having it all in the same buffer
instead of having to look at "git diff --staged" in another window is
great.

Now when you press "c" the window that's brought up looks like this:

```
Switches
 -r: Replace the tip of current branch (--amend)         -a: Stage all modified and deleted files (--all)
 -e: Allow empty commit (--allow-empty)                  -v: Show diff of changes to be committed (--verbose)
 -n: Bypass git hooks (--no-verify)                      -s: Add Signed-off-by line (--signoff)
 -S: Sign using gpg (--gpg-sign)
Actions
 c: Commit
```

And e.g. for this change I'm about to commit the buffer opens with:

```
# Please enter the commit message for your changes. Lines starting
# with '#' will be ignored, and an empty message aborts the commit.
# On branch master
# Changes to be committed:
#   (use "git reset HEAD <file>..." to unstage)
#
#   modified:   magit-key-mode.el
#
diff --git a/magit-key-mode.el b/magit-key-mode.el
index a7d9a8c..4fd5510 100644
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -192,6 +192,7 @@
       ("-r" "Replace the tip of current branch" "--amend")
       ("-a" "Stage all modified and deleted files" "--all")
       ("-e" "Allow empty commit" "--allow-empty")
+      ("-v" "Show diff of changes to be committed" "--verbose")
       ("-n" "Bypass git hooks" "--no-verify")
       ("-s" "Add Signed-off-by line" "--signoff")
       ("-S" "Sign using gpg" "--gpg-sign")))
```
