### PR TITLE
Don't try to run magit-rewrite-diff-pending from magit-status-sections-hook

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5604,7 +5604,6 @@ With two prefix args, remove ignored files as well."
 
 (defun magit-rewrite-diff-pending-transition ()
   (interactive)
-  (catch t (magit-rewrite-diff-pending))
   (message "Please remove magit-insert-pending-changes from your magit-status-sections-hook, or move to magit-rewrite-diff-pending"))
 
 (define-obsolete-function-alias


### PR DESCRIPTION
Ok, turns out the little shim doesn't always show the "help" message. This commit should fix that.

In [9a4e236: "Transition machinery for magit-insert-pending-changes"] an
obsolete function alias and "transition" function were introduced to
help users that may have customized `magit-status-sections-hook` to know
that `magit-rewrite-diff-pending` no longer exists. However, it really
never makes sense to run `magit-rewrite-diff-pending` from
`magit-status-sections-hook` and in some configurations the actual
"help" message is hidden by the error from
magit-rewrite-diff-pending. Fix this unnecessary confusion by _not_
running `magit-rewrite-diff-pending` from the shim function.
