### PR TITLE
Run magit-run-git-bisect in the toplevel directory

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5946,7 +5946,8 @@ With a prefix arg, do a submodule update --init."
 (defun magit-run-git-bisect (subcommand &optional args no-assert)
   (unless (or no-assert (magit-bisecting-p))
     (error "Not bisecting"))
-  (let ((file (magit-git-dir "BISECT_CMD_OUTPUT")))
+  (let ((file (magit-git-dir "BISECT_CMD_OUTPUT"))
+        (default-directory (magit-get-top-dir)))
     (ignore-errors (delete-file file))
     (magit-with-refresh
       (magit-run-git*


### PR DESCRIPTION
This allows to have some file in some subdirectory opened and call `M-x magit-bisect-good/bad` while looking at the buffer.
