### PR TITLE
magit-revision-refresh-buffer: Avoid file refname

### DIFF
--- a/magit-diff.el
+++ b/magit-diff.el
@@ -935,7 +935,7 @@ Type \\[magit-reverse] to reverse the change at point in the worktree.
       "show" "-p" "--cc" "--decorate=full" "--format=fuller" "--no-prefix"
       (and magit-revision-show-diffstat "--stat")
       (and magit-revision-show-notes "--notes")
-      args commit)))
+      args commit "--")))
 
 (defun magit-diff-wash-revision (args)
   (let (diffstats)


### PR DESCRIPTION
When both a file and revision have the same name, 'git show' fails:

```
fatal: ambiguous argument 'foo': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

As a result, `magit-revision-refresh-buffer' showed an empty buffer.

Use '--' to specify that this argument is a revision.
