### PR TITLE
No merges on unpulled

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -707,6 +707,11 @@ changes, e.g. because you are committing some binary files."
                  (const :tag "Expand top section" t)
                  (const :tag "Don't expand" nil)))
 
+(defcustom magit-show-merge-commits-in-status-buffer t
+  "Whether merge commits should be shown in the status buffer."
+  :group 'magit
+  :type 'boolean)
+
 ;; Not an option to avoid advertising it.
 (defvar magit-rigid-key-bindings nil
   "Use rigid key bindings instead of thematic key popups.
@@ -4647,6 +4652,8 @@ when asking for user input."
                          (apply-partially 'magit-wash-log 'unique)
                          "log" magit-log-format
                          (magit-diff-abbrev-arg)
+                         (unless magit-show-merge-commits-in-status-buffer
+                           "--no-merges")
                          (concat "HEAD.." tracked)))))
 
 (magit-define-inserter unpushed-commits ()
@@ -4656,6 +4663,8 @@ when asking for user input."
                          (apply-partially 'magit-wash-log 'unique)
                          "log" magit-log-format
                          (magit-diff-abbrev-arg)
+                         (unless magit-show-merge-commits-in-status-buffer
+                           "--no-merges")
                          (concat tracked "..HEAD")))))
 
 (magit-define-inserter stashes ()


### PR DESCRIPTION
This series allows the user to prevent merge commits from showing up in the "Unpulled comits" section with a new defcustom variable.
