### PR TITLE
Check for existance of the directory in wip.

### DIFF
--- a/magit-wip.el
+++ b/magit-wip.el
@@ -116,6 +116,7 @@ If the current buffer visits a file tracked in a Git repository,
 then turn on `magit-wip-save-mode' provided the `wip-save' Magit
 extension has been enabled in that repository."
   (when (and (buffer-file-name)
+             (file-directory-p (file-name-directory (buffer-file-name)))
              (magit-inside-worktree-p)
              (magit-file-tracked-p (buffer-file-name))
              (member "wip-save" (magit-get-all "magit.extension")))


### PR DESCRIPTION
If a buffer edit a file in an non existing directory magit-inside-worktree-p fill fail with an error. As turn-on-magit-wip-save is meant to be in post-command-hook, it must not fail with an error, so we check if the directory exists.
