### PR TITLE
magit-file-log: use magit-refresh-log-buffer instead of magit-refresh-file-log-buffer (v2)

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5903,7 +5903,7 @@ With a prefix argument show the log graph."
          current-prefix-arg))
   (magit-mode-setup magit-log-buffer-name
                     #'magit-log-mode
-                    #'magit-refresh-file-log-buffer
+                    #'magit-refresh-log-buffer
                     'oneline "HEAD"
                     `(,@(and use-graph (list "--graph"))
                       ,@magit-custom-options)
@@ -5936,6 +5936,7 @@ from the parent keymap `magit-mode-map' are also available."
 
 (defun magit-refresh-log-buffer (style range args &optional file)
   (setq magit-current-range range)
+  (setq magit-file-log-file file)
   (magit-create-log-buffer-sections
     (apply #'magit-git-section nil
            (cond (file
@@ -5958,29 +5959,7 @@ from the parent keymap `magit-mode-map' are also available."
                   (list (concat "--pretty=format:%h%d "
                                 (and magit-log-show-gpg-status "%G?")
                                 "[%an][%ar]%s"))))
-             ,@args "--"))))
-
-(defun magit-refresh-file-log-buffer (style range args file)
-  (setq magit-current-range range)
-  (setq magit-file-log-file file)
-  (magit-create-log-buffer-sections
-    (apply #'magit-git-section nil
-           (magit-rev-range-describe range (format "Commits for file %s" file))
-           (apply-partially 'magit-wash-log style 'color)
-           "log" (magit-log-cutoff-length-arg)
-           "--decorate=full" "--abbrev-commit" "--color"
-           (magit-diff-abbrev-arg)
-           `(,@(cl-case style
-                 (long
-                  (if magit-log-show-gpg-status
-                      (list "--stat" "--show-signature")
-                    (list "--stat")))
-                 (oneline
-                  (list (concat "--pretty=format:%h%d "
-                                (and magit-log-show-gpg-status "%G?")
-                                "[%an][%ar]%s"))))
-             ,@args
-             "--" ,file))))
+             ,@args "--" ,file))))
 
 (defun magit-log-show-more-entries (&optional arg)
   "Grow the number of log entries shown.


### PR DESCRIPTION
I have incorporated your suggestions and "shortened" some doc-strings.

The differences to v1 #948 are:

``` diff
diff --git a/magit.el b/magit.el
index 0bd038f..0018ba6 100644
--- a/magit.el
+++ b/magit.el
@@ -5896,9 +5896,7 @@ With a prefix arg, do a submodule update --init."

 (magit-define-command file-log (file &optional use-graph)
   "Display the log for the currently visited file or another one.
-
-With a prefix argument or if no file is currently visited, ask
-for the file whose log must be displayed."
+With a prefix argument show the log graph."
   (interactive
    (list (magit-read-file-from-rev (magit-get-current-branch)
                                    (magit-buffer-file-name t))
@@ -5907,7 +5905,8 @@ for the file whose log must be displayed."
                     #'magit-log-mode
                     #'magit-refresh-log-buffer
                     'oneline "HEAD"
-                    (and use-graph (list "--graph"))
+                    `(,@(and use-graph (list "--graph"))
+                      ,@magit-custom-options)
                     file))

 (magit-define-command reflog (ref)
@@ -5960,7 +5959,7 @@ from the parent keymap `magit-mode-map' are also available."
                   (list (concat "--pretty=format:%h%d "
                                 (and magit-log-show-gpg-status "%G?")
                                 "[%an][%ar]%s"))))
-             ,@args "--"))))
+             ,@args "--" ,file))))

 (defun magit-log-show-more-entries (&optional arg)
   "Grow the number of log entries shown.
```

I also found a problem with the use of `magit-read-file-from-rev`: it should fallback to "HEAD" if REVISION is nil.
