### PR TITLE
fix last `magit-git-string' victim

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1695,9 +1695,7 @@ Otherwise, return nil."
 
 (defun magit-ref-ambiguous-p (ref)
   "Return whether or not REF is ambiguous."
-  ;; If REF is ambiguous, rev-parse just prints errors,
-  ;; so magit-git-string returns nil.
-  (not (magit-git-string "rev-parse" "--abbrev-ref" ref)))
+  (not (magit-git-success "rev-parse" "--abbrev-ref" ref)))
 
 (defun magit-rev-diff-count (a b)
   "Return the commits in A but not B and vice versa.


### PR DESCRIPTION
Fixing another victim of the semantic change in `magit-git-string` (commit f8d304a1).

@tarsius:
I've checked all functions which make use of `magit-git-string`.
This should be the only one left to fix.
