### PR TITLE
magit-read-file-from-rev: Fix default-directory

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4068,8 +4068,8 @@ results in additional differences."
     (setq revision "HEAD"))
   (unless default
     (setq default (magit-current-file)))
-  (let ((default-directory (magit-get-top-dir))
-        (files (magit-revision-files revision)))
+  (let* ((default-directory (magit-get-top-dir))
+         (files (magit-revision-files revision)))
     (when (and default (not (member default files)))
       (setq default nil))
     (magit-completing-read prompt files


### PR DESCRIPTION
The default directory was not set when `magit-revision-files` was
called, resulting in the files being limited to the current directory.
Aside from the unintentional limiting of files, this resulted in
`magit-find-file{,-other-window}` displaying a blank buffer when called
from a subdirectory (because the file path was not correct for `git
cat-file`).
