### PR TITLE
`magit-interactive-resolve`: use `magit-git-lines'

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6625,7 +6625,7 @@ With a prefix argument, visit in other window."
 
 (defun magit-interactive-resolve (file)
   (require 'ediff)
-  (let ((merge-status (magit-git-string "ls-files" "-u" "--" file))
+  (let ((merge-status (magit-git-lines "ls-files" "-u" "--" file))
         (base-buffer (generate-new-buffer (concat file ".base")))
         (our-buffer (generate-new-buffer (concat file ".current")))
         (their-buffer (generate-new-buffer (concat file ".merged")))
@@ -6633,15 +6633,15 @@ With a prefix argument, visit in other window."
     (unless merge-status
       (error "Cannot resolve %s" file))
     (with-current-buffer base-buffer
-      (when (string-match "^[0-9]+ [0-9a-f]+ 1" merge-status)
+      (when (string-match "^[0-9]+ [0-9a-f]+ 1" (first merge-status))
         (magit-git-insert "cat-file" "blob" (concat ":1:" file))))
     (with-current-buffer our-buffer
-      (when (string-match "^[0-9]+ [0-9a-f]+ 2" merge-status)
+      (when (string-match "^[0-9]+ [0-9a-f]+ 2" (second merge-status))
         (magit-git-insert "cat-file" "blob" (concat ":2:" file)))
       (let ((buffer-file-name file))
         (normal-mode)))
     (with-current-buffer their-buffer
-      (when (string-match "^[0-9]+ [0-9a-f]+ 3" merge-status)
+      (when (string-match "^[0-9]+ [0-9a-f]+ 3" (third merge-status))
         (magit-git-insert "cat-file" "blob" (concat ":3:" file)))
       (let ((buffer-file-name file))
         (normal-mode)))


### PR DESCRIPTION
Since commit f8d304a1, `magit-git-string` _actually_ returns only the
first line of `git(1)`s output, causing `magit-interactive-resolve` to
fail because it now only gets the first of the three mode/SHA1 pairs it
needs to populate the `{base,our,their}-buffer's.

Instead of re-introducing something like `magit-git-output', which should
also sanitize the output (e.g. trailing newlines), use`magit-git-lines'.

Fixes #916.

Signed-off-by: Pieter Praet pieter@praet.org
