### PR TITLE
Fix magit-popup-mode-map

### DIFF
--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -148,7 +148,7 @@ that without users being aware of it could lead to tears.
 
 (defvar magit-popup-mode-map
   (let ((map (make-sparse-keymap)))
-    (cl-loop for key from ?a to ?z
+    (cl-loop for key from ?A to ?z
              do (define-key map (char-to-string key) 'magit-invoke-popup-action))
     (define-key map [?$] 'magit-invoke-popup-action)
     (define-key map [?!] 'magit-invoke-popup-action)

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -148,7 +148,10 @@ that without users being aware of it could lead to tears.
 
 (defvar magit-popup-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap self-insert-command] 'magit-invoke-popup-action)
+    (cl-loop for key from ?a to ?z
+             do (define-key map (char-to-string key) 'magit-invoke-popup-action))
+    (define-key map [?$] 'magit-invoke-popup-action)
+    (define-key map [?!] 'magit-invoke-popup-action)
     (define-key map [?- t]        'magit-invoke-popup-switch)
     (define-key map [?= t]        'magit-invoke-popup-option)
     (define-key map [?\C-c ?\C-c] 'magit-popup-set-default-arguments)


### PR DESCRIPTION
Hi, I'm changing some self-insert-command's keys("a" and "c" keys) by using 
[my package](https://github.com/yuutayamada/mykie-el) from default function. 
But when I push "c", "c" to  commit, it didn't work and I got 
`Buffer is read-only: #<buffer *magit-commit-popup*>` message on mini buffer.

I seems the `magit-popup-mode-map` doesn't register
`magit-invoke-popup-action` when I changed keybinding from default's 
`self-insert-command`.

You can check this problem by configuring like below:

```lisp
;; please set this configuration before load magit
(defun foo()
  (interactive)
  (call-interactively 'self-insert-command))

(global-set-key "a" 'foo)
(global-set-key "$" 'foo)
(global-set-key "!" 'foo)
;; Then push above keys in magit's popup buffer
```