### PR TITLE
Fix option of git ls-files in magit-revert-buffer

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3279,7 +3279,7 @@ few sanity checks."
                 (buffer-modified-p)
                 (verify-visited-file-modtime (current-buffer))
                 (not (file-readable-p (buffer-file-name)))
-                (not (magit-git-success "ls-files" "--error-unmatched"
+                (not (magit-git-success "ls-files" "--error-unmatch"
                                         (buffer-file-name))))
       (revert-buffer t t nil))))
 


### PR DESCRIPTION
Option "--error-unmached" of git ls is wrong.
"--error-unmatch" is correct.
