### PR TITLE
Add status buffer inserter for oneline graph

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -803,6 +803,12 @@ they are not (due to semantic considerations)."
   :type '(choice (const :tag "tags are the subjects" tag)
                  (const :tag "head is the subject" head)))
 
+(defcustom magit-recent-log-max-count 15
+  "How far back to go with `magit-insert-recent-log'"
+  :package-version '(magit . "2.0.0")
+  :group 'magit-status
+  :type 'integer)
+
 ;;;;;; Diff
 
 (defun magit-set-default-diff-options (symbol value)
@@ -4441,6 +4447,30 @@ can be used to override this."
       (magit-git-insert-section (recent "Recent commits:")
           (apply-partially 'magit-wash-log 'unique)
         "log" "--format=format:%h %s" "-n" "10"))))
+
+(defun magit-insert-recent-commits-graph ()
+  ;; doesn't work if there aren't any commits yet. If `git rev-parse HEAD'
+  ;; fails then there aren't any commits.
+  (when (= 0 (call-process "git" nil nil nil "rev-parse" "HEAD"))
+    (let ((revs (magit-git-lines "rev-list"
+                                 (format "--max-count=%d" (1+ magit-recent-log-max-count))
+                                 "HEAD")))
+      (magit-git-insert-section (recent "Recent commits:")
+          (lambda ()
+            (ansi-color-apply-on-region (point-min) (point-max)))
+        "log"
+        "--graph"
+        "--oneline"
+        "--decorate"
+        "--color"
+        (if (> (length revs) magit-recent-log-max-count)
+            ;; here we are. the reason we go through all this
+            ;; `rev-list' effort is for this range. This results in a
+            ;; dramatic performance improvement over --graph
+            ;; --max-count for repos with lots of commits.
+            (format "%s.." (car (last revs)))
+          "HEAD")
+        (format "--max-count=%d" magit-recent-log-max-count)))))
 
 (defun magit-insert-unpulled-commits ()
   (let ((tracked (magit-get-tracked-branch nil t)))


### PR DESCRIPTION
Sometimes it's nice to get a full graph view of recent commits in the
repository you're currently working on. Current status buffer inserters
are available for showing recent commits that _you_ are working on but
nothing to just show recent commits in the repository.

Add an inserter that shows `n` commits with

```
git log --graph --oneline --decorate --color
```

Since this inserter is constantly asking for --graph output, optimize
the computation of recent commits. For large repositories it's much more
efficient to do:

```
git log HEAD~15
```

than

```
git log --max-count=15
```

Profiling data is available on #686 (specifically
https://github.com/magit/magit/pull/686#issuecomment-20141371).

---

I guess this is an RFC right now because it doesn't let you select commits. However, I've been using this for a few weeks and it has been incredibly useful in my workflow (I work a lot with other developers so I used to constantly pop open the magit log buffer (which is slow in large repositories)). Anyways, hopefully it's useful to someone else. I'm open for comments on making it mergeable.
