### PR TITLE
Magit revision file log

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -6262,14 +6262,7 @@ With a prefix argument show the log graph."
    (list (magit-read-file-from-rev (magit-get-current-branch)
                                    (magit-buffer-file-name t))
          current-prefix-arg))
-  (magit-mode-setup magit-log-buffer-name nil
-                    #'magit-log-mode
-                    #'magit-refresh-log-buffer
-                    'oneline "HEAD"
-                    `(,@(and use-graph (list "--graph"))
-                      ,@magit-custom-options
-                      "--follow")
-                    file))
+  (magit-revision-file-log "HEAD" file use-graph))
 
 ;;;###autoload
 (defun magit-revision-file-log (revision file &optional use-graph)


### PR DESCRIPTION
Adds `magit-revision-file-log` that allows to limit log for a file to a revision.
