### PR TITLE
`magit-refresh-wrapper': only refresh status buffer if it has company

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3119,9 +3119,9 @@ remove the symbol `Git' from `vc-handled-backends'."
           (funcall func)
         ;; Refresh magit buffers.
         (let (magit-custom-options)
-          (when status-buffer
-            (cl-pushnew status-buffer magit-refresh-needing-buffers))
           (when magit-refresh-needing-buffers
+            (when status-buffer
+              (cl-pushnew status-buffer magit-refresh-needing-buffers))
             (mapc 'magit-refresh-buffer magit-refresh-needing-buffers)))
         ;; Refresh file visiting buffers.
         (dolist (buffer (buffer-list))


### PR DESCRIPTION
Among other things, commit 03d99ca0 changed `magit-refresh-wrapper' to
refresh the status buffer even if`magit-refresh-needing-buffers' is nil.

Given that (a) this causes point to jump to the beginning of the status
buffer every time we open a file from it, and (b) the change wasn't
motivated properly, revert it.

Fixes #687.  Replaces #906.

Signed-off-by: Pieter Praet pieter@praet.org
