### PR TITLE
git push "-f" switch uses --force-with-lease instead of --force

### DIFF
--- a/magit-key-mode.el
+++ b/magit-key-mode.el
@@ -158,7 +158,7 @@
       ("P" "Push" magit-push)
       ("t" "Push tags" magit-push-tags))
      (switches
-      ("-f" "Force" "--force")
+      ("-f" "Force" "--force-with-lease")
       ("-d" "Dry run" "-n")
       ("-u" "Set upstream" "-u")))
 


### PR DESCRIPTION
See the commit message for details.

This won't work with git < 1.8.5 (which was released November 2013) -- I don't know what your policy is for supporting older versions of git?
