### PR TITLE
`magit-log-create-author-date-overlays': remove redundant check

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4221,10 +4221,9 @@ must return a string which will represent the log line.")
             magit-log-author-date-overlay)
       (setq magit-log-author-date-string-length max-length))
     (magit-log-refresh-author-date)
-    (when magit-log-author-date-overlay
-      (add-hook 'window-configuration-change-hook
-                'magit-log-refresh-author-date
-                nil t))))
+    (add-hook 'window-configuration-change-hook
+              'magit-log-refresh-author-date
+              nil t)))
 
 (defvar magit-log-buffer-name "*magit-log*"
   "Buffer name for display of log entries.")


### PR DESCRIPTION
Commit d1e19af8 merged `magit-log-create-author-date-overlay'
into`magit-log-set-author-date-overlays' (renamed to
`magit-log-create-author-date-overlays'), but didn't remove the
second check of`magit-log-author-date-overlay'.  This variable
isn't modified between the first and second check, so the latter
is redundant.

Signed-off-by: Pieter Praet pieter@praet.org
