### PR TITLE
Check if inside repo before trying to save buffers

### DIFF
--- a/magit-mode.el
+++ b/magit-mode.el
@@ -506,6 +506,7 @@ tracked in the current repository."
 
 (defun magit-maybe-save-repository-buffers ()
   (when (and magit-save-repository-buffers
+             (magit-get-top-dir)
              (not disable-magit-save-buffers))
     (setq disable-magit-save-buffers t)
     (let ((msg (current-message)))


### PR DESCRIPTION
`magit-init` would fail when there were any modified buffers because
`magit-pre-call-git-hook` calls `magit-maybe-save-repository-buffers`,
which, when not in a repo, results in nil being passed as an argument to
`string-prefix-p`.
