### PR TITLE
magit-commit-add-log: Use symbol boundary in function name REGEXP

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6051,7 +6051,7 @@ depending on the value of option `magit-commit-squash-commit'.
                                      (forward-comment -1000)
                                      (point))))))
              (cond ((re-search-forward
-                     (format "(.*\\<%s\\>.*):" (regexp-quote fun))
+                     (format "(.*\\_<%s\\_>.*):" (regexp-quote fun))
                      limit t)
                     ;; found it, goto end of current entry
                     (if (re-search-forward "^(" limit t)


### PR DESCRIPTION
Hi Jonas Bernoulli,

I have a proposal to use symbol boundary REGEXP to match function name. I'm not
entirely sure whether this will cause other issue though. Could you please
consider my proposal and let me know if you accept this patch, or whether you
have other concerns. Below is the commit message for this patch.

Use symbol boundary instead of word boundary in function name REGEXP. This is
because using word boundary causes partial function name being matched. As an
example, let's say we have two diff hunks, one in the function `foo` and the
other in `foo-bar`. When the word boundary REGEXP is used, the REGEXP matches
both function name `foo` and `foo-bar`, which will prevent
`magit-commit-add-log` from adding a log entry for function `foo-bar` if an
entry for function `foo` already exist.
