### PR TITLE
magit-run-git-gui-blame: by default don't require confirmation

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -7026,11 +7026,15 @@ argument) in the current window."
 ;;;###autoload
 (defun magit-run-git-gui-blame (commit filename &optional linenum)
   "Run `git gui blame' on the given FILENAME and COMMIT.
-When the current buffer is visiting FILENAME instruct
-blame to center around the line point is on."
+Interactively run it for the current file and the HEAD, with a
+prefix let the user choose.  When the current buffer is visiting
+FILENAME instruct blame to center around the line point is on."
   (interactive
-   (let* ((revision (magit-read-rev "Retrieve file from revision" "HEAD"))
-          (filename (magit-read-file-from-rev revision)))
+   (let (revision filename)
+     (if current-prefix-arg
+         (setq revision (magit-read-rev "Retrieve file from revision" "HEAD")
+               filename (magit-read-file-from-rev revision))
+       (setq revision "HEAD" filename (magit-buffer-file-name t)))
      (list revision filename
            (and (equal filename
                        (ignore-errors


### PR DESCRIPTION
Instead require a prefix argument to allow selecting another revision
and/or file.  This was requested in #787.

@aspiers Could you please give this a try.

> https://github.com/magit/magit/pull/787#issuecomment-24940093  @aspiers If the user wants to launch it on a different file and/or revision, a prefix argument is the standard emacs way for the user to indicate that.

That's not universally true, see e.g. `kill-buffer`. Actually I think it is more often _not_ true. I don't really care either way except that by now this once simple function is quite ugly. Any second opinions on this?
