### PR TITLE
magit-diff-refine-hunk: avoid re-refining already refined hunks

### DIFF
--- a/magit-diff.el
+++ b/magit-diff.el
@@ -1596,13 +1596,16 @@ of SECTION including SECTION and all of them are highlighted."
                                  'magit-diff-whitespace-warning)))))
 
 (defun magit-diff-refine-hunk (hunk)
-  (save-excursion
-    (goto-char (magit-section-start hunk))
-    ;; `diff-refine-hunk' does not handle combined diffs.
-    (unless (looking-at "@@@")
-      (diff-refine-hunk))))
+  (unless (magit-section-refined hunk)
+    (setf (magit-section-refined hunk) t)
+    (save-excursion
+      (goto-char (magit-section-start hunk))
+      ;; `diff-refine-hunk' does not handle combined diffs.
+      (unless (looking-at "@@@")
+        (diff-refine-hunk)))))
 
 (defun magit-diff-unrefine-hunk (hunk)
+  (setf (magit-section-refined hunk) nil)
   (remove-overlays (magit-section-start hunk)
                    (magit-section-end hunk)
                    'diff-mode 'fine))

--- a/magit-section.el
+++ b/magit-section.el
@@ -84,7 +84,7 @@ diff-related sections being the only exception."
 ;;; Core
 
 (cl-defstruct magit-section
-  type value start content end hidden washer
+  type value start content end hidden washer refined
   source blobs process parent children)
 
 (defvar-local magit-root-section nil


### PR DESCRIPTION
This seems to be the simplest approach to avoid needlessly re-refining an already refined hunk. See #1581.