### PR TITLE
Provide autoloads for `magit-key-mode-popup-*` family of functions

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -69,7 +69,7 @@
   :group 'magit-faces)
 
 ;;; Keygroups
-
+;;;###autoload
 (defvar magit-key-mode-groups
   '((dispatch
      (actions
@@ -710,6 +710,8 @@ Return the point before the actions part, if any, nil otherwise."
 (mapc (lambda (g)
         (magit-key-mode-generate (car g)))
       magit-key-mode-groups)
+
+;;;###autoload (mapc (lambda (g) (eval `(autoload ',(intern (concat "magit-key-mode-popup-" (symbol-name (car g)))) "magit-key-mode" ,(concat "Key menu for " (symbol-name (car g))) t))) magit-key-mode-groups)
 
 (provide 'magit-key-mode)
 ;;; magit-key-mode.el ends here


### PR DESCRIPTION
I've bound many of the popup windows to shorter key sequences (so I don't have to access the status view), but they are not autoloaded so I had to go there anyway to force autoload.

This patch provides autoload mechanism for the popup views, dynamically generated from variable `magit-key-mode-groups` (so if you add or remove groups, the autoloads will auto-adjust as well).

This require that this variable is loaded with `magit-autoloads.el` but I suppose that's not a big deal. The code that generates the autoloads themselves is expanded here for clarity (in the source code it must be on one line after the `;;;###autoload` magic token)

``` scheme
(mapc (lambda (g)
        (eval `(autoload 
                 ',(intern (concat "magit-key-mode-popup-"
                                   (symbol-name (car g))))
                 "magit-key-mode"
                 ,(concat "Key menu for " (symbol-name (car g)))
                 t)))
      magit-key-mode-groups)
```
