### PR TITLE
Fix truncated diffstat with binary files

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4083,7 +4083,7 @@ Customize variable `magit-diff-refine-hunk' to change the default mode."
          (concat
           "^ ?\\(.*\\)"  ; file
           "\\( +| +\\)"  ; separator
-          "\\([0-9]+\\)" ; cnt
+          "\\([0-9]+\\|Bin\\(?: +[0-9]+ -> [0-9]+ bytes\\)?$\\)" ; cnt
           " ?"
           "\\(\\+*\\)"   ; add
           "\\(-*\\)"     ; del


### PR DESCRIPTION
This pull request extends the regular expression of `magit-wash-diffstat` to support the lines showing changes in binary files. To make it easier on humans to grasp what the regular expression is doing, it is first split into multiple lines in a separate commit.
