### PR TITLE
`magit-process-keep-history`: optionally don't clear the process buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -422,6 +422,12 @@ they are not (due to semantic considerations)."
                  (const :tag "Immediately" 0)
                  (integer :tag "After this many seconds")))
 
+(defcustom magit-process-keep-history nil
+  "Whether to always prevent clearing the process buffer."
+  :package-version '(magit . "1.3.0")
+  :group 'magit
+  :type 'boolean)
+
 (defcustom magit-revert-item-confirm t
   "Require acknowledgment before reverting an item."
   :group 'magit
@@ -2842,8 +2848,10 @@ magit-topgit and magit-svn"
                 (bury-buffer))))
       (setq buffer-read-only t)
       (let ((inhibit-read-only t))
-        (if noerase
-            (goto-char (point-max))
+        (if (or magit-process-keep-history noerase)
+            (progn
+              (goto-char (point-max))
+              (unless (bobp) (insert "\n")))
           (erase-buffer))
         (insert "$ " (or logline
                          (mapconcat 'identity cmd-and-args " "))


### PR DESCRIPTION
Most calls to `magit-run*` don't set its NOERASE arg to a non-nil value,
so the process buffer is cleared pretty much every time we run a command
that makes use of `magit-run*`.

However, sometimes it's useful to be able to refer back to the log
of recent Git commands (and their output), e.g. when cleaning up stale
remote-tracking branches after having fetched with the "--prune" flag.

Now we can prevent the process buffer from ever being cleared by setting
`magit-process-keep-history` to a non-nil value. To improve readability,
individual command invocations will be delimited with an empty line.

Signed-off-by: Pieter Praet pieter@praet.org
