### PR TITLE
magit-mode: Use `C-c C-w' for killing magit buffer things

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -253,7 +253,7 @@ has to confirm each save."
     (define-key map "\C-xa"  'magit-add-change-log-entry)
     (define-key map "\C-x4a" 'magit-add-change-log-entry-other-window)
     (define-key map "\C-w"   'magit-copy-as-kill)
-    (define-key map "\M-w"   'magit-copy-buffer-thing-as-kill)
+    (define-key map "\C-c\C-w"   'magit-copy-buffer-thing-as-kill)
     (define-key map [remap evil-previous-line] 'evil-previous-visual-line)
     (define-key map [remap evil-next-line] 'evil-next-visual-line)
     map)


### PR DESCRIPTION
It's quite common for users to want to kill things from magit
buffers (commit messages, diffs, etc).  Currently this isn't possible
since M-w is bound to `magit-copy-buffer-thing-as-kill'.  Fix this by
moving this binding to C-c C-w.

Fixes #1958