### PR TITLE
Makefile: make paths work on cygwin with NTEmacs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,15 @@ ifeq "$(DASH_DIR)" ""
   DASH_DIR = ../dash
 endif
 
-LOAD_PATH ?= -L . -L $(CL_LIB_DIR) -L $(DASH_DIR)
+CYGPATH := $(shell cygpath --version 2>/dev/null)
+
+ifdef CYGPATH
+  LOAD_PATH ?= -L . -L $(shell cygpath --mixed $(CL_LIB_DIR)) -L $(shell cygpath --mixed $(DASH_DIR))
+  CURDIR_SANE = $(shell cygpath --mixed $(CURDIR))
+else
+  LOAD_PATH ?= -L . -L $(CL_LIB_DIR) -L $(DASH_DIR)
+  CURDIR_SANE = $(CURDIR)
+endif
 
 EMACSBIN ?= emacs
 BATCH     = $(EMACSBIN) -batch -Q $(LOAD_PATH)
@@ -180,7 +188,7 @@ magit-autoloads.el: $(ELS)
 	(setq vc-handled-backends nil)\
 	(setq magit-last-seen-setup-instructions \"9999\")\
 	(defvar generated-autoload-file nil)\
-	(let ((generated-autoload-file \"$(CURDIR)/magit-autoloads.el\")\
+	(let ((generated-autoload-file \"$(CURDIR_SANE)/magit-autoloads.el\")\
 	      (make-backup-files nil))\
 	  (update-directory-autoloads \".\")))"
 


### PR DESCRIPTION
cygwin make passed cygwin paths to the emacs binary.  As a result, the library paths were not effective and autoloads could not be built.

This change makes magit's Makefile translate the paths in question, such that it builds properly on cygwin with NTEmacs.  It does not affect any non-cygwin system at all.  I did not test with cygwin's Emacs, but cygwin-built binaries generally can handle the mixed dos-drive-letter path notation as command-line arguments.