### PR TITLE
magit-log-toggle-margin: more speedy toggle magit-log-margin

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6069,13 +6069,15 @@ This command can only be used inside log buffers (usually
 *magit-log*) and only if that displays a `oneline' log.
 Also see option `magit-log-show-margin'."
   (interactive)
-  (if (derived-mode-p 'magit-log-mode)
-      (if (eq (car magit-refresh-args) 'oneline)
-          (progn (setq-local magit-log-show-margin
-                             (not magit-log-show-margin))
-                 (magit-refresh))
-        (error "The log margin cannot be used with \"long\" log"))
-    (error "The log margin cannot be used outside of log buffers")))
+  (unless (derived-mode-p 'magit-log-mode)
+    (error "The log margin cannot be used outside of log buffers"))
+  (unless (eq (car magit-refresh-args) 'oneline)
+    (error "The log margin can be used with \"short\" log only"))
+  (if magit-log-show-margin
+      (magit-set-buffer-margin (car magit-log-margin-spec)
+                               (not (cdr (window-margins))))
+    (setq-local magit-log-show-margin t)
+    (magit-refresh)))
 
 (defun magit-log-show-more-entries (&optional arg)
   "Grow the number of log entries shown.


### PR DESCRIPTION
remove 'if' nesting
if 'magit-log-show-margin' is non-nil, do margin open/close only
if 'magit-log-show-margin' is nil, turn on and refresh
