### PR TITLE
`string-{prefix,match}-p' (compat): remove

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -125,21 +125,6 @@ buffer-local wherever it is set."
       (list 'progn (list 'defvar var val docstring)
             (list 'make-variable-buffer-local (list 'quote var)))))
 
-  ;; Added in Emacs 23.2 (mirrors/emacs@35006704).
-  (unless (fboundp 'string-prefix-p)
-    (defun string-prefix-p (str1 str2 &optional ignore-case)
-      "Return non-nil if STR1 is a prefix of STR2.
-If IGNORE-CASE is non-nil, the comparison is done without paying attention
-to case differences."
-      (eq t (compare-strings str1 nil nil
-                             str2 0 (length str1) ignore-case))))
-
-  ;; Added in Emacs 23.1 (mirrors/emacs@b70a256f).
-  (unless (fboundp 'string-match-p)
-    (defun string-match-p (regexp string &optional start)
-      "Same as `string-match' but don't change the match data."
-      (let ((inhibit-changing-match-data t))
-        (string-match regexp string start))))
   )
 
 


### PR DESCRIPTION
As stated in commit dc72fc03, the `string-prefix-p' and`string-match-p'
compatibility functions no longer serve any purpose since we decided to
drop support for Emacs < v23.2 (see commit 83dac351 and issue #708).

Signed-off-by: Pieter Praet pieter@praet.org
