### PR TITLE
therefor -> therefore

### DIFF
--- a/magit-diff.el
+++ b/magit-diff.el
@@ -200,7 +200,7 @@ The value is a list of cons cells.  The car is a regular
 expression, and the cdr is the value that applies to repositories
 whose directory matches the regular expression.  If more than one
 element matches, then the *last* element in the list applies.
-The default value should therefor come first in the list.
+The default value should therefore come first in the list.
 
 If the value is `tabs', highlight indentation with tabs.  If the
 value is an integer, highlight indentation with at least that

--- a/magit-mode.el
+++ b/magit-mode.el
@@ -160,7 +160,7 @@ NUMBER    An integer or float.  Revert the buffers asynchronously,
 (defcustom magit-not-reverted-hook '(magit-refresh-vc-mode-line)
   "Normal hook for `magit-revert-buffer' to run instead of reverting.
 Run if the visited file has not changed on disk and the buffer
-therefor does not have to be reverted."
+therefore does not have to be reverted."
   :package-version '(magit . "2.1.0")
   :group 'magit-modes
   :type 'hook

--- a/magit-section.el
+++ b/magit-section.el
@@ -877,7 +877,7 @@ If SELECTION is non-nil then it is a list of sections selected by
 the region.  The headings of these sections are then highlighted.
 
 This is a fallback for people who don't want to highlight the
-current section and therefor removed `magit-section-highlight'
+current section and therefore removed `magit-section-highlight'
 from `magit-section-highlight-hook'.
 
 This function is necessary to ensure that a representation of


### PR DESCRIPTION
"therefor" means "for or in exchange for that or this; for it", while "therefore" indicates logical consequence.

Thanks for Magit!