### PR TITLE
magit-git-command: create process buffer if needed

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -1708,7 +1708,7 @@ With a prefix argument run Git in the root of the current
 repository.  Non-interactively run Git in DIRECTORY with ARGS."
   (interactive (magit-git-command-read-args))
   (require 'eshell)
-  (magit-mode-display-buffer (magit-process-buffer)
+  (magit-mode-display-buffer (magit-process-buffer nil t)
                              'magit-process-mode 'pop-to-buffer)
   (goto-char (point-max))
   (let ((default-directory directory))


### PR DESCRIPTION
Was getting `Wrong type argument: bufferp, nil` when calling `magit-git-command` before any other git-running commands.

eg:
`emacs -Q -L . -L ../dash/ -l magit -f magit-status --eval '(magit-git-command "status" default-directory)'`

