### PR TITLE
fix: magit diff view clash with .gitconfig

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1743,7 +1743,7 @@ server if necessary."
 ;;; Git Utilities
 ;;;; Git Output
 
-(defvar magit-git-standard-options '("--no-pager")
+(defvar magit-git-standard-options '("--no-pager" "-c" "color.diff=false")
   "Standard options when running Git.")
 
 (defun magit-git-string (&rest args)


### PR DESCRIPTION
When a user's .gitconfig has `color.diff=always` (and possibly "true"), magit's diff view (i.e: TAB/d in `magit-status` buffer) shows plain shell color codes.
`color.diff=always` is a perfectly reasonable option, magit should not break in its presence.

The same effect as this change can be had by adding this to your .emacs:

``` elisp
(dolist (additional-options '("-c" "color.diff=false"))
  (add-to-list 'magit-git-standard-options additional-options t))
```
