### PR TITLE
Give users more control over buffer reverts

### DIFF
--- a/magit-mode.el
+++ b/magit-mode.el
@@ -518,7 +518,7 @@ Uses the buffer-local `magit-refresh-function'."
   (setq magit-refresh-start-time (current-time))
   (when magit-refresh-function
     (when magit-refresh-verbose
-      (message "Refreshing %s..." (current-buffer)))
+      (message "Refreshing buffer `%s'..." (buffer-name)))
     (let* ((buffer (current-buffer))
            (windows
             (--mapcat (with-selected-window it
@@ -549,7 +549,7 @@ Uses the buffer-local `magit-refresh-function'."
       (magit-section-update-highlight)
       (set-buffer-modified-p nil))
     (when magit-refresh-verbose
-      (message "Refreshing %s...done (%.3fs)" (current-buffer)
+      (message "Refreshing buffer `%s'...done (%.3fs)" (buffer-name)
                (float-time (time-subtract (current-time)
                                           magit-refresh-start-time))))))
 

--- a/magit-mode.el
+++ b/magit-mode.el
@@ -88,6 +88,12 @@ or might not be what you want."
   :group 'magit
   :type 'boolean)
 
+(defcustom magit-refresh-verbose nil
+  "Whether to revert Magit buffers verbosely."
+  :package-version '(magit . "2.1.0")
+  :group 'magit-modes
+  :type 'boolean)
+
 (defcustom magit-refresh-buffer-hook nil
   "Normal hook for `magit-revert-buffer' to run after refreshing."
   :package-version '(magit . "2.1.0")
@@ -509,7 +515,6 @@ tracked in the current repository."
     (with-current-buffer buffer (magit-refresh-buffer)))
   (magit-revert-buffers t))
 
-(defvar magit-refresh-verbose nil)
 (defvar-local magit-refresh-start-time nil)
 
 (defun magit-refresh-buffer ()

--- a/magit-mode.el
+++ b/magit-mode.el
@@ -45,7 +45,6 @@
 (declare-function magit-blame-mode 'magit-blame)
 (defvar magit-blame-mode)
 
-(require 'autorevert)
 (require 'format-spec)
 (require 'help-mode)
 

--- a/magit-process.el
+++ b/magit-process.el
@@ -193,7 +193,7 @@ before use.
 After Git returns, the current buffer (if it is a Magit buffer)
 as well as the current repository's status buffer are refreshed.
 Unmodified buffers visiting files that are tracked in the current
-repository are reverted if `magit-auto-revert-mode' is active.
+repository are reverted if `magit-revert-buffers' is non-nil.
 
 Process output goes into a new section in a buffer specified by
 variable `magit-process-buffer-name-format'."
@@ -210,8 +210,6 @@ before use.
 
 After Git returns, the current buffer (if it is a Magit buffer)
 as well as the current repository's status buffer are refreshed.
-File-visiting buffers are *not* reverted, regardless of whether
-`magit-auto-revert-mode' is active or not.
 
 Process output goes into a new section in a buffer specified by
 variable `magit-process-buffer-name-format'."
@@ -260,7 +258,7 @@ flattened before use.
 After Git returns, the current buffer (if it is a Magit buffer)
 as well as the current repository's status buffer are refreshed.
 Unmodified buffers visiting files that are tracked in the current
-repository are reverted if `magit-auto-revert-mode' is active.
+repository are reverted if `magit-revert-buffers' is non-nil.
 When INPUT is nil then do not refresh any buffers.
 
 This function actually starts a asynchronous process, but it then
@@ -294,7 +292,7 @@ After Git returns some buffers are refreshed: the buffer that was
 current when this function was called (if it is a Magit buffer
 and still alive), as well as the respective Magit status buffer.
 Unmodified buffers visiting files that are tracked in the current
-repository are reverted if `magit-auto-revert-mode' is active.
+repository are reverted if `magit-revert-buffers' is non-nil.
 
 See `magit-start-process' for more information."
   (message "Running %s %s" magit-git-executable
@@ -310,8 +308,6 @@ Display the command line arguments in the echo area.
 After Git returns some buffers are refreshed: the buffer that was
 current when this function was called (if it is a Magit buffer
 and still alive), as well as the respective Magit status buffer.
-File-visiting buffers are *not* reverted, regardless of whether
-`magit-auto-revert-mode' is active or not.
 
 See `magit-start-process' for more information."
   (let ((inhibit-magit-revert t))
@@ -327,8 +323,6 @@ Display the command line arguments in the echo area.
 After Git returns some buffers are refreshed: the buffer that was
 current when this function was called (if it is a Magit buffer
 and still alive), as well as the respective Magit status buffer.
-File-visiting buffers are *not* reverted, regardless of whether
-`magit-auto-revert-mode' is active or not.
 
 See `magit-start-process' and `with-editor' for more information."
   (with-editor "GIT_EDITOR"
@@ -350,7 +344,7 @@ If the sequence stops at a commit, make the section representing
 that commit the current section by moving `point' there.
 
 Unmodified buffers visiting files that are tracked in the current
-repository are reverted if `magit-auto-revert-mode' is active.
+repository are reverted if `magit-revert-buffers' is non-nil.
 
 See `magit-start-process' and `with-editor' for more information."
   (with-editor "GIT_EDITOR"
@@ -375,7 +369,7 @@ After Git returns some buffers are refreshed: the buffer that was
 current when this function was called (if it is a Magit buffer
 and still alive), as well as the respective Magit status buffer.
 Unmodified buffers visiting files that are tracked in the current
-repository are reverted if `magit-auto-revert-mode' is active.
+repository are reverted if `magit-revert-buffers' is non-nil.
 
 See `magit-start-process' for more information."
   (run-hooks 'magit-pre-start-git-hook)
@@ -401,7 +395,7 @@ buffer that was current when `magit-start-process' was called (if
 it is a Magit buffer and still alive), as well as the respective
 Magit status buffer.  Unmodified buffers visiting files that are
 tracked in the current repository are reverted if
-`magit-auto-revert-mode' is active."
+`magit-revert-buffers' is non-nil."
   (cl-destructuring-bind (process-buf . section)
       (magit-process-setup program args)
     (let* ((process-connection-type

--- a/magit-process.el
+++ b/magit-process.el
@@ -41,7 +41,6 @@
 (require 'magit-git)
 (require 'magit-mode)
 
-(require 'autorevert)
 
 (defvar magit-status-buffer-name-format)
 

--- a/magit.el
+++ b/magit.el
@@ -1927,7 +1927,7 @@ Git, and Emacs in the echo area.\n\n(fn)"
         (error "Cannot determine Magit's version")))
     magit-version))
 
-(defun magit-assert-satisfied-dependencies ()
+(defun magit-startup-asserts ()
   (let ((version (substring (magit-git-string "version") 12)))
     (when version
       (when (string-match "^\\([0-9]+\\.[0-9]+\\.[0-9]+\\)" version)
@@ -1959,40 +1959,7 @@ always start Emacs from a shell, then that can be fixed in the
 shell's init file.  If you start Emacs by clicking on an icon,
 or using some sort of application launcher, then you probably
 have to adjust the environment as seen by graphical interface.
-For X11 something like ~/.xinitrc should work.\n" emacs-version))))
-
-(add-hook 'after-init-hook #'magit-assert-satisfied-dependencies)
-
-(defvar magit-last-seen-setup-instructions "0")
-
-(defun magit-maybe-show-setup-instructions ()
-  (when (version< magit-last-seen-setup-instructions "1.4.0")
-    (display-warning :warning "for Magit >= 1.4.0
-
-Before running Git, Magit by default reverts all unmodified
-buffers that visit files tracked in the current repository.
-This can potentially lead to data loss, so you might want to
-disable this by adding the following line to your init file:
-
-  (setq magit-auto-revert-mode nil)
-
-The risk is not as high as it might seem.  Snapshots on Melpa
-and Melpa-Stable have had this enabled for a long time, so if
-you have not experienced any data loss in the past, you should
-probably keep this enabled.
-
-Keeping this mode enabled is only problematic if you, for
-example, use `git reset --hard REV' or `magit-reset-head-hard'
-*and* expect Emacs to preserve the old state of some file in a
-buffer.  If you turn off this mode then file-visiting buffers and
-the Magit buffer will no longer be in sync, which can be confusing
-and would complicate many operations.  Note that it is possible
-to undo an automatic buffer reversion using `C-x u' (`undo').
-
-To prevent this message from being shown each time you start
-Emacs, you must add the following line to your init file:
-
-  (setq magit-last-seen-setup-instructions \"1.4.0\")\n"))
+For X11 something like ~/.xinitrc should work.\n" emacs-version)))
   (when (featurep 'magit-log-edit)
     (display-warning :error "magit-log-edit has to be removed
 
@@ -2004,7 +1971,7 @@ obsolete library getting in the way.  Then restart Emacs.
 You might also want to read:
 https://github.com/magit/magit/wiki/Emacsclient")))
 
-(add-hook 'after-init-hook #'magit-maybe-show-setup-instructions)
+(add-hook 'after-init-hook #'magit-startup-asserts)
 
 (provide 'magit)
 


### PR DESCRIPTION
It's now possible to always be asked before buffers are reverted, or to do the reverts asynchronously.

The old mode `magit-auto-revert-mode` is replaced with a new non-boolean option `magit-revert-buffers`. The default value is `usage` which behaves like enabling the mode used to do, except that it shows an annoying message at the end with usage information. This let's us keep the intended behavior (but forces us to disable the usage information) while at the same time it avoids killing puppies.

This addresses #1809, #1807, #1803, and #1783; and replaces older approaches to adress these issues.