### PR TITLE
Transition machinery for magit-insert-pending-changes

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5602,6 +5602,16 @@ With two prefix args, remove ignored files as well."
         (magit-diff orig nil "-R")
       (user-error "No rewrite in progress"))))
 
+(defun magit-rewrite-diff-pending-transition ()
+  (interactive)
+  (catch t (magit-rewrite-diff-pending))
+  (message "Please remove magit-insert-pending-changes from your magit-status-sections-hook, or move to magit-rewrite-diff-pending"))
+
+(define-obsolete-function-alias
+  'magit-insert-pending-changes 'magit-rewrite-diff-pending-transition
+  "382351845e"
+  "https://github.com/magit/magit/commit/382351845eca2425713f640f9bb55756c9ddf723")
+
 ;;;;; Fetching
 
 ;;;###autoload


### PR DESCRIPTION
If users have customized their `magit-status-sections-hook` then it can
be confusing when they update magit and suddenly start getting error
messages due to `magit-insert-pending-changes` not being defined
anymore. Define a an obsolete function alias to a shim function that
displays a message to the user about what's going on.

See also: 382351845eca2425713f640f9bb55756c9ddf723
