### PR TITLE
magit-rewrite-{set-commit-property,finish-step}: fix regressions

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5445,7 +5445,8 @@ With two prefix args, remove ignored files as well."
     (when p
       (setf (cdr p) (plist-put (cdr p) prop value))
       (magit-write-rewrite-info info)
-      (magit-refresh))))
+      (magit-refresh))
+    t))
 
 (add-hook 'magit-apply-hook 'magit-rewrite-apply)
 (put  'magit-rewrite-apply 'magit-section-action-context [commit pending])
@@ -5539,9 +5540,12 @@ With two prefix args, remove ignored files as well."
            (commit (car first-unused)))
       (cond ((not first-unused)
              (magit-rewrite-stop t))
-            ((magit-cherry-pick-commit commit)
+            ((magit-git-success "cherry-pick" commit)
              (magit-rewrite-set-commit-property commit 'used t)
-             (magit-rewrite-finish-step))))))
+             (magit-rewrite-finish-step))
+            (t
+             (magit-refresh)
+             (error "Could not apply %s" commit))))))
 
 ;;;;; Fetching
 


### PR DESCRIPTION
This is supposed to fix #1155. @dabrahams can you confirm that this works?

Make `magit-rewrite-set-commit-property` always return t so that the
`magit-section-action` hooks `magit-{apply,cherry-pick,revert}-hook`
run just the rewrite case, and not the default `commit` case too.

In `magit-rewrite-finish-step`, do not use `magit-cherry-pick-commit`.
That function does a refresh before we had a chance to call
`magit-rewrite-set-commit-property`.  If cherry-picking a commit fails,
then say so.
