### PR TITLE
magit-log: add section hook for graph'd recent commits

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1052,6 +1052,17 @@ Show the last `magit-log-section-commit-count' commits."
     (magit-insert-log nil (cons (format "-%d" magit-log-section-commit-count)
                                 magit-log-section-args))))
 
+(defun magit-insert-recent-commits-graph (&optional collapse)
+  "Insert section showing recent commits, with decorations and
+graph annotations. Show the last `magit-log-section-commit-count'
+commits."
+  (magit-insert-section (recent nil collapse)
+    (magit-insert-heading "Recent commits:")
+    (magit-insert-log nil (list "--graph"
+                                "--decorate"
+                                (format "-%d" magit-log-section-commit-count)
+                                magit-log-section-args))))
+
 (defun magit-insert-unpulled-cherries ()
   "Insert section showing unpulled commits.
 Like `magit-insert-unpulled-commits' but prefix each commit


### PR DESCRIPTION
It can be useful to see recent commits with decorations and graph
annotations.  Add a status section hook function for this (that can be
added to `magit-status-sections-hook`).

Screenshot:

![image](https://cloud.githubusercontent.com/assets/152014/8509603/270f0fc8-2261-11e5-89e6-fdf22553c847.png)
