### PR TITLE
update maintainer information

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,19 +9,19 @@ Author
 
 - Marius Vollmer <marius.vollmer@gmail.com>
 
-Maintainers
------------
+Maintainer
+----------
 
 - Jonas Bernoulli <jonas@bernoul.li>
-- Nicolas Dudebout <nicolas.dudebout@gatech.edu>
-- Rémi Vanicat <vanicat@debian.org>
-- Yann Hodique <yann.hodique@gmail.com>
 
 Retired Maintainers
 -------------------
 
+- Nicolas Dudebout <nicolas.dudebout@gatech.edu>
 - Peter J. Weisberg <pj@irregularexpressions.net>
 - Phil Jackson <phil@shellarchive.co.uk>
+- Rémi Vanicat <vanicat@debian.org>
+- Yann Hodique <yann.hodique@gmail.com>
 
 Contributors
 ------------

--- a/Makefile
+++ b/Makefile
@@ -181,19 +181,19 @@ Author
 
 - Marius Vollmer <marius.vollmer@gmail.com>
 
-Maintainers
------------
+Maintainer
+----------
 
 - Jonas Bernoulli <jonas@bernoul.li>
-- Nicolas Dudebout <nicolas.dudebout@gatech.edu>
-- Rémi Vanicat <vanicat@debian.org>
-- Yann Hodique <yann.hodique@gmail.com>
 
 Retired Maintainers
 -------------------
 
+- Nicolas Dudebout <nicolas.dudebout@gatech.edu>
 - Peter J. Weisberg <pj@irregularexpressions.net>
 - Phil Jackson <phil@shellarchive.co.uk>
+- Rémi Vanicat <vanicat@debian.org>
+- Yann Hodique <yann.hodique@gmail.com>
 
 Contributors
 ------------

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Table of Contents
 
 * [Getting Started](#getting-started)
 * [Getting Help](#getting-help)
+* [Contributions](#contributions)
 * [Installation](#installation)
   * [Installing from Melpa](#installing-from-melpa)
   * [Installing from Marmalade](#installing-from-marmalade)
   * [Installing from Git](#installing-from-git)
   * [Installing from Tarball](#installing-from-tarball)
 * [Dependencies](#dependencies)
-* [Development](#development)
 
 Getting Started
 ===============
@@ -59,6 +59,24 @@ If that doesn't help check the list of [all open issues][issues].
 
 If everything else fails please open a [new issue][issues] or ask for
 help on the [mailing list][group].
+
+Contributions
+=============
+
+Magit is [hosted on Github][development].  Please contribute by
+suggesting features on the [issue tracker][issues] or by making code
+contributions using [pull requests][pulls].  Before opening a pull
+request make sure to read the brief [guidelines][contributing].
+
+Magit was started by [Marius Vollmer][marius] and is now maintained
+by [Jonas Bernoulli][jonas].  Other Magitians (former maintainers)
+are [Nicolas Dudebout][nicolas], [Peter J. Weisberg][peter],
+[Phil Jackson][phil], [Rémi Vanicat][remi], and [Yann Hodique][yann].
+
+Many more people have [contributed code][contributors] and suggested
+features.
+
+Thanks to all of you, may (the history of) the source be with you!
 
 Installation
 ============
@@ -266,21 +284,6 @@ To run tests the following libraries are also required:
   starting with version 24.1.  You can also obtain an old version from
   the former development [repository][ert].
 
-Development
-===========
-
-Magit's canonical source repository is
-[hosted on Github][development].
-
-Magit was started by Marius Vollmer and is now collectively maintained
-by the [Magit Owners Team][owners].  [Many more people][contributors]
-have contributed.
-
-To report bugs and make feature requests please use the
-[issue tracker][issues] and Github [pull requests][pulls].  You may
-also use Magit's [Google group][group].  Before making a pull request
-please read [CONTRIBUTING.md][contributing].
-
 
 [contributing]: https://github.com/magit/magit/blob/master/CONTRIBUTING.md
 [contributors]: https://github.com/magit/magit/contributors
@@ -295,6 +298,14 @@ please read [CONTRIBUTING.md][contributing].
 [pulls]: https://github.com/magit/magit/pulls
 [screencast]: http://vimeo.com/2871241
 [website]: http://magit.github.io
+
+[jonas]: https://github.com/tarsius
+[marius]: https://github.com/mvollmer
+[nicolas]: https://github.com/dudebout
+[peter]: https://github.com/pjweisberg
+[phil]: https://github.com/philjackson
+[remi]: https://github.com/vanicat
+[yann]: https://github.com/sigma
 
 [cl-lib]: http://elpa.gnu.org/packages/cl-lib.html
 [emacs]: http://www.gnu.org/software/emacs

--- a/magit.el
+++ b/magit.el
@@ -7,14 +7,13 @@
 ;; https://raw.github.com/magit/magit/master/AUTHORS.md
 
 ;; Author: Marius Vollmer <marius.vollmer@gmail.com>
-;; Maintainers:
-;;	Jonas Bernoulli   <jonas@bernoul.li>
-;;	Nicolas Dudebout  <nicolas.dudebout@gatech.edu>
-;;	Rémi Vanicat      <vanicat@debian.org>
-;;	Yann Hodique      <yann.hodique@gmail.com>
+;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
 ;; Former-Maintainers:
+;;	Nicolas Dudebout  <nicolas.dudebout@gatech.edu>
 ;;	Peter J. Weisberg <pj@irregularexpressions.net>
 ;;	Phil Jackson      <phil@shellarchive.co.uk>
+;;	Rémi Vanicat      <vanicat@debian.org>
+;;	Yann Hodique      <yann.hodique@gmail.com>
 
 ;; Keywords: vc tools
 ;; Package: magit


### PR DESCRIPTION
With the approval of Yann, Rémi, and Nicolas I am changing the
information about who currently maintains Magit.  Previous they
and I were listed as maintainers, now only I am.
