### PR TITLE
`magit-display-process': fix displaying the process buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2907,14 +2907,13 @@ seconds.  Finally if both PROCESS and BUFFER are nil display the
 buffer of the most recent process, like in the interactive case."
   (interactive)
   (cond ((not process)
-         (unless buffer
-           (setq buffer (get-buffer magit-process-buffer-name))
-           (unless buffer
+         (or buffer
+             (setq buffer (get-buffer magit-process-buffer-name))
              (error "No Git commands have run"))
-           (when (buffer-live-p buffer)
-             (display-buffer buffer)
-             (with-current-buffer buffer
-               (goto-char (point-max))))))
+         (when (buffer-live-p buffer)
+           (display-buffer buffer)
+           (with-current-buffer buffer
+             (goto-char (point-max)))))
         ((= magit-process-popup-time 0)
          (magit-display-process nil (process-buffer process)))
         ((> magit-process-popup-time 0)


### PR DESCRIPTION
Commit e26c9c79 erroneously wrapped the call to `display-buffer'
inside the`unless', meaning if we _had_ a buffer to display, the
code to display it _wouldn't_ run, essentially causing the process
buffer to never be displayed when the BUFFER arg was non-nil, and
thus breaking `magit-process-popup-time'-based process buffer popup.

Fixes #887.

Signed-off-by: Pieter Praet pieter@praet.org
