### PR TITLE
Try to keep window start on refresh buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3201,6 +3201,7 @@ Also see `magit-mode-setup', a more convenient variant."
   (with-current-buffer (or buffer (current-buffer))
     (let* ((old-line (line-number-at-pos))
            (old-point (point))
+           (old-window-start (window-start))
            (old-section (magit-current-section))
            (old-path (and old-section
                           (magit-section-path (magit-current-section)))))
@@ -3214,6 +3215,7 @@ Also see `magit-mode-setup', a more convenient variant."
           (apply magit-refresh-function
                  magit-refresh-args))
         (magit-refresh-marked-commits-in-buffer)
+        (set-window-start (selected-window) old-window-start)
         (let ((s (and old-path (magit-find-section old-path magit-top-section))))
           (cond (s
                  (goto-char (magit-section-beginning s))


### PR DESCRIPTION
When set scroll-conservatively large value, window point moves to top of window after magit-refresh-buffer.
I try to keep window-start.
