### PR TITLE
make commit at point the default input value for magit-show-commit

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4448,7 +4448,7 @@ Noninteractively, if the commit is already displayed and SCROLL
 is provided, call SCROLL's function definition in the commit
 window.  (`scroll-up' and `scroll-down' are typically passed in
 for this argument.)"
-  (interactive (list (magit-read-rev "Show commit (hash or ref)")
+  (interactive (list (magit-read-rev-with-default "Show commit (hash or ref)")
                      nil nil t))
   (when (magit-section-p commit)
     (setq commit (magit-section-info commit)))


### PR DESCRIPTION
v2 of #870. Changes since v1:

o Just use `magit-read-rev-with-default` instead of using `word-at-point`.
