### PR TITLE
`magit-insert-status-line': remove `declare' form

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4581,7 +4581,6 @@ in `magit-commit-buffer-name'."
 (defvar magit-status-line-align-to 9)
 
 (defun magit-insert-status-line (heading info-string)
-  (declare (indent 1))
   (insert heading ":"
           (make-string (max 1 (- magit-status-line-align-to
                                  (length heading))) ?\ )


### PR DESCRIPTION
`declare' only makes sense in macro definitions...

See commit 1a9ba2ae.

Signed-off-by: Pieter Praet pieter@praet.org
