### PR TITLE
add various branch and commit readers

### DIFF
--- a/magit-diff.el
+++ b/magit-diff.el
@@ -277,7 +277,7 @@ RANGE should be a range (A..B or A...B) but can also be a single
 commit.  If one side of the range is omitted, then it defaults
 to HEAD.  If just a commit is given, then changes in the working
 tree relative to that commit are shown."
-  (interactive (list (magit-read-rev "Diff for range")))
+  (interactive (list (magit-read-range-or-commit "Diff for range")))
   (magit-mode-setup magit-diff-buffer-name-format
                     magit-diff-switch-buffer-function
                     #'magit-diff-mode
@@ -290,9 +290,7 @@ With a prefix argument show changes between the working tree and
 a commit read from the minibuffer."
   (interactive
    (and current-prefix-arg
-        (list (magit-read-rev "Diff working tree and commit"
-                              (or (magit-branch-or-commit-at-point)
-                                  (magit-get-current-branch) "HEAD")))))
+        (list (magit-read-branch-or-commit "Diff working tree and commit"))))
   (magit-diff (or rev "HEAD")))
 
 ;;;###autoload
@@ -302,9 +300,7 @@ With a prefix argument show changes between the index and
 a commit read from the minibuffer."
   (interactive
    (and current-prefix-arg
-        (list (magit-read-rev "Diff index and commit"
-                              (or (magit-branch-or-commit-at-point)
-                                  (magit-get-current-branch) "HEAD")))))
+        (list (magit-read-branch-or-commit "Diff index and commit"))))
   (magit-diff nil (cons "--cached" (and commit (list commit)))))
 
 ;;;###autoload

--- a/magit-ediff.el
+++ b/magit-ediff.el
@@ -128,7 +128,7 @@ working tree state."
      'ediff-revision))) ; this job gets no special handling at all; good
 
 (defun magit-ediff-compare--read-revisions (&optional arg)
-  (let ((input (or arg (magit-read-rev "Compare range or commit")))
+  (let ((input (or arg (magit-read-range-or-commit "Compare range or commit")))
         range revA revB)
     (if (string-match
          "^\\([^.]+\\)?\\(?:\\.\\.\\(\\.\\)?\\([^.]+\\)?\\)" input)

--- a/magit-extras.el
+++ b/magit-extras.el
@@ -80,11 +80,10 @@
   "Show changes between the marked commit and the one at point.
 If there is no commit at point, then prompt for one."
   (interactive
-   (let* ((marked (or magit-marked-commit (user-error "No commit marked")))
-          (commit (magit-read-rev (format "Diff marked commit %s with" marked)
-                                  (or (magit-branch-at-point)
-                                      (magit-get-current-branch)))))
-     (list (concat marked ".." commit))))
+   (let ((marked (or magit-marked-commit (user-error "No commit marked"))))
+     (list (concat marked ".."
+                   (magit-read-branch-or-commit
+                    (format "Diff marked commit %s with" marked))))))
   (magit-diff range))
 
 ;;; External Tools
@@ -119,7 +118,7 @@ blame to center around the line point is on."
      (when (or current-prefix-arg
                (not (setq revision "HEAD"
                           filename (magit-file-relative-name))))
-       (setq revision (magit-read-rev "Blame from revision" "HEAD")
+       (setq revision (magit-read-branch-or-commit "Blame from revision")
              filename (magit-read-file-from-rev revision "Blame file")))
      (list revision filename
            (and (equal filename

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -142,10 +142,12 @@
     (apply 'process-file magit-stgit-executable nil (list t nil) nil args)
     (split-string (buffer-string) "\n" 'omit-nulls)))
 
+(defvar magit-stgit-read-patch-history nil)
+
 (defun magit-stgit-read-patch (prompt &optional require-match)
   (magit-completing-read prompt (magit-stgit-lines "series" "--noprefix")
                          nil require-match
-                         nil 'magit-read-rev-history))
+                         nil 'magit-stgit-read-patch-history))
 
 (defun magit-stgit-read-args (prompt)
   (list (or (magit-section-when stgit-patch)

--- a/magit-topgit.el
+++ b/magit-topgit.el
@@ -142,7 +142,7 @@
 (defun magit-topgit-create-branch (branch parent)
   (interactive
    (list (magit-read-string "Create topgit branch" magit-topgit-branch-prefix)
-         (magit-read-rev "Parent" (magit-get-current-branch))))
+         (magit-read-branch "Parent")))
   (when (string-match-p magit-topgit-branch-prefix branch)
     (magit-run-topgit-async "create" branch parent)))
 


### PR DESCRIPTION
Previously mainly one function, `magit-read-rev`, was used to read all
kinds of branches and arbitrary commits and ranges from the user.  Two
other, specialized functions already existed, `magit-read-local-branch`
and `magit-read-remote-branch`, but these functions weren't used much.
Because `magit-read-rev` was very generic all callers had to duplicate
code responsible for determining the default choice and other things
that could have been abstracted away.  Aside from the duplication the
main problem was that the various defaults were not always consistent,
i.e. there were several commands that should have defaulted to the
current branch, but instead defaulted to just "HEAD".

Remove function
  `magit-read-rev`
remove variable
  `magit-read-rev-history`
add functions
  `magit-read-branch`
  `magit-read-branch-or-commit`
  `magit-read-other-branch`
  `magit-read-other-branch-or-commit`
change functions
  `magit-read-local-branch`
  `magit-read-remote-branch`
add variables
  `magit-revision-history`
  `magit-stgit-read-patch-history`

The functions whose names do not contain "no-commit" now only complete
branches.  The functions whose names do contain "no-commit" also offer
branches for completion, but also other refs, and furthermore they do
not restrict what the user can input, and even the default choice may
not be a branch.  When the default isn't a branch these functions try
to use a relative name such as "master~3" but we do not yet impose any
restrictions against which branches relative names are created.  Users
may also insert complete or abbreviated hashes.

In fact users could input arbitrary non-sense and there is no protection
against that yet, like there wasn't with `magit-read-rev`.  We currently
use this "feature" in an additional new completing function
`magit-read-range-or-commit`.  For now this is merely a stub, actually
it even is just an alias for `magit-read-branch-or-commit`.  Eventually
we need a completing function which can complete on both sides of "..".

The functions that contain "other" in their names take an optional
EXCLUDE argument.  When that is non-nil then these functions offer
branches different from that branch for completion, instead of those
different from the current branch.  Of course the excluded
branch (whether given explicitly or when defaulting to the current
branch) is never used as the default choice.

The new and improved completing functions are now consistent in what
they use as the default choice.  They use the branch at point (or commit
at point where appropriate) as default.  If there is no branch/commit at
point they use the current branch as default, except for the functions
whose name contain "other" which use the previous branch as default, and
prevent the current branch from even being selected explicitly.  Most of
the completing functions now take an optional argument DEFAULT, which
can be used to override the secondary default, i.e. the branch/commit at
point remains the default (if it isn't the excluded branch), but there
is nothing at point, then the value of this argument is used as default
instead of the current or previous branch.  There are only a few callers
which make use of this, but for a few it makes much more sense to
e.g. default to the tracked branch.
