### PR TITLE
magit: rip out iswitchb

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -93,7 +93,6 @@ Use the function by the same name instead of this variable.")
   (require 'ediff)
   (require 'eshell)
   (require 'ido)
-  (require 'iswitchb)
   (require 'package nil t)
   (require 'view))
 
@@ -108,7 +107,6 @@ Use the function by the same name instead of this variable.")
 (declare-function ediff-cleanup-mess 'ediff)
 (declare-function eshell-parse-arguments 'eshell)
 (declare-function ido-completing-read 'ido)
-(declare-function iswitchb-read-buffer 'iswitchb)
 (declare-function package-desc-vers 'package)
 (declare-function package-desc-version 'package)
 (declare-function package-version-join 'package)
@@ -637,8 +635,7 @@ when generating large diffs."
 (defcustom magit-completing-read-function 'magit-builtin-completing-read
   "Function to be called when requesting input from the user."
   :group 'magit
-  :type '(radio (function-item magit-iswitchb-completing-read)
-                (function-item magit-ido-completing-read)
+  :type '(radio (function-item magit-ido-completing-read)
                 (function-item magit-builtin-completing-read)
                 (function :tag "Other")))
 
@@ -1791,17 +1788,6 @@ set before loading libary `magit'.")
 
 ;;; Utilities (1)
 ;;;; Minibuffer Input
-
-(defun magit-iswitchb-completing-read
-  (prompt choices &optional predicate require-match initial-input hist def)
-  "iswitchb-based completing-read almost-replacement."
-  (require 'iswitchb)
-  (let ((iswitchb-make-buflist-hook
-         (lambda ()
-           (setq iswitchb-temp-buflist (if (consp (car choices))
-                                           (mapcar #'car choices)
-                                         choices)))))
-    (iswitchb-read-buffer prompt (or initial-input def) require-match)))
 
 (defun magit-ido-completing-read
   (prompt choices &optional predicate require-match initial-input hist def)


### PR DESCRIPTION
iswitchb has been deprecated.  Requiring it causes warnings
under Emacs 24.4
