### PR TITLE
magit-show-commit: Fix commit check

### DIFF
--- a/magit-diff.el
+++ b/magit-diff.el
@@ -645,7 +645,7 @@ for a commit."
                                (file-name-as-directory
                                 (expand-file-name module (magit-toplevel)))
                              default-directory)))
-    (unless (magit-rev-verify "master")
+    (unless (magit-rev-verify commit)
       (user-error "%s is not a commit" commit))
     (-when-let (buffer (magit-mode-get-buffer
                         magit-revision-buffer-name-format


### PR DESCRIPTION
Check passed rev rather than master.

----

Just out of curiousity, in what circumstances did the previous check (fc3355a25af4cf88aa4b9825ee1901b0d901427c) fail?