### PR TITLE
reimplement wazzup from scratch

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6316,14 +6316,13 @@ from the parent keymap `magit-mode-map' are also available."
           (cond
            ((and old (not (magit-section-hidden old)))
             (let ((beg (point)))
-              (magit-git-insert "log" magit-log-format
+              (magit-git-insert "cherry" "-v"
                                 (magit-diff-abbrev-arg)
-                                (concat head ".." upstream))
-              (insert "\n")
+                                head upstream)
               (save-restriction
                 (narrow-to-region beg (point))
                 (goto-char (point-min))
-                (magit-wash-log 'unique))))
+                (magit-wash-log 'cherry))))
            (t
             (setf (magit-section-hidden magit-top-section) t)
             (setf (magit-section-needs-refresh-on-show magit-top-section) t)


### PR DESCRIPTION
The last commit additionally switches from `git log` to `git cherry`. This could be made optional. However because I am considering to eventually stop using `git cherry' completely and instead display cherries everywhere, adding an option would mean that at some point someone would say we should not have removed it, so I would prefer just not to offer the option. (The cherry-everywhere thing would be implemented in elisp and use a cache. Furthermore the information would be updated asynchronously, so this would not cause any noticeable delay.) It's not something I am going to do tomorrow, so I can probably be convinced to add the option, if someone feels like it is needed.

Also sorry for the big commit in here - I saw no good in tearing down the old implementation step by step and then building up the new one.
