### PR TITLE
guess merge when cursor on unpulled section

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4910,6 +4910,9 @@ If no branch is found near the cursor return nil."
     ((branch)        (magit-section-info (magit-current-section)))
     ((wazzup commit) (magit-section-info (magit-section-parent item)))
     ((commit)        (magit-name-rev info))
+    ((unpulled)      (magit-name-rev
+                      (magit-section-info
+                       (car (magit-section-children (magit-current-section))))))
     ((wazzup)        info)
     (t               (magit-get-previous-branch))))
 


### PR DESCRIPTION
When sitting on the header of the unpulled section we probably want to
merge up to the last unpulled commit.
