### PR TITLE
Fix a problem with some space in some path

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -7135,7 +7135,7 @@ actually were a single commit."
           (magit-insert (propertize (format "unmerged   %s\n" dst)
                                     'face 'magit-diff-file-header)))))
     t)
-   ((looking-at "^diff \\(?:--git a/\\(.+\\) b/\\(.+\\)\\|--cc \\(.*\\)\\)$")
+   ((looking-at "^diff \\(?:--git \"?a/\\(.+\\)\"? \"?b/\\(.+?\\)\"?\\|--cc \\(.*\\)\\)$")
     (let (src dst status modes)
       (if (match-end 1)
           (setq dst (magit-decode-git-path (match-string 2))


### PR DESCRIPTION
When there is a space in a path, magit failed to corectly detect the bondary of the filename.
Using the a/ and b/ used by git to differentiate both filename, this patch fix this.

I not completely sure that git always use a/ and b/, so this might need testing.

The second commit handle the case when there are " in the output of git
