### PR TITLE
* magit.el: Autocommit on pull

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5967,14 +5967,17 @@ user because of prefix arguments are not saved with git config."
                    (not choose-branch))
           (magit-set (format "%s" chosen-branch-merge-name)
                      "branch" branch "merge"))
-        (magit-run-git-async
+        (magit-run-git
          "pull" magit-custom-options
          (and choose-remote chosen-branch-remote)
          (and choose-branch
               (list (format "refs/heads/%s:refs/remotes/%s/%s"
-                            chosen-branch-merge-name
-                            chosen-branch-remote
-                            chosen-branch-merge-name)))))))
+                              chosen-branch-merge-name
+                              chosen-branch-remote
+                              chosen-branch-merge-name))))
+        (when (file-exists-p ".git/MERGE_MSG")
+          (let ((magit-custom-options nil))
+            (magit-commit))))))
 
 ;;;;; Pushing
 


### PR DESCRIPTION
This fixes the issue introduced when git requested the systematic edition of merge messages when pulling.

Before this patch git was in the background and opened the deffault core.editor to edit the messages which caused the process to stall in the background.
Pull now uses the same policy as merge, meaning the default merge message is automatically commited.
