### PR TITLE
magit-log-toggle-margin: don't call magit-refresh

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6600,10 +6600,9 @@ Also see option `magit-log-show-margin'."
     (user-error "The log margin cannot be used outside of log buffers"))
   (when (eq (car magit-refresh-args) 'long)
     (user-error "The log margin cannot be used with verbose logs"))
-  (if (setq-local magit-log-show-margin (not magit-log-show-margin))
-      (magit-refresh)
-    (magit-set-buffer-margin (car magit-log-margin-spec)
-                             (not (cdr (window-margins))))))
+  (magit-set-buffer-margin
+   (car magit-log-margin-spec)
+   (setq-local magit-log-show-margin (not magit-log-show-margin))))
 
 (defun magit-log-show-more-entries (&optional arg)
   "Grow the number of log entries shown.


### PR DESCRIPTION
`magit-log-toggle-margin` is pretty useful, but I notice it calls `magit-refresh` when re-enabling the margin. The pause makes it kind of annoying to use. 

The refresh call doesn't seem needed, it seems to work without it. I'm not sure if the old code sometimes toggling on `(cdr (window-margins))` instead of `magit-log-show-margin` is important, I've dropped that behaviour...
