### PR TITLE
Fix issue #1103 and improve a bit

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1317,6 +1317,7 @@ Many Magit faces inherit from this one by default."
     (define-key map (kbd "C-x 4 a") 'magit-add-change-log-entry-other-window)
     (define-key map (kbd "L") 'magit-add-change-log-entry)
     (define-key map (kbd "RET") 'magit-visit-item)
+    (define-key map (kbd "C-<return>") 'magit-dired-jump)
     (define-key map (kbd "SPC") 'magit-show-item-or-scroll-up)
     (define-key map (kbd "DEL") 'magit-show-item-or-scroll-down)
     (define-key map (kbd "C-w") 'magit-copy-item-as-kill)


### PR DESCRIPTION
#1103

The status buffer for the submodule is now shown in the same window as the super status buffer. This is consistent with how other things are shown by this command. With a prefix argument show it in another window, again like for other things.

Use `dired` only when visiting directories that are not submodules. (Because previously `dired-jump` was used instead of `magit-dired-jump` this previously didn't even work for regular directories.)

Bind `C-<return>` to `magit-dired-jump`.
