### PR TITLE
stgit: Fix 'magit-run-stgit'

### DIFF
--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -90,7 +90,7 @@
 ;;; Utilities
 
 (defun magit-run-stgit (&rest args)
-  (apply #'magit-call-git (cons magit-stgit-executable args))
+  (apply #'magit-call-process magit-stgit-executable args)
   (magit-refresh))
 
 (defun magit-stgit-lines (&rest args)


### PR DESCRIPTION
Use 'magit-call-process' instead of 'magit-call-git'.
