### PR TITLE
`magit-goto-previous-sibling-section` gets "stuck" between sections

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2318,7 +2318,7 @@ If SECTION is nil, default to setting `magit-top-section'"
          (previous-sibling (magit-find-section-before* beginning siblings)))
     (if previous-sibling
         (magit-goto-section previous-sibling)
-      (magit-goto-parent-section))))
+      (magit-goto-previous-section))))
 
 (defun magit-goto-section (section)
   (goto-char (magit-section-beginning section))


### PR DESCRIPTION
`magit-goto-previous-sibling-section` falls back to `magit-goto-parent-section` if there are no previous siblings. When point is in between sections or on the last line of the buffer, `magit-goto-previous-sibling-section` doesn't move at all because that line belongs to the top status section so there is no parent or siblings.

I fixed this by making it fall back to `magit-goto-previous-section` instead. This is symmetric with `magit-goto-next-sibling-section`.

---

Actually, I think I might prefer if it jumped to the section header instead, but I can't think of a clean to implement that.

What I mean is, given a `magit-status` buffer that looks like this (`!` represents point):

```
Untracked files:
    not-tracked
!
```

Without this patch, `M-p` would do nothing, with patch it goes to `not-tracked` line, best might be to go to `Untracked files:` line.
