### PR TITLE
`magit-git-string': only move point if buffer contains anything

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1466,8 +1466,8 @@ newline return an empty string."
   (with-temp-buffer
     (apply 'process-file magit-git-executable nil (list t nil) nil
            (append magit-git-standard-options args))
-    (goto-char (point-min))
     (unless (= (point-min) (point-max))
+      (goto-char (point-min))
       (buffer-substring-no-properties
        (line-beginning-position)
        (line-end-position)))))


### PR DESCRIPTION
Using a stock configuration, running `magit-status' results in 27 calls
to`magit-git-string', so the less it does, the better.

Even though it doesn't make a measurable difference, there's no point in
moving `point' unless we're sure the buffer contains anything.

Signed-off-by: Pieter Praet pieter@praet.org
