### PR TITLE
Display source for copy, and correctly discard rename and copy

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4636,7 +4636,7 @@ without requiring confirmation."
        (when stagedp
          (magit-run-git "reset" "-q" "--" file))
        (magit-run-git "checkout" "--" file)))
-    (new
+    ((new rename copy)
      (when (yes-or-no-p (format "Delete %s? " file))
        (magit-run-git "rm" "-f" "--" file)))
     (t


### PR DESCRIPTION
When a file has been copied, we didn't knew the source of the copy, when it was shown for rename. so let's display it. Also, there was an error when discarding a renamed staged file, and the first commit of this pr introduce the same bug for copy, so let fix both bug.

By the way, I'm wondering if it would interesting to display the similarity index for rename and copy, I don't know of the clutter of the interface is worth the added information. What do you think? (I can easily do it).
