### PR TITLE
magit.texi: add beginnings of a Magit info manual

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,12 +91,14 @@ help:
 	$(info make                  - build elisp files)
 	$(info make lisp             - ditto)
 	$(info make all              - build elisp files and documentation)
+	$(info make docs             - generate documentation)
 	$(info )
 	$(info Install)
 	$(info =======)
 	$(info )
 	$(info make install          - install elisp files and documentation)
 	$(info make install-lisp     - install elisp files)
+	$(info make install-docs     - install documentation)
 	$(info make install-script   - install shell script)
 	$(info make install-all      - install elisp files, script, and docs)
 	$(info )
@@ -217,6 +219,9 @@ install-lisp: lisp
 
 .PHONY: install-docs
 install-docs: docs
+	$(MKDIR) $(DESTDIR)$(infodir)
+	$(CP) magit.info $(DESTDIR)$(infodir)
+	$(INSTALL_INFO) --info-dir=$(DESTDIR)$(infodir) $(DESTDIR)$(infodir)/magit.info
 	$(MKDIR) $(DESTDIR)$(docdir)
 	$(CP) AUTHORS.md $(DESTDIR)$(docdir)
 
@@ -237,6 +242,7 @@ clean:
 	@test ! -e .git || $(RM) magit.info
 
 DIST_FILES = $(ELS) magit-version.el Makefile AUTHORS.md README.md
+DIST_FILES += magit.texi magit.info dir
 
 .PHONY: dist
 dist: magit-$(VERSION).tar.gz
@@ -247,7 +253,7 @@ magit-$(VERSION).tar.gz: $(DIST_FILES)
 	@tar -cz --mtime=./magit-$(VERSION) -f magit-$(VERSION).tar.gz magit-$(VERSION)
 	@$(RMDIR) magit-$(VERSION)
 
-ELPA_FILES = $(ELS) magit-pkg.el AUTHORS.md
+ELPA_FILES = $(ELS) magit-pkg.el AUTHORS.md magit.info dir
 
 .PHONY: marmalade
 marmalade: magit-$(VERSION).tar

--- a/magit.texi
+++ b/magit.texi
@@ -1,0 +1,60 @@
+\input texinfo   @c -*-texinfo-*-
+@c %**start of header
+@setfilename magit.info
+@settitle Magit
+@dircategory Emacs
+@direntry
+* magit: (magit.info). It's Magit! An Emacs mode for Git
+@end direntry
+@documentencoding UTF-8
+@c %**end of header
+
+@copying
+This is the `Magit manual' for Magit version 2.1.0.
+
+Copyright @copyright{} 2014, Jonas Bernoulli
+
+@quotation
+@end quotation
+@end copying
+
+@titlepage
+@title Magit
+@insertcopying
+@end titlepage
+@contents
+
+@ifnottex
+@node Top
+@top Magit
+@insertcopying
+@end ifnottex
+
+@c %**start of body
+@menu
+* Overview::    Magit in brief.
+* Index::       The index.
+@end menu
+
+@node Overview
+@chapter Overview
+
+Magit is an interface to the version control system
+Git@footnote{http://git-scm.com/}, implemented as an Emacs extension.
+
+Unlike the `VC' package which is part of Emacs and strives to provide
+a unified interface to various version control systems, Magit only
+supports Git and can therefore better take advantage of its native
+features. @xref{Introduction to VC, VC,, emacs, The Emacs Editor}.
+
+Magit supports `GNU Emacs' 23.2 or later; 24.1 or later is
+recommended. Magit supports `Git' 1.7.2.5 or later; 1.8.2 or later is
+recommended. The minimal versions are those available in Debian
+oldstable.
+
+@node Index
+@unnumbered Index
+
+@printindex cp
+
+@bye


### PR DESCRIPTION
- Restore the relevant bits in the Makefile

`make install` still depended on `docs` which depended on the existence of `magit.info`, so that was broken.  Since it was suggested that documentation is on the 2.1.0 roadmap, instead of fixing the Makefile, I figured it wouldn't hurt to put together a stub for the new manual (it is going to be info, right?).

I put your name on it, beyond that I don't know what license you intend to use, and I just plugged some useful information from README.md into an Overview section.  I didn't look at the old manual as the commit where you removed it mentioned licensing.
