### PR TITLE
`magit-diffstat-keymap': fix docstring

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1240,7 +1240,7 @@ Also see option `magit-diff-use-overlays'."
     (set-keymap-parent map magit-mode-map)
     (define-key map (kbd "e") 'magit-diffstat-ediff)
     map)
-  "Keymap for `magit-diffstat-mode'.")
+  "Keymap for diffstats in `magit-commit-mode' and `magit-diff-mode'.")
 
 (easy-menu-define magit-mode-menu magit-mode-map
   "Magit menu"


### PR DESCRIPTION
Commit 8618430b changed `magit-diffstat-keymap's docstring to refer to
`magit-diffstat-mode', but that doesn't exist.  `magit-diffstat-keymap'
is used in`magit-commit-mode' and `magit-diff-mode' though.

Signed-off-by: Pieter Praet pieter@praet.org
