### PR TITLE
Require at least Git-1.9.4 and Emacs-24.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ provide a unified interface to various version control systems, Magit
 only supports Git and can therefore better take advantage of its
 native features.
 
-*Magit 2.0.50 requires at least GNU Emacs 24.1 and Git 1.9.1.*
+*Magit 2.0.50 requires at least GNU Emacs 24.2 and Git 1.9.1.*
 
 Installation
 ============

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ provide a unified interface to various version control systems, Magit
 only supports Git and can therefore better take advantage of its
 native features.
 
-*Magit 2.0.50 requires at least GNU Emacs 24.2 and Git 1.9.1.*
+*Magit 2.0.50 requires at least GNU Emacs 24.2 and Git 1.9.4.*
 
 Installation
 ============

--- a/magit-pkg.el
+++ b/magit-pkg.el
@@ -1,4 +1,4 @@
 (define-package "magit" "2.0.50"
   "Control Git from Emacs"
-  '((cl-lib "0.5")
+  '((emacs "24.2")
     (dash "2.10.0")))

--- a/magit.el
+++ b/magit.el
@@ -17,7 +17,7 @@
 
 ;; Keywords: vc tools
 
-;; Magit requires at least GNU Emacs 24.1 and Git 1.9.1.
+;; Magit requires at least GNU Emacs 24.2 and Git 1.9.1.
 
 ;; Magit is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
@@ -47,8 +47,8 @@
 
 ;;; Code:
 
-(when (version< emacs-version "24.1")
-  (error "Magit requires at least GNU Emacs 24.1"))
+(when (version< emacs-version "24.2")
+  (error "Magit requires at least GNU Emacs 24.2"))
 
 (require 'cl-lib)
 (require 'dash)

--- a/magit.el
+++ b/magit.el
@@ -47,9 +47,6 @@
 
 ;;; Code:
 
-(when (version< emacs-version "24.2")
-  (error "Magit requires at least GNU Emacs 24.2"))
-
 (require 'cl-lib)
 (require 'dash)
 
@@ -1892,11 +1889,43 @@ Git, and Emacs in the echo area.\n\n(fn)"
         (error "Cannot determine Magit's version")))
     magit-version))
 
+(defun magit-assert-satisfied-dependencies ()
+  (let ((version (substring (magit-git-string "version") 12)))
+    (when (and version (version< version "1.9.4"))
+      (display-warning :error (format "\
+Magit requires Git >= 1.9.4, you are using %s.
+
+If this comes as a surprise to you, because you do actually have
+a newer version installed, then that probably means that the
+older version happens to appear earlier on the `$PATH'.  If you
+always start Emacs from a shell, then that can be fixed in the
+shell's init file.  If you start Emacs by clicking on an icon,
+or using some sort of application launcher, then you probably
+have to adjust the environment as seen by graphical interface.
+For X11 something like ~/.xinitrc should work.
+
+If you use Tramp to work inside remote Git repositories, then you
+have to make sure a suitable Git is used on the remote machines
+too.\n" version))))
+  (when (version< emacs-version "24.2")
+    (display-warning :error (format "\
+Magit requires Emacs >= 24.2, you are using %s.
+
+If this comes as a surprise to you, because you do actually have
+a newer version installed, then that probably means that the
+older version happens to appear earlier on the `$PATH'.  If you
+always start Emacs from a shell, then that can be fixed in the
+shell's init file.  If you start Emacs by clicking on an icon,
+or using some sort of application launcher, then you probably
+have to adjust the environment as seen by graphical interface.
+For X11 something like ~/.xinitrc should work.\n" emacs-version))))
+
+(add-hook 'after-init-hook #'magit-assert-satisfied-dependencies)
+
 (defvar magit-last-seen-setup-instructions "0")
 
 (defun magit-maybe-show-setup-instructions ()
   (when (version< magit-last-seen-setup-instructions "1.4.0")
-    (require 'warnings)
     (display-warning :warning "for Magit >= 1.4.0
 
 Before running Git, Magit by default reverts all unmodified
@@ -1923,7 +1952,7 @@ Then you also have to add the following line to your init file
 to prevent this message from being shown again when you restart
 Emacs:
 
-  (setq magit-last-seen-setup-instructions \"1.4.0\")")))
+  (setq magit-last-seen-setup-instructions \"1.4.0\")\n")))
 
 (add-hook 'after-init-hook #'magit-maybe-show-setup-instructions)
 

--- a/magit.el
+++ b/magit.el
@@ -17,7 +17,7 @@
 
 ;; Keywords: vc tools
 
-;; Magit requires at least GNU Emacs 24.2 and Git 1.9.1.
+;; Magit requires at least GNU Emacs 24.2 and Git 1.9.4.
 
 ;; Magit is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by


### PR DESCRIPTION
and if these dependencies are not satisfied complain at startup.

This will force some users to finally update. I am sorry for the inconvenience, but the cost of supporting older versions is getting to high.

This already is a compromise. I would have preferred to update to `24.4` and `2.*.*`. The former can be delayed until we update to nest release `25.1` (which will provide some very welcome additions for the seasoned elisper). Updating to `2.0.0` would have been nice, because that's when the defaults for pushing changed in Git, but that can be delayed until Magit itself gets the next pushing remake *and* `2.*.*` is available for MS Windows (why is that lagging behind so much?!).