### PR TITLE
use saved arguments when command is invoked outside popup

### DIFF
--- a/magit-blame.el
+++ b/magit-blame.el
@@ -194,9 +194,7 @@ ARGS is a list of additional arguments to pass to `git blame';
 only arguments available from `magit-blame-popup' should be used.
 \n(fn REVISON FILE &optional ARGS)" ; LINE is for internal use
   (interactive
-   (let ((args (if magit-current-popup
-                   magit-current-popup-args
-                 magit-blame-arguments)))
+   (let ((args (magit-blame-arguments)))
      (if magit-blame-mode
          (--if-let (magit-blame-chunk-get :previous-hash)
              (list it (magit-blame-chunk-get :previous-file)

--- a/magit-commit.el
+++ b/magit-commit.el
@@ -110,8 +110,8 @@ an error while using those is harder to recover from."
 With a prefix argument amend to the commit at HEAD instead.
 \n(git commit [--amend] ARGS)"
   (interactive (if current-prefix-arg
-                   (list (cons "--amend" magit-current-popup-args))
-                 (list magit-current-popup-args)))
+                   (list (cons "--amend" (magit-commit-arguments)))
+                 (list (magit-commit-arguments))))
   (when (setq args (magit-commit-assert args))
     (magit-run-git-with-editor "commit" args)))
 
@@ -119,7 +119,7 @@ With a prefix argument amend to the commit at HEAD instead.
 (defun magit-commit-amend (&optional args)
   "Amend the last commit.
 \n(git commit --amend ARGS)"
-  (interactive (list magit-current-popup-args))
+  (interactive (list (magit-commit-arguments)))
   (magit-run-git-with-editor "commit" "--amend" args))
 
 ;;;###autoload
@@ -129,7 +129,7 @@ With a prefix argument do change the committer date, otherwise
 don't.  The option `magit-commit-extend-override-date' can be
 used to inverse the meaning of the prefix argument.
 \n(git commit --amend --no-edit)"
-  (interactive (list magit-current-popup-args
+  (interactive (list (magit-commit-arguments)
                      (if current-prefix-arg
                          (not magit-commit-reword-override-date)
                        magit-commit-reword-override-date)))
@@ -150,7 +150,7 @@ used to inverse the meaning of the prefix argument.
 Non-interactively respect the optional OVERRIDE-DATE argument
 and ignore the option.
 \n(git commit --amend --only)"
-  (interactive (list magit-current-popup-args
+  (interactive (list (magit-commit-arguments)
                      (if current-prefix-arg
                          (not magit-commit-reword-override-date)
                        magit-commit-reword-override-date)))
@@ -186,7 +186,8 @@ depending on the value of option `magit-commit-squash-confirm'.
   "Create a fixup commit and instantly rebase.
 \n(git commit --no-edit --fixup=COMMIT ARGS;
  git rebase -i COMMIT^ --autosquash --autostash)"
-  (interactive (list (magit-commit-at-point) magit-current-popup-args))
+  (interactive (list (magit-commit-at-point)
+                     (magit-commit-arguments)))
   (magit-commit-squash-internal
    (lambda (c a)
      (when (setq c (magit-commit-fixup c a))
@@ -198,7 +199,8 @@ depending on the value of option `magit-commit-squash-confirm'.
   "Create a squash commit and instantly rebase.
 \n(git commit --no-edit --squash=COMMIT ARGS;
  git rebase -i COMMIT^ --autosquash --autostash)"
-  (interactive (list (magit-commit-at-point) magit-current-popup-args))
+  (interactive (list (magit-commit-at-point)
+                     (magit-commit-arguments)))
   (magit-commit-squash-internal
    (lambda (c a)
      (when (setq c (magit-commit-squash c a))
@@ -206,7 +208,8 @@ depending on the value of option `magit-commit-squash-confirm'.
    "--squash" commit args t))
 
 (defun magit-commit-squash-read-args ()
-  (list (magit-commit-at-point) magit-current-popup-args
+  (list (magit-commit-at-point)
+        (magit-commit-arguments)
         (or current-prefix-arg magit-commit-squash-confirm)))
 
 (defun magit-commit-squash-internal (fn option commit args confirm)

--- a/magit-log.el
+++ b/magit-log.el
@@ -325,7 +325,7 @@ http://www.mail-archive.com/git@vger.kernel.org/msg51337.html"
             (magit-read-range-or-commit "Show log for"
                                         (unless use-current
                                           (magit-get-previous-branch))))
-        magit-current-popup-args))
+        (magit-log-arguments)))
 
 ;;;###autoload
 (defun magit-log-current (range &optional args)
@@ -351,7 +351,7 @@ http://www.mail-archive.com/git@vger.kernel.org/msg51337.html"
 
 ;;;###autoload
 (defun magit-log-head (args)
-  (interactive (list magit-current-popup-args))
+  (interactive (list (magit-log-arguments)))
   (magit-log "HEAD" args))
 
 ;;;###autoload
@@ -367,8 +367,8 @@ With a prefix argument show the log graph."
                     'oneline "HEAD"
                     (cons "--follow"
                           (if use-graph
-                              (cons "--graph" magit-current-popup-args)
-                            (delete "--graph" magit-current-popup-args)))
+                              (cons "--graph" (magit-log-arguments))
+                            (delete "--graph" (magit-log-arguments))))
                     file)
   (magit-log-goto-same-commit))
 

--- a/magit-popup.el
+++ b/magit-popup.el
@@ -330,6 +330,10 @@ that without users being aware of it could lead to tears.
          ""
          ,@(and grp (list :group grp))
          :type '(repeat (string :tag "Argument")))
+       (defun ,opt ()
+         (if (eq magit-current-popup ',name)
+             magit-current-popup-args
+           ,opt))
        (put ',opt 'definition-name ',name))))
 
 (defun magit-define-popup-switch (popup key desc switch

--- a/magit-remote.el
+++ b/magit-remote.el
@@ -91,20 +91,20 @@ If `HEAD' is detached or if the upstream is not configured,
 then read the remote."
   (interactive (list (or (magit-get-remote)
                          (magit-read-remote "Fetch remote"))
-                     magit-current-popup-args))
+                     (magit-fetch-arguments)))
   (magit-run-git-async "fetch" remote args))
 
 ;;;###autoload
 (defun magit-fetch (remote &optional args)
   "Fetch from another repository."
   (interactive (list (magit-read-remote "Fetch remote")
-                     magit-current-popup-args))
+                     (magit-fetch-arguments)))
   (magit-run-git-async "fetch" remote args))
 
 ;;;###autoload
 (defun magit-fetch-all (&optional args)
   "Fetch from another repository."
-  (interactive (list magit-current-popup-args))
+  (interactive (list (magit-fetch-arguments)))
   (magit-run-git-async "remote" "update" args))
 
 ;;; Pull
@@ -134,7 +134,7 @@ then read the remote."
   (let ((remote (magit-get-remote-branch)))
     (unless (and use-upstream remote)
       (setq remote (magit-read-remote-branch "Pull" nil remote t)))
-    (list (car remote) (cdr remote) magit-current-popup-args)))
+    (list (car remote) (cdr remote) (magit-pull-arguments))))
 
 ;;; Push
 
@@ -192,7 +192,7 @@ Read the local and remote branch."
     (unless (and use-upstream remote)
       (setq remote (magit-read-remote-branch (format "Push %s to" local)
                                              nil remote 'confirm)))
-    (list local (car remote) (cdr remote) magit-current-popup-args)))
+    (list local (car remote) (cdr remote) (magit-pull-arguments))))
 
 ;;;###autoload
 (defun magit-push-matching (remote &optional args)
@@ -209,7 +209,7 @@ If only one remote exists, then push to that.  Otherwise prompt
 for a remote, offering the remote configured for the current
 branch as default."
   (interactive (list (magit-read-remote "Push tags to remote" nil t)
-                     magit-current-popup-args))
+                     (magit-push-arguments)))
   (magit-run-git-async "push" remote "--tags" args))
 
 ;;; magit-remote.el ends soon

--- a/magit-sequence.el
+++ b/magit-sequence.el
@@ -151,7 +151,7 @@
 (defun magit-cherry-pick-read-args (prompt)
   (list (or (nreverse (magit-region-values 'commit))
             (magit-read-other-branch-or-commit prompt))
-        magit-current-popup-args))
+        (magit-cherry-pick-arguments)))
 
 ;;;###autoload
 (defun magit-cherry-pick (commit &optional args)
@@ -192,7 +192,7 @@
 (defun magit-revert-read-args (prompt)
   (list (or (magit-region-values 'commit)
             (magit-read-branch-or-commit prompt))
-        magit-current-popup-args))
+        (magit-revert-arguments)))
 
 ;;;###autoload
 (defun magit-revert (commit &optional args)
@@ -239,13 +239,13 @@
 (defun magit-am-apply-patches (&optional files args)
   (interactive (list (or (magit-region-values 'file)
                          (list (read-file-name "Apply patch: ")))
-                     magit-current-popup-args))
+                     (magit-am-arguments)))
   (magit-run-git-sequencer "am" args "--" (mapcar 'expand-file-name files)))
 
 ;;;###autoload
 (defun magit-am-apply-maildir (&optional maildir args)
   (interactive (list (read-file-name "Apply mbox or Maildir: ")
-                     magit-current-popup-args))
+                     (magit-am-arguments)))
   (magit-run-git-sequencer "am" args (expand-file-name maildir)))
 
 ;;;###autoload
@@ -309,7 +309,7 @@
                       "Rebase to"
                       (magit-get-current-branch)
                       (magit-get-tracked-branch))
-                     magit-current-popup-args))
+                     (magit-rebase-arguments)))
   (if upstream
       (progn (message "Rebasing...")
              (magit-run-git-sequencer "rebase" upstream args)
@@ -341,7 +341,7 @@
 \n(git rebase -i COMMIT[^] [ARGS])"
   (interactive (let ((commit (magit-commit-at-point)))
                  (list (and commit (concat commit "^"))
-                       magit-current-popup-args)))
+                       (magit-rebase-arguments))))
   (if (setq commit (magit-rebase-interactive-assert commit))
       (magit-run-git-sequencer "rebase" "-i" commit args)
     (magit-log-select
@@ -352,7 +352,7 @@
 (defun magit-rebase-autosquash (commit &optional args)
   "Combine squash and fixup commits with their intended targets.
 \n(git rebase -i COMMIT[^] --autosquash --autostash [ARGS])"
-  (interactive (list (magit-get-tracked-branch) magit-current-popup-args))
+  (interactive (list (magit-get-tracked-branch) (magit-rebase-arguments)))
   (if (setq commit (magit-rebase-interactive-assert commit))
       (let ((process-environment process-environment))
         (setenv "GIT_SEQUENCE_EDITOR" "true")

--- a/magit-stash.el
+++ b/magit-stash.el
@@ -95,10 +95,10 @@ while two prefix arguments are equivalent to `--all'."
         (magit-stash-read-untracked)))
 
 (defun magit-stash-read-untracked ()
-  (let ((prefix (prefix-numeric-value current-prefix-arg)))
-    (cond ((or (= prefix 16) (member "--all" magit-current-popup-args)) 'all)
-          ((or (= prefix  4)
-               (member "--include-untracked" magit-current-popup-args)) t))))
+  (let ((prefix (prefix-numeric-value current-prefix-arg))
+        (args   (magit-stash-arguments)))
+    (cond ((or (= prefix 16) (member "--all" args)) 'all)
+          ((or (= prefix  4) (member "--include-untracked" args)) t))))
 
 (defun magit-stash-read-message ()
   (let* ((default (format "On %s: "

--- a/magit.el
+++ b/magit.el
@@ -506,7 +506,7 @@ Type \\[magit-reset-head] to reset HEAD to the commit at point.
 (defun magit-show-refs-head (&optional args)
   "List and compare references in a dedicated buffer.
 Refs are compared with `HEAD'."
-  (interactive (list magit-current-popup-args))
+  (interactive (list (magit-show-refs-arguments)))
   (magit-show-refs nil args))
 
 ;;;###autoload
@@ -514,7 +514,7 @@ Refs are compared with `HEAD'."
   "List and compare references in a dedicated buffer.
 Refs are compared with the current branch or `HEAD' if
 it is detached."
-  (interactive (list magit-current-popup-args))
+  (interactive (list (magit-show-refs-arguments)))
   (magit-show-refs (magit-get-current-branch) args))
 
 ;;;###autoload
@@ -522,7 +522,7 @@ it is detached."
   "List and compare references in a dedicated buffer.
 Refs are compared with a branch read form the user."
   (interactive (list (magit-read-other-branch "Compare with")
-                     magit-current-popup-args))
+                     (magit-show-refs-arguments)))
   (magit-mode-setup magit-refs-buffer-name-format nil
                     #'magit-refs-mode
                     #'magit-refs-refresh-buffer ref args))
@@ -855,7 +855,7 @@ changes.
   (magit-run-git "checkout" args "-b" branch start-point))
 
 (defun magit-branch-read-args (prompt)
-  (let* ((args magit-current-popup-args)
+  (let* ((args (magit-branch-arguments))
          (start (magit-read-branch-or-commit (concat prompt " starting at")))
          (branch
           (magit-read-string
@@ -1010,7 +1010,7 @@ merge.
 
 \(git merge --no-edit|--no-commit [ARGS] REV)"
   (interactive (list (magit-read-other-branch-or-commit "Merge")
-                     magit-current-popup-args
+                     (magit-merge-arguments)
                      current-prefix-arg))
   (magit-merge-assert)
   (magit-run-git "merge" (if nocommit "--no-commit" "--no-edit") args rev))
@@ -1022,7 +1022,7 @@ Perform the merge and prepare a commit message but let the user
 edit it.
 \n(git merge --edit [ARGS] rev)"
   (interactive (list (magit-read-other-branch-or-commit "Merge")
-                     magit-current-popup-args))
+                     (magit-merge-arguments)))
   (magit-merge-assert)
   (magit-run-git-with-editor "merge" "--edit" args rev))
 
@@ -1033,7 +1033,7 @@ Pretend the merge failed to give the user the opportunity to
 inspect the merge and change the commit message.
 \n(git merge --no-commit [ARGS] rev)"
   (interactive (list (magit-read-other-branch-or-commit "Merge")
-                     magit-current-popup-args))
+                     (magit-merge-arguments)))
   (magit-merge-assert)
   (magit-run-git "merge" "--no-commit" args rev))
 
@@ -1194,7 +1194,7 @@ With a prefix argument annotate the tag.
 \n(git tag [--annotate] NAME REV)"
   (interactive (list (magit-read-tag "Tag name")
                      (magit-read-branch-or-commit "Place tag on")
-                     (let ((args magit-current-popup-args))
+                     (let ((args (magit-tag-arguments)))
                        (when current-prefix-arg
                          (add-to-list 'args "--annotate"))
                        args)))
@@ -1278,7 +1278,7 @@ defaulting to the tag at point.
   (magit-run-git-with-editor "notes" "merge" "--abort"))
 
 (defun magit-notes-prune (&optional dry-run)
-  (interactive (list (and (member "--dry-run" magit-current-popup-args) t)))
+  (interactive (list (and (member "--dry-run" (magit-notes-arguments)) t)))
   (when dry-run
     (magit-process))
   (magit-run-git-with-editor "notes" "prune" (and dry-run "--dry-run")))
@@ -1323,7 +1323,7 @@ defaulting to the tag at point.
 (defun magit-notes-read-args (prompt)
  (list (magit-read-branch-or-commit prompt)
        (--when-let (--first (string-match "^--ref=\\(.+\\)" it)
-                            magit-current-popup-args)
+                            (magit-notes-arguments))
          (match-string 1 it))))
 
 (defun magit-notes-popup-read-ref (prompt &optional initial-input)


### PR DESCRIPTION
When a command which is usually invoked as a popup action is invoked
directly then use the global value of the respective `PREFIX-arguments`
variable.

`magit-define-popup` now also defines a function by the same name.
When that function is called while a action is being invoked from the
respective popup, then it returns `magit-current-prefix-args`s value.
Otherwise it returns the value of the variable `PREFIX-arguments'.

Replace most occurrences of `magit-current-prefix-args` with a call to
such a function.
