### PR TITLE
Update magit-section-title in tests

### DIFF
--- a/tests/magit-tests.el
+++ b/tests/magit-tests.el
@@ -60,7 +60,7 @@
 (defun magit-tests--should-have-item-title (title section-path)
   (magit-status default-directory)
   (should (member title
-                  (mapcar 'magit-section-title
+                  (mapcar 'magit-section-info
                           (magit-section-children
                            (magit-find-section section-path
                                                magit-root-section))))))


### PR DESCRIPTION
When 7f58159 changed `magit-section-title` to `magit-section-info`,
magit-tests.el was not updated.
