### PR TITLE
magit-status: bug fix when initializing.

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4373,8 +4373,9 @@ can be used to override this."
               (and (yes-or-no-p
                     (format "There is no Git repository in %s.  Create one? "
                             dir))
-                   (magit-init dir)
-                   (setq topdir (magit-get-top-dir dir))))
+                   (progn
+                     (magit-init dir)
+                     (setq topdir (magit-get-top-dir dir)))))
       (let ((default-directory topdir))
         (magit-mode-setup magit-status-buffer-name
                           (or switch-function


### PR DESCRIPTION
Because magit-init returns nil even when a repo is created, the code in
magit-status that brings up the status buffer wasn't executed.

Thanks to kyleam for finding the misgiving code.

Fix #1562 on master
