### PR TITLE
magit-log-oneline-re: allow empty commit message

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3906,7 +3906,7 @@ Customize variable `magit-diff-refine-hunk' to change the default mode."
           "\\(?7:[BGUN]\\)?"                       ; gpg
           "\\[\\(?5:[^]]*\\)\\]"                   ; author
           "\\[\\(?6:[^]]*\\)\\]"                   ; date
-          "\\(?2:.+\\)"                            ; msg
+          "\\(?2:.*\\)"                            ; msg
           "\\)?$"))
 
 (defconst magit-log-long-re


### PR DESCRIPTION
We have some commits in our repo that have an empty commit message. Without this change to magit-log-oneline-re these commits are not shown correctly in a short log. Here's an example of the `git log` output:

```
* a68e906 [Michael Radford][1342463601]escape blank lines in control file
* 9abb9dd [Paul Mineiro][1334618244]
* a0439e3 [Paul Mineiro][1334618173]
* d452b0b [Anthony Molinaro][1331760688]add none as a template type
```

And this is how magit displays it without this change:

```
a68e906 * escape blank lines in control file
8e906 * a6 file
* 9abb9dd [Paul Mineiro][133
8e906 * a6 file
8e906 * a6 file
* 9abb9dd [P
d452b0b * add none as a template type
```
