### PR TITLE
magit-file-log: use magit-refresh-log-buffer instead of magit-refresh-file-log-buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5905,7 +5905,7 @@ for the file whose log must be displayed."
          current-prefix-arg))
   (magit-mode-setup magit-log-buffer-name
                     #'magit-log-mode
-                    #'magit-refresh-file-log-buffer
+                    #'magit-refresh-log-buffer
                     'oneline "HEAD"
                     (and use-graph (list "--graph"))
                     file))
@@ -5961,28 +5961,6 @@ from the parent keymap `magit-mode-map' are also available."
                                 (and magit-log-show-gpg-status "%G?")
                                 "[%an][%ar]%s"))))
              ,@args "--"))))
-
-(defun magit-refresh-file-log-buffer (style range args file)
-  (setq magit-current-range range)
-  (setq magit-file-log-file file)
-  (magit-create-log-buffer-sections
-    (apply #'magit-git-section nil
-           (magit-rev-range-describe range (format "Commits for file %s" file))
-           (apply-partially 'magit-wash-log style 'color)
-           "log" (magit-log-cutoff-length-arg)
-           "--decorate=full" "--abbrev-commit" "--color"
-           (magit-diff-abbrev-arg)
-           `(,@(cl-case style
-                 (long
-                  (if magit-log-show-gpg-status
-                      (list "--stat" "--show-signature")
-                    (list "--stat")))
-                 (oneline
-                  (list (concat "--pretty=format:%h%d "
-                                (and magit-log-show-gpg-status "%G?")
-                                "[%an][%ar]%s"))))
-             ,@args
-             "--" ,file))))
 
 (defun magit-log-show-more-entries (&optional arg)
   "Grow the number of log entries shown.


### PR DESCRIPTION
In `magit-file-log` use `magit-refresh-log-buffer` instead of the
"specialized" `magit-refresh-file-log-buffer`.

The latter refresher was wrong for several reasons:
- There ain't no "file log" buffer - file log uses the same buffer
  as "regular log".  Whether that is a good idea is a different
  issue.
- The file-log refresher effectively re-implemented the regular
  refresher but in a less feature full and buggy fashion.  The person
  who implemented the file-log refresher should instead just have made
  the, rather minimal, required adjustments to the log refresher and
  then have used that.
