### PR TITLE
Using magit-run-git-async for stashing

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6082,7 +6082,7 @@ With prefix argument, changes in staging area are kept.
 \('git stash save [--keep-index] DESCRIPTION')"
   (interactive (list (read-string "Stash description: " nil
                                   'magit-read-stash-history)))
-  (magit-run-git "stash" "save" magit-custom-options "--" description))
+  (magit-run-git-async "stash" "save" magit-custom-options "--" description))
 
 ;;;###autoload
 (defun magit-stash-snapshot ()


### PR DESCRIPTION
This solves issue #1647 for git stash communicating with GPG. My guess
is that the asynchronous process is actually able to read the tty that
it needs to talk with gpg-agent.

I looked at the same code on the 'next' branch, and `magit-stash` has
been totally redone. I was unable to properly reproduce my issue on that
branch, but that's because it was not working in other, unrelated, ways.

That said, this is more of a hotfix since it is branched off 'master'.
