### PR TITLE
Correct the documentation of `magit-push-dwim'.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5988,13 +5988,13 @@ Also see option `magit-set-upstream-on-push'."
 (defun magit-push-dwim (arg)
   "Push the current branch to a remote repository.
 
-With a single prefix argument ask the user what branch to push
-to.  With two or more prefix arguments also ask the user what
-remote to push to.  Otherwise use the remote and branch as
+With a single prefix argument ask the user what remote to push to.
+With two or more prefix arguments also ask the user the name of the
+remote branch to push to.  Otherwise use the remote and branch as
 configured using the Git variables `branch.<name>.remote' and
-`branch.<name>.merge'.  If the former is undefined ask the user.
-If the latter is undefined push without specifing the remote
-branch explicitly.
+`branch.<name>.merge'.  If the former is undefined ask the user.  If
+the latter is undefined push without specifing the remote branch
+explicitly.
 
 Also see option `magit-set-upstream-on-push'."
   (interactive "P")
@@ -7668,5 +7668,7 @@ init file:
 
 ;; Local Variables:
 ;; indent-tabs-mode: nil
+;; fill-column: 70
 ;; End:
+
 ;;; magit.el ends here


### PR DESCRIPTION
Since pressing `C-u` once ask for the remote, and twice for the remote and the remote branch name, this should be noted properly in the documentation of the function.
