### PR TITLE
Makefile: follow links in finding libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ statsdir    ?= ./stats
 ELPA_DIR    ?= $(HOME)/.emacs.d/elpa
 
 CL_LIB_DIR ?= $(shell \
-  find $(ELPA_DIR) -maxdepth 1 -regex '.*/cl-lib-[.0-9]*' 2> /dev/null | \
+  find -L $(ELPA_DIR) -maxdepth 1 -regex '.*/cl-lib-[.0-9]*' 2> /dev/null | \
   sort | tail -n 1)
 ifeq "$(CL_LIB_DIR)" ""
   CL_LIB_DIR = ../cl-lib
 endif
 
 DASH_DIR ?= $(shell \
-  find $(ELPA_DIR) -maxdepth 1 -regex '.*/dash-[.0-9]*' 2> /dev/null | \
+  find -L $(ELPA_DIR) -maxdepth 1 -regex '.*/dash-[.0-9]*' 2> /dev/null | \
   sort | tail -n 1)
 ifeq "$(DASH_DIR)" ""
   DASH_DIR = ../dash


### PR DESCRIPTION
If the ELPA_DIR is a link to another directory, ``dash`` etc were not found.  With the ```-L``` option find succeeds again.  I cannot think of any drawbacks this has, since emacs finds the library one way or the other.