### PR TITLE
magit-file-relative-name: fix for W32 with Cygwin

### DIFF
--- a/magit-git.el
+++ b/magit-git.el
@@ -371,7 +371,7 @@ If the file is not inside a Git repository then return nil."
   (when file
     (setq file (file-truename file))
     (--when-let (magit-get-top-dir (file-name-directory file))
-      (substring file (length it)))))
+      (substring file (length (expand-file-name it))))))
 
 (defun magit-file-tracked-p (file)
   (magit-git-success "ls-files" "--error-unmatch" file))


### PR DESCRIPTION
I came across this issue via  `magit-blame`, which errors out on my Windows box at work. I believe it only affects people using a W32 build of Emacs but with a shell and git from Cygwin, which I suspect is rare. As such, I think it would be fair to consider it low priority and wait on until after the release if you see any issues here.

The cause of the error is that  `magit-file-relative-name` ends up comparing the lengths of `"c:/path/to/repo/file.el"` (the file name, from Emacs) and `"/path/to/repo"` (the repo dir, from git), so the result is `"o/file.el"` (two extraneous characters at the front).

This commit fixes it by calling `expand-file-name` on the repo dir from git, which ensures it has the leading drive letter, like the file.

It works for me without issue on Windows, Linux, and Mac, and I can't think of any gotchas from the call to `expand-file-name`, so I think it's a safe change - but you know how that can go.

Thanks for all your work on Magit. It's truly a pleasure to use, and `next` is better than ever.