### PR TITLE
magit-default-rev: always respect NO-TRIM argument

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1897,7 +1897,8 @@ PROMPT and UNINTERESTING are passed to `magit-read-rev'."
   (or (magit-name-rev (magit-commit-at-point) no-trim)
       (let ((branch (magit-guess-branch)))
         (when branch
-          (if (string-match "^refs/\\(.*\\)" branch)
+          (if (and (not no-trim)
+                   (string-match "^refs/\\(.*\\)" branch))
               (match-string 1 branch)
             branch)))))
 


### PR DESCRIPTION
Previously this was only done when a commit could be found at point but
not when we had to use `magit-guess-branch'.
