### PR TITLE
magit-file-log: follow renames

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6049,7 +6049,8 @@ With a prefix argument show the log graph."
                     #'magit-refresh-log-buffer
                     'oneline "HEAD"
                     `(,@(and use-graph (list "--graph"))
-                      ,@magit-custom-options)
+                      ,@magit-custom-options
+                      "--follow")
                     file))
 
 ;;;###autoload


### PR DESCRIPTION
When doing a log for a particular file (using `magit-file-log') it is
useful to see the history of the file across renames. Add the --follow
option to the log command to do so.
