### PR TITLE
add `magit-add-section-hook`

### DIFF
--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -177,7 +177,7 @@
     (let ((magit-old-top-section nil))
       (magit-wash-sequence #'magit-stgit--wash-patch)))
 
-(magit-define-inserter stgit-series ()
+(defun magit-insert-stgit-series ()
   (when (executable-find magit-stgit-executable)
     (magit-insert-section 'series
                           "Series:" 'magit-stgit--wash-series

--- a/magit-svn.el
+++ b/magit-svn.el
@@ -184,7 +184,7 @@ If USE-CACHE is non nil, use the cached information."
   (let ((info (magit-svn-get-ref-info use-cache)))
     (cdr (assoc 'local-ref info))))
 
-(magit-define-inserter svn-unpulled ()
+(defun magit-insert-svn-unpulled ()
   (when (magit-svn-enabled)
     (magit-git-section 'svn-unpulled "Unpulled commits (SVN):"
                        (apply-partially 'magit-wash-log 'unique)
@@ -192,7 +192,7 @@ If USE-CACHE is non nil, use the cached information."
                        (magit-diff-abbrev-arg)
                        (format "HEAD..%s" (magit-svn-get-ref t)))))
 
-(magit-define-inserter svn-unpushed ()
+(defun magit-insert-svn-unpushed ()
   (when (magit-svn-enabled)
     (magit-git-section 'svn-unpushed "Unpushed commits (SVN):"
                        (apply-partially 'magit-wash-log 'unique)

--- a/magit-topgit.el
+++ b/magit-topgit.el
@@ -134,7 +134,7 @@
           (magit-git-standard-options nil))
       (apply 'magit-git-section section title washer args))))
 
-(magit-define-inserter topgit-topics ()
+(defun magit-insert-topgit-topics ()
   (magit-topgit-section 'topgit-topics
                         "Topics:" 'magit-topgit-wash-topics
                         "summary"))
@@ -178,7 +178,7 @@
     ;; hide refs in the top-bases namespace, as they're not meant for the user
     (add-to-list 'magit-refs-namespaces magit-topgit-ignored-namespace))
    (t
-    (remove-hook 'magit-after-insert-stashes-hook 'magit-insert-topgit-topics t)
+    (remove-hook 'magit-status-sections-hook 'magit-insert-topgit-topics t)
     (remove-hook 'magit-create-branch-command-hook 'magit-topgit-create-branch t)
     (remove-hook 'magit-pull-command-hook 'magit-topgit-pull t)
     (remove-hook 'magit-remote-update-command-hook 'magit-topgit-remote-update t)


### PR DESCRIPTION
Complete the move to the new `magit-BUFFER-sections-hook`s, replacing the two hooks per `magit-insert-SOMETHING`.

Add new function `magit-add-section-hook` and remove `magit-define-inserter`.
