### PR TITLE
(magit-process-yes-or-no-prompt) Save match data during prompt.

### DIFF
--- a/magit-process.el
+++ b/magit-process.el
@@ -445,7 +445,8 @@ tracked in the current repository are reverted if
       (process-send-string
        proc
        (downcase
-        (concat (match-string (if (yes-or-no-p (substring string 0 beg)) 1 2)
+        (concat (match-string (if (save-match-data
+                                    (yes-or-no-p (substring string 0 beg))) 1 2)
                               string)
                 "\n"))))))
 


### PR DESCRIPTION
I had a weird error in match-string, which I assume was due to the fact I did not answer the prompt immediately. Adding save-match-data should not hurt.
