### PR TITLE
new special purpose commit commands

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -219,7 +219,9 @@
       ("c" "Commit" magit-commit)
       ("a" "Amend"  magit-commit-amend)
       ("e" "Extend" magit-commit-extend)
-      ("r" "Reword" magit-commit-reword))
+      ("r" "Reword" magit-commit-reword)
+      ("f" "Fixup"  magit-commit-fixup)
+      ("s" "Squash" magit-commit-squash))
      (switches
       ("-r" "Replace the tip of current branch" "--amend")
       ("-R" "Claim authorship and reset author date" "--reset-author")

--- a/magit.el
+++ b/magit.el
@@ -322,6 +322,27 @@ which generates a tracking name of the form \"REMOTE-BRANCHNAME\"."
   :type 'boolean
   :package-version '(magit . "1.3.0"))
 
+(defcustom magit-commit-squash-commit nil
+  "Whether to target the marked or current commit when squashing.
+
+When this is nil then the command `magit-commit-fixup' and
+`magit-commit-squash' always require that the user explicitly
+selects a commit.  This is also the case when these commands are
+used with a prefix argument, in which case this option is ignored.
+
+Otherwise this controls which commit to target, either the
+current or marked commit.  Or if both can be used, which should
+be preferred."
+  :group 'magit
+  :type
+  '(choice
+    (const :tag "Always prompt" nil)
+    (const :tag "Prefer current commit, else use marked" current-or-marked)
+    (const :tag "Prefer marked commit, else use current" marked-or-current)
+    (const :tag "Use current commit, if any" current)
+    (const :tag "Use marked commit, if any" marked))
+  :package-version '(magit . "1.3.0"))
+
 (defcustom magit-commit-mode-show-buttons t
   "Whether to show navigation buttons in the *magit-commit* buffer."
   :group 'magit
@@ -5634,6 +5655,69 @@ and ignore the option.
               (magit-git-string "log" "-1" "--format:format=%cd")))
     (magit-commit-internal "commit" (nconc (list "--only" "--amend")
                                            magit-custom-options))))
+
+(defvar-local magit-commit-squash-args  nil)
+(defvar-local magit-commit-squash-fixup nil)
+
+;;;###autoload
+(defun magit-commit-fixup (&optional commit)
+  "Create a fixup commit.
+With a prefix argument the user is always queried for the commit
+to be fixed.  Otherwise the current or marked commit may be used
+depending on the value of option `magit-commit-squash-commit'.
+\('git commit [--no-edit] --fixup=COMMIT')."
+  (interactive (list (magit-commit-squash-commit)))
+  (magit-commit-squash commit t))
+
+;;;###autoload
+(defun magit-commit-squash (&optional commit fixup)
+  "Create a squash commit.
+With a prefix argument the user is always queried for the commit
+to be fixed.  Otherwise the current or marked commit may be used
+depending on the value of option `magit-commit-squash-commit'.
+\('git commit [--no-edit] --fixup=COMMIT')."
+  (interactive (list (magit-commit-squash-commit)))
+  (let ((args magit-custom-options))
+    (cond
+     ((not commit)
+      (magit-commit-assert args)
+      (magit-log)
+      (setq magit-commit-squash-args  args
+            magit-commit-squash-fixup fixup)
+      (add-hook 'magit-mark-commit-hook 'magit-commit-squash-marked t t)
+      (add-hook 'magit-quit-window-hook 'magit-commit-squash-abort t t)
+      (message "Select commit using \".\", or abort using \"q\""))
+     ((setq args (magit-commit-assert args))
+      (when (eq args t) (setq args nil))
+      (magit-commit-internal
+       "commit"
+       (nconc (list "--no-edit"
+                    (concat (if fixup "--fixup=" "--squash=") commit))
+              args))))))
+
+(defun magit-commit-squash-commit ()
+  (unless (or current-prefix-arg
+              (eq magit-commit-squash-commit nil))
+    (let ((current (magit-commit-at-point)))
+      (cl-ecase magit-commit-squash-commit
+        (current-or-marked (or current magit-marked-commit))
+        (marked-or-current (or magit-marked-commit current))
+        (current current)
+        (marked magit-marked-commit)))))
+
+(defun magit-commit-squash-marked ()
+  (when magit-marked-commit
+    (magit-commit-squash magit-marked-commit magit-commit-squash-fixup))
+  (kill-local-variable 'magit-commit-squash-fixup)
+  (remove-hook 'magit-mark-commit-hook 'magit-commit-squash-marked t)
+  (remove-hook 'magit-quit-window-hook 'magit-commit-squash-abort t)
+  (magit-quit-window))
+
+(defun magit-commit-squash-abort (buffer)
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (remove-hook 'magit-mark-commit-hook 'magit-commit-squash-marked t)
+      (remove-hook 'magit-quit-window-hook 'magit-commit-squash-abort t))))
 
 (defun magit-commit-assert (args)
   (cond


### PR DESCRIPTION
Add new special purpose commit commands `magit-commit-{amend,extend,reword,fixup,squash}`.

Note that the last two just create fixup/squash commits, they don't actually squash. Likewise interactive rebase does not automatically modify the todo list, unless one has set the appropriate git variable. I will later work on adding `--autosquash` to rebase, which requires the use of a popup (but that will have to be done very very carefully).

This also adds option `magit-commit-ask-to-stage` which is somewhat like `magit-commit-all-when-nothing-staged`, which in turn was removed a while ago. It does not offer multiple ways of staging like the old option did, that wasn't really very useful. When the user is asked whether he wants to stage or not, the unstaged changes are shown, similar to how the staged changes are shown when creating a commit (and something is already staged).

This still needs some testing. Maybe those who requested these things could help. @azuk @mgalgs @Andersbakken 
I did test but also did a lot of uhm... squashing, and that doesn't come without risks, especially since I was _at the same time_ writing the commands used for... squashing. :-)
