### PR TITLE
On Windows use git.exe

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -235,7 +235,10 @@ aborts and returns that value."
 ;;;;; Processes
 
 (defcustom magit-git-executable
-  (or (executable-find "git") "git")
+  (or (and (eq system-type 'windows-nt)
+           (executable-find "git.exe"))
+      (executable-find "git")
+      "git")
   "The name of the Git executable."
   :group 'magit-process
   :type 'string)


### PR DESCRIPTION
It has been reported that forcing Magit to use `git.exe` instead of `git.cmd` gives a considerable speedup. I don't know whether that is true but the arguments are sound. So now Magit tries to use `git.exe` but falls back to just `git` (which ends up meaning the `git.cmd` script or so it appears).
