### PR TITLE
Remove merged dependencies from magit-pkg.el

### DIFF
--- a/magit-pkg.el
+++ b/magit-pkg.el
@@ -1,7 +1,4 @@
 (define-package "magit" "2.0.50"
   "Control Git from Emacs"
   '((cl-lib "0.5")
-    (dash "2.8.0")
-    (git-commit "1.0.0")
-    (git-rebase "1.0.0")
-    (with-editor "1.0.0")))
+    (dash "2.8.0")))


### PR DESCRIPTION
Hi,

When attempting to install the next branch using Cask, like so:

`(depends-on "magit" :git "https://github.com/magit/magit.git" :branch "next")`

I get the following error:

`Dependency magit failed to install: Package `git-commit-1.0.0' is unavailable`

Since these dependencies are now in the main repo, I don't think they need to specified as package dependencies? I can confirm that installing using the patched branch works, and that `git-commit-mode` and `git-rebase-mode` are both available and working.
