### PR TITLE
A popup for popups

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -71,7 +71,37 @@
 ;;; Keygroups
 
 (defvar magit-key-mode-groups
-  '((logging
+  '((dispatch
+     (actions
+      ("b" "Branching"       magit-key-mode-popup-branching)
+      ("B" "Bisecting"       magit-key-mode-popup-bisecting)
+      ("c" "Committing"      magit-key-mode-popup-committing)
+      ("d" "Diff worktree"   magit-diff-working-tree)
+      ("D" "Diff"            magit-diff)
+      ("f" "Fetching"        magit-key-mode-popup-fetching)
+      ("F" "Pulling"         magit-key-mode-popup-pulling)
+      ("g" "Refresh Buffers" magit-refresh-all)
+      ("j" "Jump"            magit-section-jump-map) ; only in status
+      ("l" "Logging"         magit-key-mode-popup-logging)
+      ("m" "Merging"         magit-key-mode-popup-merging)
+      ("M" "Remoting"        magit-key-mode-popup-remoting)
+      ("P" "Pushing"         magit-key-mode-popup-pushing)
+      ("o" "Submoduling"     magit-key-mode-popup-submodule)
+      ("r" "Rewriting"       magit-key-mode-popup-rewriting)
+      ("s" "Show Status"     magit-status) ; vs. status: magit-state
+      ("S" "Stage all"       magit-stage-all)
+      ("t" "Tagging"         magit-key-mode-popup-tagging)
+      ("U" "Unstage all"     magit-unstage-all)
+      ("v" "Show Commit"     magit-show-commit) ; vs. status: magit-revert-item
+      ("V" "Show File"       magit-show)
+      ("w" "Wazzup"          magit-wazzup)
+      ("X" "Reset worktree"  magit-reset-working-tree)
+      ("y" "Cherry"          magit-cherry)
+      ("z" "Stashing"        magit-key-mode-popup-stashing)
+      ("!" "Running"         magit-key-mode-popup-running)
+      ("$" "Show Process"    magit-display-process)))
+
+    (logging
      (man-page "git-log")
      (actions
       ("l" "Short" magit-log)

--- a/magit.el
+++ b/magit.el
@@ -1142,7 +1142,8 @@ Also see option `magit-diff-use-overlays'."
     (define-key map (kbd "M-g") 'magit-goto-diffstats)
     (define-key map (kbd "S") 'magit-stage-all)
     (define-key map (kbd "U") 'magit-unstage-all)
-    (define-key map (kbd "X") 'magit-reset-working-tree)
+    (define-key map (kbd "C-c C-c") 'magit-key-mode-popup-dispatch)
+    (define-key map (kbd "C-c C-e") 'magit-key-mode-popup-dispatch)
     map)
   "Parent keymap for all keymaps of modes derived from `magit-mode'.")
 


### PR DESCRIPTION
Add `magit-key-mode-popup-dispatch`.

There are still some open key binding questions to be resolved. I have added a few comments to that effect. But if someone can come up with a better order, I am open for suggestions. (But note that with the current key-mode we cannot control the number of rows and the order therefore has to make sense in the first dimension.)
