### PR TITLE
magit-log: Update default action

### DIFF
--- a/magit-log.el
+++ b/magit-log.el
@@ -308,7 +308,7 @@ http://www.mail-archive.com/git@vger.kernel.org/msg51337.html"
               (?H "Reflog HEAD"             magit-reflog-head)
               (?f "Log file"                magit-log-file))
   :default-arguments '("--graph" "--decorate")
-  :default-action 'magit-log-dwim
+  :default-action 'magit-log-current
   :max-action-columns 2
   :max-switch-columns 1)
 


### PR DESCRIPTION
The default action was not updated when `magit-log-dwim` was removed in
e0979bb6bd22a9ce5009a7cdf458034e52817da3.
