### PR TITLE
magit-insert-untracked-files-1: cd to list file in subdirectory

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -503,11 +503,10 @@ can be used to override this."
           (insert (directory-file-name file) "/\n")
           (magit-insert-heading)
           (let ((files (--map (substring it 3)
-                              (magit-git-lines "status" "--porcelain"
-                                               "-unormal" "--" file))))
-            (if (equal (car files) file)
-                (insert "(cannot expand because of Git bug)\n")
-              (magit-insert-untracked-files-1 files))))
+                              (let ((default-directory (expand-file-name file)))
+                                (magit-git-lines "status" "--porcelain"
+                                                 "-unormal" "--" ".")))))
+            (magit-insert-untracked-files-1 files)))
       (magit-insert-section (file file)
         (insert file "\n")))))
 


### PR DESCRIPTION
It's another quick fix. That realy fix the bug, even if calling git only once would be even better.
