### PR TITLE
Update README.md with the new MELPA url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ configure `package.el` once.
 ```lisp
 (require 'package)
 (add-to-list 'package-archives
-             '("melpa" . "http://melpa.milkbox.net/packages/") t)
+             '("melpa" . "http://melpa.org/packages/") t)
 ```
 
 Then evaluate these forms, update the package cache, and install


### PR DESCRIPTION
The MELPA url changed recently, I believe the old one is still working for now but I'm not sure how long that will remain true for. Since it's just a small documentation correction I figured it could probably go to master, but I'll rebase it if there is disagreement.
