### PR TITLE
`magit-mark-item': fix toggling mark in status buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6550,7 +6550,7 @@ With a prefix argument, visit in other window."
     (magit-section-action (item info "mark")
       ((commit)
        (setq magit-marked-commit
-             (if (eq magit-marked-commit info) nil info)))))
+             (if (equal magit-marked-commit info) nil info)))))
   (magit-refresh-marked-commits))
 
 ;;;; Describe


### PR DESCRIPTION
Running `magit-mark-item' on a marked commit is supposed to unmark it.

Since the value stored in `magit-marked-commit' is a string, doing
comparison using`eq' can't possibly work, so use `equal' instead.

BTW, for some odd reason (which I don't feel like investigating right
now), the previous state of affairs _did_ in fact _work_ in the log
buffer (as opposed to the status buffer).  Doesn't matter anymore
though.  Now it works in both of them...

Fixes #898.

Signed-off-by: Pieter Praet pieter@praet.org
