### PR TITLE
Do not abort when buffers visit files in nonexistent directories

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4704,12 +4704,13 @@ to consider it or not when called with that buffer current."
   "Only prompt to save buffers which are within the current git project.
 As determined by the directory passed to `magit-status'."
   (and buffer-file-name
-       (let ((topdir (magit-get-top-dir magit-default-directory)))
+       (let ((topdir (magit-get-top-dir magit-default-directory))
+             (buffer-dir (file-name-directory buffer-file-name)))
          (and topdir
               (equal (file-remote-p topdir) (file-remote-p buffer-file-name))
               ;; ^ Avoid needlessly connecting to unrelated tramp remotes.
-              (string= topdir (magit-get-top-dir
-                               (file-name-directory buffer-file-name)))))))
+              (file-directory-p buffer-dir)
+              (string= topdir (magit-get-top-dir buffer-dir))))))
 
 ;;; Porcelain
 ;;;; Apply


### PR DESCRIPTION
After `(find-file "/does-not-exist/file")` and switching to an existing file, `magit-status` used to abort when Magit tried to determine whether the file in a nonexistent directory belongs to the current project. This change fixes that.
