### PR TITLE
for pcase, require at least version 24.1 of Emacs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
   global:
     - CURL=curl -fsSkL --retry 9 --retry-delay 9
   matrix:
-    - EMACS=emacs AKA=emacs23
     - EMACS=emacs24
     - EMACS=emacs-snapshot
 # matrix:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ provide a unified interface to various version control systems, Magit
 only supports Git and can therefore better take advantage of its native
 features.
 
-Magit supports GNU Emacs 23.2 or later; 24.1 or later is recommended.
-Magit supports Git 1.7.2.5 or later; 1.8.2 or later is recommended.
-The minimal versions are those available in Debian oldstable.
+Magit requires at least GNU Emacs 24.1 and Git 1.7.2.5.
 
 ### Table of Contents
 
@@ -250,6 +248,8 @@ Add the above lines to your init file and restart Emacs.
 
 Dependencies
 ============
+
+Magit requires at least GNU Emacs 24.1 and Git 1.7.2.5.
 
 If you install Magit using `package.el` then dependencies are
 automatically being taken care of.  Otherwise you have to track down

--- a/magit.el
+++ b/magit.el
@@ -19,8 +19,7 @@
 ;; Package: magit
 ;; Package-Requires: ((cl-lib "0.3") (dash "2.6.0") (git-commit-mode "0.14.0") (git-rebase-mode "0.14.0") (with-editor "0"))
 
-;; Magit requires at least GNU Emacs 23.2 and Git 1.7.2.5.
-;; These are the versions shipped by Debian oldstable (6.0, Squeeze).
+;; Magit requires at least GNU Emacs 24.1 and Git 1.7.2.5.
 
 ;; Magit is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
@@ -52,8 +51,8 @@
 ;;; Code:
 ;;;; Dependencies
 
-(when (version< emacs-version "23.2")
-  (error "Magit requires at least GNU Emacs 23.2"))
+(when (version< emacs-version "24.1")
+  (error "Magit requires at least GNU Emacs 24.1"))
 
 (require 'git-commit-mode)
 (require 'git-rebase-mode)

--- a/magit.texi
+++ b/magit.texi
@@ -39,9 +39,7 @@ provide a unified interface to various version control systems, Magit
 only supports Git and can therefor better take advantage of its native
 features.
 
-Magit supports GNU Emacs 23.2 or later; 24.1 or later is recommended.
-Magit supports Git 1.7.2.5 or later; 1.8.2 or later is recommended.
-The minimal versions are those available in Debian oldstable.
+Magit requires at least GNU Emacs 24.1 and Git 1.7.2.5.
 
 When something breaks please see the curated list of
 @magit{wiki/Known-Issues, known issues} and the @magit{wiki/FAQ, FAQ}.


### PR DESCRIPTION
Sooner or later this had to happen.  While I would have preferred to
delay this move until after releasing version 2.1.0, it was always
clear, that I was only willing to maintain backward compatibility as
long as the cost was not very high.

Denying myself the use of `pcase` is such a cost.  I am going to use
this macro a lot, and while it would be possible to implement the
things to come without using `pcase`, doing so would not be pleasant.
So unpleasant in fact, that the temptation would be big to write a
specialized "case" macro, similar to `magit-section-case`.  But my
experience with that, and `magit-section-action`, has taught me that
going down that road leads to over-specialized abstractions which
eventually end up being rather featureful, but never-the-less to
restrictive even for its intended use-cases.
