### PR TITLE
don't call magit-refresh-function if nil

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3399,11 +3399,12 @@ tracked in the current repository."
       (setq ident (magit-section-ident section)
             line  (count-lines (magit-section-start section) (point))
             char  (- (point) (line-beginning-position))))
-    (let ((inhibit-read-only t))
-      (erase-buffer)
-      (save-excursion
-        (apply magit-refresh-function
-               magit-refresh-args)))
+    (when magit-refresh-function
+      (let ((inhibit-read-only t))
+        (erase-buffer)
+        (save-excursion
+          (apply magit-refresh-function
+                 magit-refresh-args))))
     (when section
       (--if-let (magit-find-section ident)
           (let ((start (magit-section-start it)))


### PR DESCRIPTION
Symptom: an error thrown when refreshing the process buffer after running `magit-git-command`, eg: `:` `status` `RET` (full stacktrace below). I bisected to 8aa75bf025f9353642c719a46b0257d1467ee90d where I saw the check for `nil` `magit-refresh-function` was dropped. But maybe it's `magit-git-command` that needs to be fixed? Somehow other commands can output to the process buffer without triggering a problem...

```
Debugger entered--Lisp error: (void-function nil)
  nil()
  apply(nil nil)
  (save-excursion (apply magit-refresh-function magit-refresh-args))
  (let ((inhibit-read-only t)) (erase-buffer) (save-excursion (apply magit-refresh-function magit-refresh-args)))
  (let ((section (magit-current-section)) ident line char other) (if section (progn (setq ident (magit-section-ident section) line (count-lines (progn (or (and ... ... ...) (error "%s accessing a non-%s" ... ...)) (aref section 3)) (point)) char (- (point) (line-beginning-position))))) (let ((inhibit-read-only t)) (erase-buffer) (save-excursion (apply magit-refresh-function magit-refresh-args))) (if section (progn (let ((it (magit-find-section ident))) (if it (let ((start ...)) (goto-char start) (if (> ... 1) (progn ... ...))) (goto-char (let (...) (if it ... ...))))))) (run-hooks (quote magit-refresh-buffer-hook)) (magit-highlight-section))
  magit-refresh-buffer()
  (progn (run-hooks (quote magit-pre-refresh-hook)) (magit-refresh-buffer) (if (derived-mode-p (quote magit-status-mode)) nil (let ((it (magit-mode-get-buffer magit-status-buffer-name-format (quote magit-status-mode)))) (if it (progn (save-current-buffer (set-buffer it) (magit-refresh-buffer)))))))
  (if (derived-mode-p (quote magit-mode)) (progn (run-hooks (quote magit-pre-refresh-hook)) (magit-refresh-buffer) (if (derived-mode-p (quote magit-status-mode)) nil (let ((it (magit-mode-get-buffer magit-status-buffer-name-format (quote magit-status-mode)))) (if it (progn (save-current-buffer (set-buffer it) (magit-refresh-buffer))))))))
  (if inhibit-magit-refresh nil (if (derived-mode-p (quote magit-mode)) (progn (run-hooks (quote magit-pre-refresh-hook)) (magit-refresh-buffer) (if (derived-mode-p (quote magit-status-mode)) nil (let ((it (magit-mode-get-buffer magit-status-buffer-name-format ...))) (if it (progn (save-current-buffer ... ...))))))) (if magit-auto-revert-mode (progn (magit-revert-buffers))))
  magit-refresh()
  (save-current-buffer (set-buffer it) (magit-refresh))
  (progn (save-current-buffer (set-buffer it) (magit-refresh)))
  (if (buffer-live-p it) (progn (save-current-buffer (set-buffer it) (magit-refresh))))
  (progn (if (buffer-live-p it) (progn (save-current-buffer (set-buffer it) (magit-refresh)))))
  (if it (progn (if (buffer-live-p it) (progn (save-current-buffer (set-buffer it) (magit-refresh))))))
  (let ((it (process-get process (quote command-buf)))) (if it (progn (if (buffer-live-p it) (progn (save-current-buffer (set-buffer it) (magit-refresh)))))))
  (progn (setq event (substring event 0 -1)) (magit-process-unset-mode-line) (if (string-match "^finished" event) (progn (message (concat (capitalize (process-name process)) " finished")))) (magit-process-finish process) (if (eq process magit-this-process) (progn (setq magit-this-process nil))) (let ((it (process-get process (quote command-buf)))) (if it (progn (if (buffer-live-p it) (progn (save-current-buffer (set-buffer it) (magit-refresh))))))))
  (if (memq (process-status process) (quote (exit signal))) (progn (setq event (substring event 0 -1)) (magit-process-unset-mode-line) (if (string-match "^finished" event) (progn (message (concat (capitalize (process-name process)) " finished")))) (magit-process-finish process) (if (eq process magit-this-process) (progn (setq magit-this-process nil))) (let ((it (process-get process (quote command-buf)))) (if it (progn (if (buffer-live-p it) (progn (save-current-buffer ... ...))))))))
  magit-process-sentinel(#<process git> "finished\n")
```
