### PR TITLE
magit-run-git-gui-blame: fix when linenum is missing

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -7671,8 +7671,7 @@ blame to center around the line point is on."
      (list revision filename
            (and (equal filename
                        (ignore-errors
-                         (magit-file-relative-name
-                          (file-name-directory (buffer-file-name)))))
+                         (magit-file-relative-name (buffer-file-name))))
                 (line-number-at-pos)))))
   (let ((default-directory (magit-get-top-dir)))
     (apply #'call-process magit-git-executable nil 0 nil "gui" "blame"


### PR DESCRIPTION
2eb34da broke `magit-run-git-gui-blame` by erroneously changing the argument to `magit-file-relative-name` to be a directory.  This prevented the `linenum` argument from being properly populated.
