### PR TITLE
remove magit-insert-pending-changes

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -368,7 +368,6 @@ Only considered when moving past the last entry with
     magit-insert-empty-line
     magit-insert-stashes
     magit-insert-untracked-files
-    magit-insert-pending-changes
     magit-insert-pending-commits
     magit-insert-unstaged-changes
     magit-insert-staged-changes
@@ -4636,16 +4635,6 @@ when asking for user input."
                        commit "--")
                       "\n")))))
       (insert "\n"))))
-
-(magit-define-inserter pending-changes ()
-  (let* ((info (magit-read-rewrite-info))
-         (orig (cadr (assq 'orig info))))
-    (when orig
-      (let ((magit-hide-diffs t))
-        (magit-git-section 'pending-changes
-                           "Pending changes"
-                           'magit-wash-diffs
-                           "diff" (magit-diff-U-arg) "-R" orig)))))
 
 (magit-define-inserter unstaged-changes ()
   (let ((magit-hide-diffs t)

--- a/magit.texi
+++ b/magit.texi
@@ -231,8 +231,8 @@ status buffer shows the differences between the current branch and the
 tracking branch.  See @ref{Pushing and Pulling} for more information.
 
 During a history rewriting session, the status buffer shows the
-@emph{Pending changes} and @emph{Pending commits} sections.  See
-@ref{Rewriting} for more details.
+@emph{Pending changes} sections.  See @ref{Rewriting} for more
+details.
 
 @node Untracked files
 @chapter Untracked files
@@ -804,12 +804,6 @@ all of them.
 
 You can change the @kbd{*} and @kbd{.} marks of a pending commit
 explicitly with @kbd{r *} and @kbd{r .}.
-
-In addition to a list of pending commits, the status buffer will show
-the @emph{Pending changes}.  This section shows the diff between the
-original head and the current head.  You can use it to review the
-changes that you still need to rewrite, and you can apply hunks from
-it, like from any other diff.
 
 @node Pushing and Pulling
 @chapter Pushing and Pulling


### PR DESCRIPTION
The reason for this is provided in issue #966.
