### PR TITLE
magit.el: add `magit-diff-use-overlays' to `magit-faces' as custom-VARIABLE

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -704,7 +704,7 @@ set before loading libary `magit'.")
 
 ;; Add to faces group because it affects `magit-item-highlight's
 ;; default, and because the doc-strings of many faces refer to it.
-(custom-add-to-group 'magit-faces 'magit-diff-use-overlays 'custom-group)
+(custom-add-to-group 'magit-faces 'magit-diff-use-overlays 'custom-variable)
 
 (custom-add-to-group 'magit-faces 'git-commit-faces 'custom-group)
 (custom-add-to-group 'magit-faces 'git-rebase-faces 'custom-group)


### PR DESCRIPTION
Visiting the `magit-diff-use-overlays' option from the`magit-faces'
group resulted in an empty Customize buffer, stating:

  "Group definition missing."

See commit 66a06442.

Fixes #889.

Signed-off-by: Pieter Praet pieter@praet.org
