### PR TITLE
use numeric path to find section after refresh (v2)

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -2255,7 +2255,8 @@ Like `magit-section-path' but uses child index instead of title."
         top
       (let* ((pos (car numpath))
              (sec (nth pos secs)))
-        (and sec (magit-find-section-by-num (cdr numpath) sec))))))
+        (or (and sec (magit-find-section-by-num (cdr numpath) sec))
+            (magit-find-section-after (magit-section-end top)))))))
 
 (defun magit-find-section-after (pos)
   "Find the first section that begins after POS."


### PR DESCRIPTION
This is a better version of #1010 with proper commit messages explaining what's going on. Also I split the code that decides to move forward when there is no section n+1 into a separate commit. Perhaps we want to move backwards instead.

Fixes #336.
