### PR TITLE
Support blame mode for revision files and add command to show item on previous revision

### DIFF
--- a/magit-blame.el
+++ b/magit-blame.el
@@ -143,7 +143,7 @@
         (with-temp-buffer
           (apply 'magit-git-insert "blame" "--porcelain"
                  `(,@(and magit-blame-ignore-whitespace (list "-w"))
-                   ,@(buffer-local-value 'magit-show-current-version buffer) "--"
+                   ,@(and (eq '(nil) (buffer-local-value 'magit-show-current-version buffer)) nil) "--"
                    ,(or (and (buffer-file-name buffer) (file-name-nondirectory (buffer-file-name buffer)))
                         (buffer-local-value 'magit-file-name buffer))))
           (magit-blame-parse buffer (current-buffer)))))))

--- a/magit.el
+++ b/magit.el
@@ -5254,7 +5254,7 @@ With a prefix argument, visit in other window."
 With a prefix argument, visit in other window."
   (interactive "P")
   (magit-visit-item other-window
-                    (concat (buffer-substring (point-min) (+ (point-min) magit-sha1-abbrev-length)) "^")))
+                    (concat (buffer-substring-no-properties (point-min) (+ (point-min) magit-sha1-abbrev-length)) "^")))
 
 (defun magit-hunk-item-target-line (hunk)
   (save-excursion


### PR DESCRIPTION
These two patches are together because they deserve the same purpose:
Doing git blame by going into multiple revision steps when you want to blame code that as just been moved.

So we add the capacity to blame buffers that show a file under a specified revision (got by magit-show)
And we add a command magit-visit-item-before-commit which, when used in a magit-commit buffer, open the current item at the revision just before the current commit.
