### PR TITLE
fix remote branch names with slashes

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1612,7 +1612,7 @@ according to option `magit-remote-ref-format'."
                   (if (setq match (cadr (assoc prefix fetch)))
                       (setq match (concat (substring match 0 -1)
                                           (mapconcat 'identity
-                                                     (nreverse unique)
+                                                     unique
                                                      "/")))
                     (setq unique (cons (car prefix) unique)
                           prefix (cdr prefix))))))


### PR DESCRIPTION
I have remote branches with "/" in the names, which are not recognized by magit since the introduction of magit-get-tracked-branch.  This patch fixes it for me.
