### PR TITLE
magit-insert-untracked-files: respect status.showUntrackedFiles

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -442,7 +442,12 @@ then offer to initialize it as a new repository."
 (magit-define-section-jumper untracked "Untracked files")
 
 (defun magit-insert-untracked-files ()
-  (-when-let (files (magit-untracked-files))
+  (-when-let (files (--mapcat (and (eq (aref it 0) ??)
+                                   (list (substring it 3)))
+                              (magit-git-lines
+                               "status" "--porcelain"
+                               (unless (magit-get "status.showUntrackedFiles")
+                                 "-uall"))))
     (magit-insert-section (untracked)
       (magit-insert-heading "Untracked files:")
       (magit-insert-untracked-files-1 files nil)
@@ -455,6 +460,8 @@ then offer to initialize it as a new repository."
           (let ((file (pop files)))
             (magit-insert-section (file file)
               (insert (propertize file 'face 'magit-filename) ?\n)))
+        (when (equal (car files) dir)
+          (pop files))
         (magit-insert-section (file dir t)
           (insert (propertize dir 'file 'magit-filename) ?\n)
           (magit-insert-heading)


### PR DESCRIPTION
Showing all untracked files can be slow.  So respect the Git variable
`status.showUntrackedFiles` allowing users to make it faster at the
cost of not being able to stage every untracked file individually.

When the variable is unset `git status` defaults to `normal` while
`magit-insert-untracked-files` defaults to `all`, allowing them to
be staged individually.

Note that when `normal` is used the untracked files are still displayed
as a tree, but some of the trees cannot be expanded.  If directory
`mixed` contains an untracked and a tracked file then it is expandable
and expanding it will show the untracked file.  While the directory
`untracked` contains only untracked files and cannot be expanded.  With
everything expanded this would look like this:

Untracked files (2)
mixed/
mixed/untracked
untracked/

@Niluge-KiWi how does that look as a fix for #1599?
