### PR TITLE
support git notes

### DIFF
--- a/magit-git.el
+++ b/magit-git.el
@@ -565,6 +565,9 @@ where COMMITS is the number of commits in TAG but not in \"HEAD\"."
 (defun magit-list-tags ()
   (magit-git-lines "tag"))
 
+(defun magit-list-notes-refnames ()
+  (--map (substring it 6) (magit-list-refnames "refs/notes")))
+
 (defun magit-list-remote-tags (remote)
   (--map (substring it 51)
          (--filter (not (string-match-p "\\^{}$" it))

--- a/magit-mode.el
+++ b/magit-mode.el
@@ -154,6 +154,7 @@ the user has to confirm each save."
     (define-key map "P" 'magit-push-popup)
     (define-key map "r" 'magit-rebase-popup)
     (define-key map "t" 'magit-tag-popup)
+    (define-key map "T" 'magit-notes-popup)
     (define-key map [C-return] 'magit-dired-jump)
     (define-key map "\s"       'magit-show-or-scroll-up)
     (define-key map "\d"       'magit-show-or-scroll-down)


### PR DESCRIPTION
Add basic support for Git notes.

Notes are displayed in commit buffers unless `magit-commit-show-notes` is nil. The new `magit-notes-popup` and its commands can be used to manipulate notes. `magit-notes-set-ref` can be used to set the notes ref to be manipulated and displayed. `magit-notes-set-display-refs` can be used to set additional note refs to be displayed (unfortunately Git has a bug, so it doesn't work except if you use a glob, I recommend `"*"`.

Only the subcommands `edit`, `merge`, `remove` and `prune` are supported. Instead of `get-ref` we have a command to set it (which shows the current value as default), `list` doesn't display something useful out of the box, the various `edit` variants are about copying text from elsewhere, if you need that drop to the command line.

Additional functionality could be built on top of that but that won't happen anytime soon.
