### PR TITLE
Fix git pull behavior with multiple remotes

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5616,7 +5616,7 @@ user because of prefix arguments are not saved with git config."
         (magit-run-git-async
          "pull" magit-custom-options
          (and choose-remote chosen-branch-remote)
-         (and choose-branch
+         (and (or choose-remote choose-branch)
               (list (format "refs/heads/%s:refs/remotes/%s/%s"
                             chosen-branch-merge-name
                             chosen-branch-remote


### PR DESCRIPTION
[EDIT] ignore this, read below.

Hello,

This is probably not the final commit, but it already fixes my problem:

With multiple remote, when doing `C-u F F`, git pull fails after selecting the remote because the resulting command is `git pull $remote`, and of course if you select another remote there's no default upstream for this remote. Which makes people have to do `C-u C-u F F` anyway so they can pick the branch name too.

If you look at https://github.com/Silex/magit/blob/277459badf316182944b8d8fead4089eecfc2a7f/magit.el#L5603-5608, we already pick up the correct branch name, but then it's only used at git pull point if `C-u C-u` is used.

I guess the original idea is to have neat & short `git pull` commands being run when the upstream are set correctly, and the more verbose `git pull origin branch` with refs etc when we can't.

My current fix simply removes the "neat & short" git pull commands, so it's always very verbose but fixes my problem. I guess the other fix would be a more hairy logic at the git pull point, something like "if there is a custom remote, use custom remote and (custom branch name or default branch), else if there is a custom branch, use default remote and custom branch, else use nothing".

As the latter was harder to write I went the lazy route, tell me what you think/want about this.
