### PR TITLE
Option to elide stage all confirmation when safe to do so.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -448,12 +448,14 @@ they are not (due to semantic considerations)."
 
 A value of nil means never ask.
 A value of `safe' means only ask when there are already staged changes.
+A value of `looks-safe' is like `safe' but only checks the status buffer.
 A value of t mean always ask."
   :package-version '(magit . "1.3.0")
   :group 'magit
   :type '(choice (const t)
                  (const safe)
-                 (const nil))
+                 (const looks-safe)
+                 (const nil)))
 
 (defcustom magit-unstage-all-confirm t
   "Require acknowledgment before unstaging all changes.
@@ -461,11 +463,13 @@ A value of t mean always ask."
 A value of nil means never ask.
 A value of `safe' means only ask when there are already unstaged
 changes or untracked files.
+A value of `looks-safe' is like `safe' but only checks the status buffer.
 A value of t mean always ask."
   :package-version '(magit . "1.3.0")
   :group 'magit
   :type '(choice (const t)
                  (const safe)
+                 (const looks-safe)
                  (const nil)))
 
 (defcustom magit-process-keep-history nil
@@ -4730,6 +4734,8 @@ With a prefix argument, add remaining untracked files as well.
   (when (or (not magit-stage-all-confirm)
             (and (eq magit-stage-all-confirm 'safe)
                  (not (magit-anything-staged-p)))
+            (and (eq magit-stage-all-confirm 'looks-safe) magit-top-section
+                 (not (magit-find-section '(staged) magit-top-section)))
             (yes-or-no-p "Stage all changes?"))
     (if including-untracked
         (magit-run-git "add" ".")
@@ -4778,6 +4784,9 @@ With a prefix argument, add remaining untracked files as well.
   (when (or (not magit-unstage-all-confirm)
             (and (eq magit-unstage-all-confirm 'safe)
                  (not (magit-anything-unstaged-p)))
+            (and (eq magit-unstage-all-confirm 'looks-safe) magit-top-section
+                 (not (magit-find-section '(unstaged) magit-top-section))
+                 (not (magit-find-section '(untracked) magit-top-section)))
             (yes-or-no-p "Unstage all changes?"))
     (magit-run-git "reset" "HEAD" "--")))
 


### PR DESCRIPTION
As mentioned in [#970](https://github.com/magit/magit/pull/970#issuecomment-25470864) `stage-all` can result in loss of work. However, a lot of the time (when nothing is staged yet) it is easily undoable with `unstage-all`.

I added a `safe` option which only asks for confirmation when there is already something staged (or unstaged|untracked for unstaging). I also added a `looks-safe` option that saves the git calls by only checking the status buffer (this should be pretty safe if you avoid doing index manipulation outside magit).
