### PR TITLE
magit-svn.el: finish magit{->-log}-wash-log rename

### DIFF
--- a/magit-svn.el
+++ b/magit-svn.el
@@ -235,7 +235,7 @@ If USE-CACHE is non-nil, use the cached information."
   (when (magit-svn-enabled)
     (magit-insert-section (svn-unpulled)
       (magit-insert-heading "Unpulled commits (svn):")
-      (magit-git-wash (apply-partially 'magit-wash-log 'unique)
+      (magit-git-wash (apply-partially 'magit-log-wash-log 'unique)
         "log" "--format=format:%h %s"
         (format "HEAD..%s" (magit-svn-get-ref t))))))
 
@@ -243,7 +243,7 @@ If USE-CACHE is non-nil, use the cached information."
   (when (magit-svn-enabled)
     (magit-insert-section (svn-unpushed)
       (magit-insert-heading "Unpushed commits (svn):")
-      (magit-git-wash (apply-partially 'magit-wash-log 'unique)
+      (magit-git-wash (apply-partially 'magit-log-wash-log 'unique)
         "log" "--format=format:%h %s"
         (format "%s..HEAD" (magit-svn-get-ref t))))))
 


### PR DESCRIPTION
magit-svn.el was overlooked in 4126fb173576910cb2f21977cd70ce113f0ba864

fixes #1470
