### PR TITLE
Correct docstring of magit-status

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -327,8 +327,10 @@ This mode is documented in info node `(magit)Status'.
 Type \\[magit-refresh] to refresh the current buffer.
 Type \\[magit-dispatch-popup] to see available action popups.
 Type \\[magit-section-toggle] to expand or hide the section at point.
+\\<magit-hunk-section-map>\
 Type \\[magit-diff-visit-file] to visit the change at point.
 Type \\[magit-stage] to stage the change at point; \\[magit-unstage] to unstage.
+\\<magit-status-mode-map>\
 Type \\[magit-commit-popup] to create a commit.
 \n\\{magit-status-mode-map}"
   :group 'magit-status)


### PR DESCRIPTION
As magit now use magit-*-section-map, the docstring of magit-status did
not refer anymore to the correct binding, so let's tell it where to find
them.
