### PR TITLE
magit-insert-local-branches: check upstream name

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -596,8 +596,9 @@ Refs are compared with a branch read form the user."
 (defun magit-insert-local-branches ()
   (magit-insert-section (local nil)
     (magit-insert-heading "Branches:")
-    (let ((current  (magit-get-current-branch))
-          (branches (magit-list-local-branch-names)))
+    (let* ((current  (magit-get-current-branch))
+           (branches (magit-list-local-branch-names))
+           (all-branches (append branches (magit-list-remote-branch-names))))
       (dolist (line (magit-git-lines "branch" "-vv"
                                      (cadr magit-refresh-args)))
         (string-match magit-wash-branch-line-re line)
@@ -605,6 +606,10 @@ Refs are compared with a branch read form the user."
             (branch hash message upstream ahead behind) line
           (when (string-match-p "(" branch)
             (setq branch nil))
+          (when (and upstream
+                     (not (member upstream all-branches)))
+            (setq message (concat "[" upstream "] " message))
+            (setq upstream nil))
           (magit-insert-branch
            branch current branches
            magit-local-branch-format 'magit-branch-local


### PR DESCRIPTION
Check whether upstream name is in local or remote branch names.
If upstream name is not include in branch names, it should be
beginning of commit message.
