### PR TITLE
magit-run-git-gui-blame: fix when linenum is missing

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -7045,9 +7045,9 @@ blame to center around the line point is on."
   (let ((default-directory (magit-get-top-dir default-directory)))
     (apply 'start-file-process "Git Gui Blame" nil
            magit-git-executable "gui" "blame"
-           (list (and linenum (format "--line=%d" linenum))
-                 commit
-                 filename))))
+           `(,@(and linenum (list (format "--line=%d" linenum)))
+             ,commit
+             ,filename))))
 
 (defun magit-run-gitk ()
   "Run `gitk --all' for the current git repository."


### PR DESCRIPTION
We can't guarantee that we'll always know which line number
we want to center the `git gui blame' process around.  This
fixes an error caused by attempting to pass nil as one of
the arguments to`start-file-process'.

Message-by: Sylvain Chouleur sylvain.chouleur@intel.com :-)
Reported-by: Sylvain Chouleur sylvain.chouleur@intel.com
