### PR TITLE
use ido-completing-read+ for all Ido completion

### DIFF
--- a/magit-utils.el
+++ b/magit-utils.el
@@ -47,7 +47,7 @@
 (require 'dash)
 
 (eval-when-compile (require 'ido))
-(declare-function completing-read-ido 'ido-ubiquitous)
+(declare-function ido-completing-read+ 'ido-completing-read+)
 
 (defvar magit-backup-mode)
 (defvar magit-backup-untracked)
@@ -278,29 +278,20 @@ results in additional differences."
   (prompt choices &optional predicate require-match initial-input hist def)
   "Ido-based `completing-read' almost-replacement.
 
-`ido-completing-read' is not suitable as a replacement for
-`completing-read', because it lacks essential features and
-has bugs.  Instead use the wrapper `completing-read-ido'
-from the `ido-ubiquitous' package."
-  (require 'ido-ubiquitous)
-  (let* (;; Pretend these modes are on because otherwise we would
-         ;; end up using regular `completing-read'.
-         (ido-mode t)
-         (ido-ubiquitous-mode t)
-         ;; Keep `completing-read-ido' from falling back to regular
-         ;; `completing-read' and force use of `enable-old' style.
-         (ido-ubiquitous-next-override 'enable-old)
-         (reply (completing-read-ido
-                 prompt
-                 ;; Unlike `completing-read', `ido-completing-read'
-                 ;; and `completing-read-ido' cannot handle alists.
-                 (if (consp (car choices))
-                     (mapcar #'car choices)
-                   choices)
-                 predicate require-match initial-input hist def)))
-    (or (and (consp (car choices))
-             (cdr (assoc reply choices)))
-        reply)))
+Unfortunately `ido-completing-read' is not suitable as a
+drop-in replacement for `completing-read', instead we use
+`ido-completing-read+' from third-party the package by the
+same name."
+  (if (require 'ido-completing-read+ nil t)
+      (ido-completing-read+ prompt choices predicate require-match
+                            initial-input hist def)
+    (display-warning :error "ido-completing-read+ is not installed
+
+To use Ido completion with Magit you need to install the
+third-party `ido-completing-read+' packages.  Falling
+back to built-in `completing-read' for now.")
+    (magit-builtin-completing-read prompt choices predicate require-match
+                                   initial-input hist def)))
 
 (defun magit-prompt-with-default (prompt def)
   (if (and def (> (length prompt) 2)

--- a/magit.el
+++ b/magit.el
@@ -955,9 +955,10 @@ Non-interactively DIRECTORY is (re-)initialized unconditionally."
               (?u "Set upstream"      magit-branch-set-upstream)
               (?k "Delete"            magit-branch-delete)
               (?c "Create"            magit-branch)
-              (?e "Set description"   magit-branch-edit-description)
+              (?U "Unset upstream"    magit-branch-unset-upstream)
               (?r "Rename"            magit-branch-rename)
-              (?B "Create & Checkout" magit-branch-and-checkout))
+              (?B "Create & Checkout" magit-branch-and-checkout)
+              (?e "Set description"   magit-branch-edit-description))
   :default-arguments '("--track")
   :default-action 'magit-checkout
   :max-action-columns 3)
@@ -1067,14 +1068,18 @@ defaulting to the branch at point."
 (defun magit-branch-set-upstream (branch upstream)
   "Change the UPSTREAM branch of BRANCH."
   (interactive
-   (let ((branch (magit-read-local-branch "Change upstream of branch")))
+   (let  ((branch (magit-read-local-branch "Change upstream of branch")))
      (list branch (magit-completing-read
-                   "Change upstream to branch (empty to unset)"
+                   "Change upstream to branch"
                    (delete branch (magit-list-branch-names))
                    nil nil nil 'magit-revision-history))))
-  (if upstream
-      (magit-run-git "branch" (concat "--set-upstream-to=" upstream) branch)
-    (magit-run-git "branch" "--unset-upstream" branch)))
+  (magit-run-git "branch" (concat "--set-upstream-to=" upstream) branch))
+
+;;;###autoload
+(defun magit-branch-unset-upstream (branch)
+  "Unset the upstream branch of BRANCH."
+  (interactive (list (magit-read-local-branch "Unset upstream of branch")))
+  (magit-run-git "branch" "--unset-upstream" branch))
 
 ;;;###autoload
 (defun magit-branch-rename (old new &optional force)


### PR DESCRIPTION
Fixes #1781.

Add new command `magit-branch-unset-upstream` to
avoid a complication, with the completion DEFAULT.