### PR TITLE
Fix/truncated diffstat for null files or no changes

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4050,7 +4050,7 @@ Customize variable `magit-diff-refine-hunk' to change the default mode."
 
 (defun magit-wash-diffstat ()
   (when (looking-at
-         "^ ?\\(.*?\\)\\( +| +\\)\\([0-9]+\\) ?\\([+]*\\)?\\([-]*\\)?$")
+         "^ ?\\(.*\\)\\( +| +\\)\\([0-9]+\\) ?\\(\\+*\\)\\(-*\\)$")
     (magit-bind-match-strings (file sep cnt add del)
       (delete-region (point) (1+ (line-end-position)))
       (magit-with-section (section diffstat 'diffstat)


### PR DESCRIPTION
The first commit from this pair fixes a bug in `magit-wash-diffstat`, the second is just a minor change to simplify the regular expression.
