### PR TITLE
Copyedit documentation

### DIFF
--- a/magit.el
+++ b/magit.el
@@ -7782,28 +7782,27 @@ You have just updated to version 1.4.0 of Magit, and have to
 make a choice.
 
 Before running Git, Magit by default reverts all unmodified
-buffers which visit files tracked in the current repository.
-This can potentially lead to dataloss so you might want to
-disable this by adding the following line to your init file:
+buffers that visit files tracked in the current repository.  This
+can potentially lead to data loss, so you might want to disable
+this by adding the following line to your init file:
 
   (setq magit-auto-revert-mode nil)
 
-The risk is not as high as it might seem.  If snapshots on Melpa
-and Melpa-Stable had this enabled for a long time, so if you did
-not experience any dataloss in the past, then you should probably
-keep this enabled.
+The risk is not as high as it might seem.  Snapshots on MELPA and
+MELPA-Stable have had this enabled for a long time, so if you
+have not experienced any data loss in the past, you should
+probably keep this enabled.
 
 Keeping this mode enabled is only problematic if you, for
-example, use `git reset --hard REV' or `magit-reset-head-hard',
+example, use `git reset --hard REV' or `magit-reset-head-hard'
 and expect Emacs to preserve the old state of some file in a
-buffer.  If you turn of this mode then file-visiting buffers and
-Magit buffer will no longer by in sync, which can be confusing
-and complicates many operations.  Also note that it is possible
-to undo a buffer revert using `C-x u' (`undo').
+buffer.  If you turn off this mode then file-visiting buffers and
+the Magit buffer will no longer be in sync, which can be confusing
+and would complicate many operations.  Note that it is possible
+to undo an automatic buffer reversion using `C-x u' (`undo').
 
-Then you also have to add the following line to your init file
-to prevent this message from being shown again when you restart
-Emacs:
+To prevent this message from being shown each time you start
+Emacs, you must add the following line to your init file:
 
   (setq magit-last-seen-setup-instructions \"1.4.0\")
 


### PR DESCRIPTION
Function `magit-maybe-show-setup-instructions` presents a warning and
some configuration advice when the `magit-last-seen-setup-instructions`
variable's value suggests that the user hasn't seen it yet. Adjust the
language for an American English-appropriate tone.