### PR TITLE
magit-emacsclient-executable: discover emacsclient name via pattern match

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -230,13 +230,18 @@ tramp to connect to servers with ancient Git versions."
     (shell-quote-argument
      (let ((version (format "%s.%s"
                             emacs-major-version
-                            emacs-minor-version)))
+                            emacs-minor-version))
+           (emacsclient-name (car (directory-files invocation-directory
+                                                   nil
+                                                   "emacsclient.*"))))
        (or (let ((exec-path (list (expand-file-name "bin" invocation-directory)
                                   invocation-directory)))
-             (or (executable-find (format "emacsclient-%s" version))
+             (or (executable-find emacsclient-name)
+                 (executable-find (format "emacsclient-%s" version))
                  (executable-find (format "emacsclient-%s.exe" version))
                  (executable-find "emacsclient")
                  (executable-find "emacsclient.exe")))
+           (executable-find emacsclient-name)
            (executable-find (format "emacsclient-%s" version))
            (executable-find (format "emacsclient-%s.exe" version))
            (executable-find "emacsclient")


### PR DESCRIPTION
It's possible to configure Emacs with `--program-suffix=-suffix` which
results in the `emacsclient` executable being named
`emacsclient-suffix`. For example, it's not uncommon to track the Emacs
development repository and configure Emacs with `--program-suffix=-git` or
`--program-suffix=-bzr`.

The current search patterns all assume Emacs wasn't configured with a
program suffix. Fix this by searching the `invocation-directory` for any
program that matches the regexp: `emacsclient.*`.
