### PR TITLE
Make interactive form return a list for magit-init.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -7407,7 +7407,7 @@ Non-interactively DIRECTORY is always (re-)initialized."
                       (format "%s is a repository.  Create another in %s? "
                               top dir)))))
          (user-error "Abort")
-       dir)))
+       (list dir))))
   (magit-run-git "init" (expand-file-name directory)))
 
 (defun magit-copy-item-as-kill ()


### PR DESCRIPTION
M-x magit-init gave an error "wrong-type-argument listp". I think it was because the lisp form in interactive was returning `dir` not `(list dir)`.
