### PR TITLE
README.md: add link label def for `git-modes'

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ please read [CONTRIBUTING.md][contributing].
 [ert]: https://github.com/ohler/ert
 [git-wip]: https://github.com/bartman/git-wip
 [git]: http://git-scm.com
+[git-modes]: https://github.com/magit/git-modes
 [marmalade]: http://marmalade-repo.org
 [melpa]: http://melpa.milkbox.net
 [vc]: http://www.gnu.org/software/emacs/manual/html_node/emacs/Version-Control.html


### PR DESCRIPTION
Commit 41b1bb7a added a reference link for `git-modes', but forgot
to add the link label definition.

Signed-off-by: Pieter Praet pieter@praet.org
