### PR TITLE
magit-reset*: Fix ambiguous argument

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1918,7 +1918,7 @@ With a prefix argument also reset the working tree.
                      current-prefix-arg))
   (unless hard
     (magit-maybe-save-head-message commit))
-  (magit-run-git "reset" (if hard "--hard" "--mixed") commit))
+  (magit-run-git "reset" (if hard "--hard" "--mixed") commit "--"))
 
 ;;;###autoload
 (defun magit-reset-head (commit)
@@ -1926,7 +1926,7 @@ With a prefix argument also reset the working tree.
 \n(git reset --mixed COMMIT)"
   (interactive (list (magit-read-branch-or-commit "Reset head to")))
   (magit-maybe-save-head-message commit)
-  (magit-run-git "reset" "--mixed" commit))
+  (magit-run-git "reset" "--mixed" commit "--"))
 
 ;;;###autoload
 (defun magit-reset-soft (commit)
@@ -1934,14 +1934,14 @@ With a prefix argument also reset the working tree.
 \n(git reset --soft REVISION)"
   (interactive (list (magit-read-branch-or-commit "Soft reset to")))
   (magit-maybe-save-head-message commit)
-  (magit-run-git "reset" "--soft" commit))
+  (magit-run-git "reset" "--soft" commit "--"))
 
 ;;;###autoload
 (defun magit-reset-hard (commit)
   "Reset the head, index, and working tree to COMMIT.
 \n(git reset --hard REVISION)"
   (interactive (list (magit-read-branch-or-commit "Hard reset to")))
-  (magit-run-git "reset" "--hard" commit))
+  (magit-run-git "reset" "--hard" commit "--"))
 
 (defun magit-maybe-save-head-message (commit)
   (when (equal (magit-rev-parse commit)


### PR DESCRIPTION
When both a revision and a file have the same name,
`magit-reset{,head,soft,hard}` would fail with the following error.

```
fatal: ambiguous argument 'NAME': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

Add '--' to all commands to make it clear that the argument is a
revision. (This is already used in `magit-reset-index` and is the same
fix used in commit c5a6cc2577 before the reset functions were
rewritten).
