### PR TITLE
`magit-file-log`: use "HEAD" instead of `magit-get-current-branch`

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5928,7 +5928,7 @@ for the file whose log must be displayed."
                     #'magit-refresh-file-log-buffer
                     (magit-file-relative-name
                      (if (or current-prefix-arg (not buffer-file-name))
-                         (magit-read-file-from-rev (magit-get-current-branch))
+                         (magit-read-file-from-rev "HEAD")
                        buffer-file-name))
                     "HEAD" 'oneline))
 


### PR DESCRIPTION
Before commit 8c41df7, running `magit-file-log` with HEAD in a detached
state used to result in a `wrong-type-argument` error due to us passing
the return value of `magit-get-current-branch` (which in this case would
be nil) as REVISION arg to `magit-read-file-from-rev`.

Commit 8c41df7 fixed this bug by making `magit-read-file-from-rev` set
its REVISION arg to "HEAD" if it was nil, but it's still a good idea to
replace `magit-get-current-branch` with "HEAD", as this saves us from
making a perfectly dispensable call to `git-symbolic-ref(1)`.
