### PR TITLE
magit-log-goto-same-commit: Check section value

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6453,12 +6453,15 @@ With a non numeric prefix ARG, show all entries"
     (magit-show-commit (magit-section-value section) t)))
 
 (defun magit-log-goto-same-commit ()
-  (--when-let (and magit-previous-section
-                   (derived-mode-p 'magit-log-mode)
-                   (cl-find (magit-section-value magit-previous-section)
-                            (magit-section-children magit-root-section)
-                            :test 'equal :key 'magit-section-value))
-    (goto-char (magit-section-start it))))
+  (let ((previous-section-value
+         (and magit-previous-section
+              (magit-section-value magit-previous-section))))
+    (--when-let (and previous-section-value
+                     (derived-mode-p 'magit-log-mode)
+                     (cl-find previous-section-value
+                              (magit-section-children magit-root-section)
+                              :test 'equal :key 'magit-section-value))
+      (goto-char (magit-section-start it)))))
 
 ;;;; Log Select Mode
 


### PR DESCRIPTION
If I place the point on a blank line in the status buffer and then pull up the log, the point ends up at the end of the log buffer. This PR fixes the issue (though I'm not sure it's the appropriate way to fix it).
