### PR TITLE
Use define-obsolete-variable-alias before defcustom

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -54,6 +54,17 @@
 (require 'cl-lib)
 (require 'dash)
 
+(define-obsolete-variable-alias 'magit-highlight-indentation 'magit-diff-highlight-indentation)
+(define-obsolete-variable-alias 'magit-highlight-trailing-whitespace 'magit-diff-highlight-trailing)
+(define-obsolete-variable-alias 'magit-highlight-whitespace 'magit-diff-paint-whitespace)
+(define-obsolete-variable-alias 'magit-mode-refresh-buffer-hook 'magit-refresh-buffer-hook)
+(define-obsolete-variable-alias 'magit-repo-dirs 'magit-repository-directories)
+(define-obsolete-variable-alias 'magit-repo-dirs-depth 'magit-repository-directories-depth)
+(define-obsolete-variable-alias 'magit-revert-backup 'magit-apply-backup)
+(define-obsolete-variable-alias 'magit-revert-buffer-hook 'magit-after-revert-hook)
+(define-obsolete-variable-alias 'magit-show-child-count 'magit-section-show-child-count)
+(define-obsolete-variable-alias 'magit-status-refresh-hook 'magit-refresh-status-hook)
+
 (require 'with-editor)
 (require 'git-commit)
 (require 'git-rebase)
@@ -1693,17 +1704,6 @@ Use the function by the same name instead of this variable.")
     magit-version))
 
 (cl-eval-when (load eval) (magit-version t))
-
-(define-obsolete-variable-alias 'magit-highlight-indentation 'magit-diff-highlight-indentation)
-(define-obsolete-variable-alias 'magit-highlight-trailing-whitespace 'magit-diff-highlight-trailing)
-(define-obsolete-variable-alias 'magit-highlight-whitespace 'magit-diff-paint-whitespace)
-(define-obsolete-variable-alias 'magit-mode-refresh-buffer-hook 'magit-refresh-buffer-hook)
-(define-obsolete-variable-alias 'magit-repo-dirs 'magit-repository-directories)
-(define-obsolete-variable-alias 'magit-repo-dirs-depth 'magit-repository-directories-depth)
-(define-obsolete-variable-alias 'magit-revert-backup 'magit-apply-backup)
-(define-obsolete-variable-alias 'magit-revert-buffer-hook 'magit-after-revert-hook)
-(define-obsolete-variable-alias 'magit-show-child-count 'magit-section-show-child-count)
-(define-obsolete-variable-alias 'magit-status-refresh-hook 'magit-refresh-status-hook)
 
 (provide 'magit)
 


### PR DESCRIPTION
Using define-obsolete-variable-alias after the corresponding defcustom will remove the value that the user has already set (but maybe the side effect of making users migrate their settings faster was intended ?).
