### PR TITLE
DOC : Correct load path in install directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Then compile the libraries:
 
 Finally add this to your init file:
 
-    (add-to-list 'load-path "~/emacs.d/site-lisp/magit")
+    (add-to-list 'load-path "~/.emacs.d/site-lisp/magit")
     (require 'magit)
 
 To update Magit use:


### PR DESCRIPTION
There is a missing `.` from the path to add to the `.emacs` as compared to the directions in the previous code blocks.