### PR TITLE
`magit-cherry-mode-map': add

### DIFF
--- a/magit-cherry.el
+++ b/magit-cherry.el
@@ -33,6 +33,12 @@
 (defvar magit-cherry-buffer-name "*magit-cherry*"
   "Name of buffer used to display commits not merged upstream.")
 
+(defvar magit-cherry-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map magit-mode-map)
+    map)
+  "Keymap for `magit-cherry-mode'.")
+
 (define-derived-mode magit-cherry-mode magit-mode "Magit Cherry"
   "Mode for looking at commits not merged upstream.
 


### PR DESCRIPTION
Commit 8618430b added a reference to MAPVAR `magit-cherry-mode-map'
in`magit-cherry-mode's docstring, but the former didn't exist.

Signed-off-by: Pieter Praet pieter@praet.org
