### PR TITLE
Add magit-completing-read wrapper for helm

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -93,7 +93,7 @@ Use the function by the same name instead of this variable.")
   (require 'ediff)
   (require 'eshell)
   (require 'ido)
-  (require 'helm-mode)
+  (require 'helm-mode nil t)
   (require 'iswitchb)
   (require 'package nil t)
   (require 'view))
@@ -1818,16 +1818,14 @@ set before loading libary `magit'.")
 
 (defun magit-helm-completing-read
   (prompt choices &optional predicate require-match initial-input hist def)
-  "helm-based completing-read almost-replacement"
+  "helm-based completing-read almost-replacement."
   (require 'helm-mode)
-  (helm-comp-read
-   prompt
-   choices
-   :test predicate
-   :must-match require-match
-   :initial-input initial-input
-   :history hist
-   :default def))
+  (helm-comp-read prompt choices
+                  :test predicate
+                  :must-match require-match
+                  :initial-input initial-input
+                  :history hist
+                  :default def))
 
 (defun magit-builtin-completing-read
   (prompt choices &optional predicate require-match initial-input hist def)


### PR DESCRIPTION
Slightly improves completion for helm users, with a much simpler completion function. Also allows for helm-dependent functionality to be used in the future.

If you're wondering why I don't check `(consp choices)`, see this (from `helm-comp-read` and `all-completions`):

> - COLLECTION can be a list, vector, obarray or hash-table.
>   It can be also a function that receives three arguments:
>   the values string, predicate and t. See `all-completions' for more details.
> 
> If COLLECTION is an alist, the keys (cars of elements) are the
> possible completions.  If an element is not a cons cell, then the
> element itself is the possible completion.

I verified the behaviour by running `magit-create-branch`, which displays the parent branch choices correctly, unlike the ido function with the consp check removed.

Byte-compilation is happy, but I couldn't run the tests due to a dependency issue on `git-rebase-mode`, which I tried reinstalling without success. I can `(require)` it just fine.
