### PR TITLE
magit-mode: Don't bind M-w

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -253,7 +253,6 @@ has to confirm each save."
     (define-key map "\C-xa"  'magit-add-change-log-entry)
     (define-key map "\C-x4a" 'magit-add-change-log-entry-other-window)
     (define-key map "\C-w"   'magit-copy-as-kill)
-    (define-key map "\M-w"   'magit-copy-buffer-thing-as-kill)
     (define-key map [remap evil-previous-line] 'evil-previous-visual-line)
     (define-key map [remap evil-next-line] 'evil-next-visual-line)
     map)


### PR DESCRIPTION
It's quite common for users to want to kill things from magit
buffers (commit messages, diffs, etc).  Currently this isn't possible
since M-w is bound to `magit-copy-buffer-thing-as-kill`.  Fix this by
not binding M-w.  Users who want M-w bound to
`magit-copy-buffer-thing-as-kill` can bind it themselves.

Fixes #1958