### PR TITLE
magit-blame-detect-copies-moves for magit-blame

### DIFF
--- a/magit-blame.el
+++ b/magit-blame.el
@@ -52,6 +52,12 @@
   :group 'magit-blame
   :type 'string)
 
+(defcustom magit-blame-detect-copies-moves nil
+  "Detect moved or copied lines within a file. Enables options -M
+and -C in git blame."
+  :group 'magit-blame
+  :type 'boolean)
+
 (defface magit-blame-header
   '((t :inherit magit-section-title))
   "Face for blame header."
@@ -140,6 +146,8 @@
       (save-restriction
         (with-temp-buffer
           (apply 'magit-git-insert "blame" "--porcelain"
+                 (when magit-blame-detect-copies-moves "-M")
+                 (when magit-blame-detect-copies-moves "-C")
                  `(,@(and magit-blame-ignore-whitespace (list "-w")) "--"
                    ,(file-name-nondirectory (buffer-file-name buffer))))
           (magit-blame-parse buffer (current-buffer)))))))


### PR DESCRIPTION
The `-M` `-C` options passed to git blame make for a nice enhancement. I made this an option with the default turned off.

Manual entry for `-M`:

> Detect moved or copied lines within a file. When a commit moves or
> copies a block of lines (e.g. the original file has A and then B,
> and the commit changes it to B and then A), the traditional blame
> algorithm notices only half of the movement and typically blames the
> lines that were moved up (i.e. B) to the parent and assigns blame to
> the lines that were moved down (i.e. A) to the child commit.

Manual for `-C`:

> In addition to -M, detect lines moved or copied from other files that
> were modified in the same commit. This is useful when you reorganize
> your program and move code around across files. When this option is
> given twice, the command additionally looks for copies from other
> files in the commit that creates the file.