### PR TITLE
Set this-command in magit-key-mode-command

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -505,7 +505,8 @@ Do not customize this (used in the `magit-key-mode' implementation).")
     (set-window-configuration magit-pre-key-mode-window-conf)
     (kill-buffer magit-key-mode-last-buffer)
     (when func
-      (call-interactively func))))
+      (setq this-command func)
+      (call-interactively this-command))))
 
 (defun magit-key-mode-add-argument (for-group arg-name input-func)
   (let ((input (funcall input-func (concat arg-name ": "))))


### PR DESCRIPTION
Some library (ido) could have problem when this-command is set to
something that is not a symbol, and when a key is pressed, its binding
is put into this-command. In magit-key-mode, lambda expression are bind
to key, and this could confuse ido.

As a side effect, last-command will be set to the real command that have
be run, and not to lambda expression.

The problem with ido is probably a bug in Emacs, it seem to be fixed there: https://lists.gnu.org/archive/html/emacs-diffs/2013-07/msg00185.html and so in future version of Emacs.

I don't know if the problem occur in one of the magit command, it will happen if a command, called by magit-key-mode, interactively read a file name, and ido-everywhere is enabled.
