### PR TITLE
magit-key-mode-update-group: Create a THING entry if it does not exist

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -353,6 +353,9 @@ The option may be a switch, argument or action."
   (let* ((options (magit-key-mode-options-for-group for-group))
          (things (assoc thing options))
          (key (car args)))
+    (unless things
+      (setq things (list thing))
+      (setcdr options (cons things (cdr options))))
     (if (cdr things)
         (if (magit-key-mode-key-defined-p for-group key)
             (error "%s is already defined in the %s group." key for-group)


### PR DESCRIPTION
`magit-key-mode-update-group' could not handle unknown
THINGs. Unfortunately one of the unknown things were`arguments'.  This
fix allows to add any type of THING, but the key-collision detection
only works for `actions',`switches' and `arguments'.
