### PR TITLE
Correct a typo in magit-list-remote-branch-names

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3753,8 +3753,8 @@ where COMMITS is the number of commits in TAG but not in \"HEAD\"."
 (defun magit-list-remote-branch-names (&optional remote relative)
   (if (and remote relative)
       (let ((regexp (format "^refs/remotes/%s/\\(.+\\)" remote)))
-        (--mapcat (and (string-match regexp it)
-                       (list (match-string t it)))
+        (--mapcat (when (string-match regexp it)
+                    (list (match-string 1 it)))
                   (magit-list-remote-branches remote)))
     (magit-list-refnames (concat "refs/remotes/" remote))))
 

--- a/tests/magit-tests.el
+++ b/tests/magit-tests.el
@@ -153,6 +153,27 @@
     (should-not (magit-get-boolean "a.b"))
     (should-not (magit-get-boolean "a" "b"))))
 
+;;;; branch and remotes
+(ert-deftest magit-list-branch ()
+  (magit-tests--with-temp-repo
+    (magit-tests--modify-and-commit "file")
+    (should (member "master" (magit-list-branch-names)))
+    (should (member "master" (magit-list-local-branch-names)))
+    (should (null (magit-list-remote-branch-names)))
+
+    (magit-tests--with-temp-clone default-directory
+      (should (member "origin/master" (magit-list-branch-names)))
+      (should-not (member "origin/master" (magit-list-local-branch-names)))
+
+      (should (member "origin/master" (magit-list-remote-branch-names)))
+      (should (member "origin/master" (magit-list-remote-branch-names "origin")))
+
+      (should-not (member "origin/master" (magit-list-remote-branch-names "foo")))
+      (should (member "master" (magit-list-remote-branch-names "origin" t)))
+
+      (should-not (member "master" (magit-list-remote-branch-names "foo" t)))
+)))
+
 ;;; magit-tests.el ends soon
 
 (defconst magit-tests-font-lock-keywords


### PR DESCRIPTION
The same as #1406, but with the corrected test.
