### PR TITLE
Fix magit-insert-untracked-files & 'status.showUntrackedFiles' git config

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4728,8 +4728,7 @@ can be used to override this."
                   (lambda (f)
                     (when (eq (aref f 0) ??) (list f)))
                   (magit-git-lines
-                   "status" "--porcelain"
-                   (concat "-u" (magit-get "status.showUntrackedFiles"))))))
+                   "status" "--porcelain"))))
       (if (not files)
           (setq section nil)
         (dolist (file files)


### PR DESCRIPTION
Commit 1c4136e cleaned up magit-insert-untracked-files to always rely
rely on status.showUntrackedFiles, however it's broken when this
configuration is not set:
in such case 'git config status.showUntrackedFiles' returns nothing, not
the default value as the code expected.

Then git status was run just with "-u", which is equivalent to "-u
all". It's not what the user specified by not defining
'status.showUntrackedFiles'. It should be "-u normal" in such case.

This commit fixes and simplify this by removing the git config retrieval
altogether since git status reads this config, even with the
"--porcelain" flag.

(This git status behavior is a little ambiguous in the man: it says the
output format will be stable "regardless of user configuration", so one
can wonder why the 'status.showUntrackedFiles' user config is not
ignored. But it's about the output _format_, and not the output itself.)
