### PR TITLE
magit-branch-delete: Handle non-unique ref patterns

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -5109,9 +5109,9 @@ checkout the \"master\" branch.
     (if (string-match "^refs/remotes/\\([^/]+\\)/\\(.+\\)" ref)
         (magit-run-git-async "push"      (match-string 1 ref)
                              (concat ":" (match-string 2 ref)))
-      (cl-case (when (equal ref (magit-ref-fullname (magit-get-current-branch)))
+      (cl-case (when (equal branch (magit-get-current-branch))
                  (let ((msg (format "Branch %s is checked out.  " branch)))
-                   (if (equal ref "refs/heads/master")
+                   (if (equal branch "master")
                        (magit-read-char-case msg nil
                          (?d "[d]etach HEAD & delete" 'detach)
                          (?a "[a]bort"                'abort))


### PR DESCRIPTION
`magit-branch-delete` treated the first line of `git show-ref` as the branch to be deleted, but this is not always the case. For example, if the current branch is 'some-branch' and there exists another branch 'a/some-branch', trying to delete 'a/some-branch' will result in `magit-branch-delete` saying 'a/some-branch' is checked out. This is because 'a/some-branch' appears first in the 'git show-ref' output, so

```
(magit-ref-fullname (magit-get-current-branch))
```

returns 'refs/heads/a/some-branch' instead of 'refs/heads/some-branch'.

This is fixed by using branch names (instead of the full reference name) to test if the branch for deletion is checked out.
