### PR TITLE
magit-delete-branch: fix bug missing ':'

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4858,7 +4858,7 @@ Works with local or remote branches.
   (if (string-match "^\\(?:refs/\\)?remotes/\\([^/]+\\)/\\(.+\\)" branch)
       (magit-run-git-async "push"
                            (match-string 1 branch)
-                           (match-string 2 branch))
+                           (concat ":" (match-string 2 branch)))
     (let* ((current (magit-get-current-branch))
            (is-current (string= branch current))
            (is-master (string= branch "master"))


### PR DESCRIPTION
fix bug missing `:` before branch name when branch is remote.
