### PR TITLE
`magit-ignore-item': make LOCAL arg optional

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6311,7 +6311,7 @@ except if LOCAL is non-nil in which case they are written to
       (write-region nil nil ignore-file))
     (magit-need-refresh)))
 
-(defun magit-ignore-item (edit local)
+(defun magit-ignore-item (edit &optional local)
   "Ignore the item at point.
 With a prefix argument edit the ignore string."
   (interactive "P")


### PR DESCRIPTION
Commit 15c08f9e merged `magit-ignore-item' and`magit--ignore-item', and
for some reason made the LOCAL arg non-optional, causing Emacs to signal
`wrong-number-of-arguments' when running`magit-ignore-item' ("i") on a
file in the status buffer.

Fixes #893.

Signed-off-by: Pieter Praet pieter@praet.org
