### PR TITLE
(magit-refresh-commit-buffer): add --find-renames

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4094,7 +4094,7 @@ commit or stash at point, then prompt for a commit."
 (defun magit-refresh-commit-buffer (commit)
   (magit-insert-section (commitbuf)
     (magit-git-wash #'magit-wash-commit
-      "log" "-1" "-p" "--cc" "--no-prefix"
+      "log" "-1" "-p" "--cc" "--no-prefix" "--find-renames"
       "--decorate=full" "--pretty=medium"
       (and magit-show-diffstat "--stat")
       magit-diff-options commit)))


### PR DESCRIPTION
Currently, when a file is renamed, showing that commit in magit results
in two separate files: a fully deleted file where every line is a
removal and a fully added file where every line is an addition. This is
usually just spammy and not useful. Leverage git's --find-renames option
to git-log (and friends) which makes the output much more succinct and
readable.
