### PR TITLE
Add send-email to magit-patch-popup

### DIFF
--- a/magit-git.el
+++ b/magit-git.el
@@ -980,6 +980,17 @@ Return a list of two integers: (A>B B>A)."
                                  (magit-remote-at-point)
                                  (magit-get-remote))))))
 
+(defun magit-read-repeated-options (prompt &optional option)
+  "Read multiple comma-separated strings and repeat option for each.
+
+PROMPT is prepended to each token in the split input string in
+addition to being used as the prompt.
+
+If the empty string is given, no options are returned."
+  (mapcar (lambda (x) (and (not (string= "" x))
+                           (concat (or option prompt) x)))
+          (split-string (read-from-minibuffer prompt) ",")))
+
 ;;; Variables
 
 (defun magit-get (&rest keys)

--- a/magit-git.el
+++ b/magit-git.el
@@ -989,9 +989,8 @@ OPTION is prepended to each token of the split string, resulting
 in repeating options. If not given, prompt is used instead.
 
 If the empty string is given, no options are returned."
-  (mapcar (lambda (x) (and (not (string= "" x))
-                           (concat (or option prompt) x)))
-          (split-string (read-from-minibuffer (concat prompt ": ")) ",")))
+  (mapcar (lambda (x) (concat (or option prompt) x))
+          (completing-read-multiple (concat prompt ": ") nil nil nil)))
 
 ;;; Variables
 

--- a/magit-git.el
+++ b/magit-git.el
@@ -989,8 +989,8 @@ OPTION is prepended to each token of the split string, resulting
 in repeating options. If not given, prompt is used instead.
 
 If the empty string is given, no options are returned."
-  (mapcar (lambda (x) (concat (or option prompt) x))
-          (completing-read-multiple (concat prompt ": ") nil nil nil)))
+  (--map (concat (or option prompt) it)
+         (completing-read-multiple (concat prompt ": ") nil nil nil)))
 
 ;;; Variables
 

--- a/magit-git.el
+++ b/magit-git.el
@@ -980,17 +980,23 @@ Return a list of two integers: (A>B B>A)."
                                  (magit-remote-at-point)
                                  (magit-get-remote))))))
 
-(defun magit-read-repeated-options (prompt &optional option)
-  "Read multiple comma-separated strings and repeat option for each.
+(defun magit-repeat-options (opt &optional required)
+  "Convert --opt=a,b,c into --opt=a --opt=b --opt=c.
 
-PROMPT is concatenated with a colon and passed to read-from-minibuffer.
+When called within a popup, this retrieves the current arguments
+matching OPT and repeats the option for each comma-separated
+value given to the argument.  The argument may be specified
+multiple times.
 
-OPTION is prepended to each token of the split string, resulting
-in repeating options. If not given, prompt is used instead.
-
-If the empty string is given, no options are returned."
-  (--map (concat (or option prompt) it)
-         (completing-read-multiple (concat prompt ": ") nil nil nil)))
+OPT is the option '--opt='
+REQUIRED will cause a 'user-error' if the option is not specified"
+  (let ((args (--mapcat (split-string it ",") (magit-current-popup-args opt))))
+    (when (and (not args) required)
+      (user-error "Required option %s not specified" opt))
+    (setq magit-current-popup-args
+          (--remove (-contains? (magit-current-popup-args opt) it)
+                    magit-current-popup-args))
+    (--map (if (string-prefix-p opt it) it (concat opt it)) args)))
 
 ;;; Variables
 

--- a/magit-git.el
+++ b/magit-git.el
@@ -983,13 +983,15 @@ Return a list of two integers: (A>B B>A)."
 (defun magit-read-repeated-options (prompt &optional option)
   "Read multiple comma-separated strings and repeat option for each.
 
-PROMPT is prepended to each token in the split input string in
-addition to being used as the prompt.
+PROMPT is concatenated with a colon and passed to read-from-minibuffer.
+
+OPTION is prepended to each token of the split string, resulting
+in repeating options. If not given, prompt is used instead.
 
 If the empty string is given, no options are returned."
   (mapcar (lambda (x) (and (not (string= "" x))
                            (concat (or option prompt) x)))
-          (split-string (read-from-minibuffer prompt) ",")))
+          (split-string (read-from-minibuffer (concat prompt ": ")) ",")))
 
 ;;; Variables
 

--- a/magit-remote.el
+++ b/magit-remote.el
@@ -282,8 +282,8 @@ branch as default."
   "Emails patches for range. Prompts for To and Cc fields."
   (interactive
    (list (magit-read-range-or-commit "Files, directories, rev-lists")
-         (magit-read-repeated-options "To email,s: " "--to=")
-         (magit-read-repeated-options "Cc email,s: " "--cc=")
+         (magit-read-repeated-options "To email,s" "--to=")
+         (magit-read-repeated-options "Cc email,s" "--cc=")
          (magit-patch-arguments)))
   (magit-run-git "send-email" range to cc args))
 

--- a/magit-remote.el
+++ b/magit-remote.el
@@ -260,6 +260,7 @@ branch as default."
                   magit-diff-select-algorithm)
               (?o "Output directory" "--output-directory="))
   :actions  '((?p "Format patches"   magit-format-patch)
+              (?s "Send email"       magit-send-email)
               (?r "Request pull"     magit-request-pull))
   :default-action 'magit-format-patch)
 
@@ -275,6 +276,13 @@ branch as default."
                (format "%s~..%s" range range))))
          (magit-patch-arguments)))
   (magit-run-git "format-patch" range args))
+
+;;;###autoload
+(defun magit-send-email (range args)
+  (interactive
+   (list (magit-read-range-or-commit "Files, directories, rev-lists")
+         (magit-patch-arguments)))
+   (magit-run-git "send-email" range args))
 
 ;;;###autoload
 (defun magit-request-pull (url start end)

--- a/magit-remote.el
+++ b/magit-remote.el
@@ -282,8 +282,8 @@ branch as default."
   "Emails patches for range. Prompts for To and Cc fields."
   (interactive
    (list (magit-read-range-or-commit "Files, directories, rev-lists")
-         (magit-read-repeated-options "To email,s" "--to=")
-         (magit-read-repeated-options "Cc email,s" "--cc=")
+         (magit-repeat-options "--to=" t)
+         (magit-repeat-options "--cc=")
          (magit-patch-arguments)))
   (magit-run-git "send-email" range to cc args))
 

--- a/magit-remote.el
+++ b/magit-remote.el
@@ -282,19 +282,10 @@ branch as default."
   "Emails patches for range. Prompts for To and Cc fields."
   (interactive
    (list (magit-read-range-or-commit "Files, directories, rev-lists")
-         (magit-remote-read-emails "To" "to")
-         (magit-remote-read-emails "Cc" "cc")
+         (magit-read-repeated-options "To email,s: " "--to=")
+         (magit-read-repeated-options "Cc email,s: " "--cc=")
          (magit-patch-arguments)))
   (magit-run-git "send-email" range to cc args))
-
-(defun magit-remote-read-emails (prompt option)
-  "Read multiple comma-separated emails and repeat option for each.
-
-PROMPT is the string preprended to ' email,s: ' for 'To email,s: '.
-OPTION is the string inserted between '--' and '=' for '--to='."
-  (mapcar (lambda (email) (and (not (string= "" email))
-                               (concat "--" option "=" email)))
-          (split-string (read-from-minibuffer (concat prompt " email,s: ")) ",")))
 
 ;;;###autoload
 (defun magit-request-pull (url start end)

--- a/magit-remote.el
+++ b/magit-remote.el
@@ -278,11 +278,23 @@ branch as default."
   (magit-run-git "format-patch" range args))
 
 ;;;###autoload
-(defun magit-send-email (range args)
+(defun magit-send-email (range to cc args)
+  "Emails patches for range. Prompts for To and Cc fields."
   (interactive
    (list (magit-read-range-or-commit "Files, directories, rev-lists")
+         (magit-remote-read-emails "To" "to")
+         (magit-remote-read-emails "Cc" "cc")
          (magit-patch-arguments)))
-   (magit-run-git "send-email" range args))
+  (magit-run-git "send-email" range to cc args))
+
+(defun magit-remote-read-emails (prompt option)
+  "Read multiple comma-separated emails and repeat option for each.
+
+PROMPT is the string preprended to ' email,s: ' for 'To email,s: '.
+OPTION is the string inserted between '--' and '=' for '--to='."
+  (mapcar (lambda (email) (and (not (string= "" email))
+                               (concat "--" option "=" email)))
+          (split-string (read-from-minibuffer (concat prompt " email,s: ")) ",")))
 
 ;;;###autoload
 (defun magit-request-pull (url start end)


### PR DESCRIPTION
Per feature request #1747.

This isn't done, but I figured a PR would be a better place to continue discussing it than the issue.

* [x] Accept files and directories in addition to range
* [ ] Complete for files
* [ ] Add subject option

This adds `magit-read-repeated-options` for repeating an option (like `--to=`) using comma-separated input. It would be much better to use this as the reader for the popup option.

Currently `magit-send-email` interactively prompts for To and Cc fields, and should probably prompt for Subject. The man page says subject is prompted for, but it actually seems to default to the `subject-prefix` that `format-patch` uses.

There are thoughts about making `send-email` a separate popup from `format-patch`, but they do share some options.