### PR TITLE
Explicitly specify date format for magit-insert-stashes

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4393,7 +4393,7 @@ when asking for user input.
 ;;;; Real Sections
 
 (defun magit-insert-stashes ()
-  (let ((stashes (magit-git-lines "stash" "list")))
+  (let ((stashes (magit-git-lines "stash" "list" "--date=default")))
     (when stashes
       (magit-with-section (section stashes 'stashes "Stashes:" t)
         (dolist (stash stashes)


### PR DESCRIPTION
If Git configuration option log.date is set to non-default value (for
example iso8601), then "git stash list" output will be like

stash@{2013-12-03 16:13:51 +0200}: WIP on master: 7ae906e ...

This breaks the parsing of the output, so use --date=default to make the
stash list output in correct format, e.g.:

stash@{0}: WIP on master: 7ae906e ...
