### PR TITLE
magit-wip-save is failing with no such file of directory /something/index4176xhf

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -7520,7 +7520,7 @@ to the current branch and `magit-wip-ref-format'."
                      wipref
                    (or ref "HEAD")))
          (tree   (let ((process-environment process-environment)
-                       (index-file (make-temp-name "index")))
+                       (index-file (make-temp-name (expand-file-name "index" toplevel))))
                    (setenv "GIT_INDEX_FILE" index-file)
                    (magit-call-git "read-tree" parent)
                    (magit-call-git "add" filename)


### PR DESCRIPTION
Apparently on my computer, magit-wip-save supose that git create the temporary index somewhere else than what git is doing, making magit-wip-save failed. This patch fix this by using an absolute file name.
