### PR TITLE
Add magit-insert-recent-commits to magit-status-sections-hook

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -110,7 +110,8 @@ at all."
     magit-insert-staged-changes
     magit-insert-stashes
     magit-insert-unpulled-commits
-    magit-insert-unpushed-commits)
+    magit-insert-unpushed-commits
+    magit-insert-recent-commits)
   "Hook run to insert sections into a status buffer."
   :package-version '(magit . "2.1.0")
   :group 'magit-status


### PR DESCRIPTION
`(magit-insert-recent-commits)` is amazing. Enable it by default.