### PR TITLE
magit-revert-buffers: revert buffers in emacs 24.4

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4011,7 +4011,8 @@ the current repository."
               (and file (string-prefix-p topdir file)
                    (not (string-prefix-p gitdir file))
                    (member (file-relative-name file topdir) tracked)
-                   (auto-revert-handler)))))))))
+                   (let ((auto-revert-mode t))
+                     (auto-revert-handler))))))))))
 
 ;;; (misplaced)
 ;;;; Diff Options


### PR DESCRIPTION
In Emacs 24.4, when `auto-revert-use-notify` is t, but auto-revert is
not enabled for current buffer (auto-revert-notify-modified-p remains
nil), `auto-revert-handler` will not revert the buffer. Setting
`auto-revert-mode` to t for buffer to be reverted will make
`auto-revert-handler` effective.
