### PR TITLE
Use correct window in `magit-mode-refresh-buffer`

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -3884,8 +3884,8 @@ Magit mode."
     (when magit-refresh-function
       (let* ((old-line (line-number-at-pos))
              (old-point (point))
-             (old-window (selected-window))
-             (old-window-start (window-start))
+             (old-window (car (get-buffer-window-list buffer nil t)))
+             (old-window-start (window-start old-window))
              (old-section (magit-current-section))
              (old-path (and old-section
                             (magit-section-path (magit-current-section)))))
@@ -3909,8 +3909,6 @@ Magit mode."
                      (widen)
                      (goto-char (point-min))
                      (forward-line (1- old-line)))))))
-        (when (fboundp 'unrecord-window-buffer)
-          (unrecord-window-buffer old-window buffer))
         (dolist (w (get-buffer-window-list buffer nil t))
           (set-window-point w (point))
           (set-window-start w old-window-start t))


### PR DESCRIPTION
(I am not sure how `magit-mode-refresh-buffer` is supposed to work, but it seems to work better with this fix.)

The current code seems to assume that `with-current-buffer` sets the
window buffer of the selected window. Since this is not the case,
`old-window-start` is sometimes wrong, and `unrecord-window-buffer` does
not seem to be needed.

See #1451 for discussion.
