### PR TITLE
don't spam "revert inhibited" in blame mode

### DIFF
--- a/magit-blame.el
+++ b/magit-blame.el
@@ -169,8 +169,7 @@ and then turned on again when turning on the latter."
 (defadvice auto-revert-handler (around magit-blame activate)
   "If Magit-Blame mode is on, then do nothing.
 See #1731."
-  (if magit-blame-mode
-      (message "Reverting %s inhibited due to magit-blame-mode" buffer-file-name)
+  (unless magit-blame-mode
     ad-do-it))
 
 ;;;###autoload (autoload 'magit-blame-popup "magit-blame" nil t)


### PR DESCRIPTION
Hi, so I know Magit is in feature freeze, but I have a small bug fix for the `next` branch. I would
consider it a bug fix anyway:

If the user has turned on `global-auto-revert-mode`, and then does a `magit-blame`, the user will
start getting the message "Reverting (buffer) inhibited due to magit-blame-mode" every few seconds
(depending on the value of `auto-revert-interval`). This seems pretty spammy to me. It's especially
annoying when you are trying to type in the minibuffer, and this keeps popping up.

So could we remove this message? My opinion is that it does more harm than good. The original author meant well I'm sure, but I'm guessing they didn't use `global-auto-revert-mode`, or perhaps their `auto-revert-interval` is much higher then mine.