### PR TITLE
magit-wash-hunk: fix argument of magit-diff-refine-hunk

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3635,7 +3635,7 @@ Customize variable `magit-diff-refine-hunk' to change the default mode."
                    (funcall set-line-face 'magit-diff-none))))
           (forward-line))
         (when (eq magit-diff-refine-hunk 'all)
-          (magit-diff-refine-hunk (magit-current-section)))))
+          (magit-diff-refine-hunk section))))
     t))
 
 (defun magit-highlight-line-whitespace ()


### PR DESCRIPTION
In magit-wash-hunk, magit-diff-refine-hunk seems to be called
invalid argument. So error occurs when variable magit-diff-refine-hunk
is set not nil.
