### PR TITLE
magit-status: add a section with recent commits

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -4461,15 +4461,18 @@ can be used to override this."
             (apply-partially #'magit-wash-raw-diffs t)
           "diff-index" "--cached" base)))))
 
+(defun magit-insert-recent-commits ()
+  (magit-git-insert-section (recent "Recent commits:")
+      (apply-partially 'magit-wash-log 'unique)
+    "log" "--format=format:%h %s" "-n" "10"))
+
 (defun magit-insert-unpulled-or-recent-commits ()
   (let ((tracked (magit-get-tracked-branch nil t)))
     (if (and tracked
              (not (equal (magit-git-string "rev-parse" "HEAD")
                          (magit-git-string "rev-parse" tracked))))
         (magit-insert-unpulled-commits)
-      (magit-git-insert-section (recent "Recent commits:")
-          (apply-partially 'magit-wash-log 'unique)
-        "log" "--format=format:%h %s" "-n" "10"))))
+      (magit-insert-recent-commits))))
 
 (defun magit-insert-unpulled-commits ()
   (let ((tracked (magit-get-tracked-branch nil t)))


### PR DESCRIPTION
This section existed in the past but has been removed in favor of
`magit-insert-unpulled-or-recent-commits`. I am disturbed but the fact
that recent commits are only displayed when there is no unpulled nor
unpushed commits. I prefer to have those commits always displayed.