### PR TITLE
Fix magit-dired-jump when point is not on a file

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6783,12 +6783,13 @@ With a prefix argument, visit in other window."
   (dired-jump
    other-window
    (file-truename
-    (magit-section-action (item info "dired-jump" t)
-      ((untracked file) info)
-      ((diffstat)       (magit-section-info item))
-      ((diff)           (magit-section-info item))
-      ((hunk)           (magit-section-info (magit-section-parent item)))
-      (nil              nil)))))
+    (or (magit-section-action (item info "dired-jump" t)
+          ((untracked file) info)
+          ((diffstat)       (magit-section-info item))
+          ((diff)           (magit-section-info item))
+          ((hunk)           (magit-section-info (magit-section-parent item)))
+          (nil              nil))
+        default-directory))))
 
 ;;;###autoload
 (defun magit-show (rev file &optional switch-function)


### PR DESCRIPTION
In the absence of anything better, argument of `file-truename' now
defaults to default-directory instead of nil.
