### PR TITLE
magit-log: limit commit count as efficiently as possible

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1059,13 +1059,28 @@ commits."
         (magit-insert-unpulled-commits)
       (magit-insert-recent-commits t))))
 
+(defun magit-commit-count-limiting-args (num-args)
+  "Returns a list of arguments for `git log' that limit the
+number of commits as efficiently as possible using a combination
+of git revisions and -NUM-ARGS."
+  (let ((args (list (format "-%d" num-args))))
+    (-when-let (nrevs (magit-git-string "rev-list"
+                                        (format "--max-count=%d" (1+ num-args))
+                                        "--count"
+                                        "HEAD"))
+      (setq nrevs (string-to-number nrevs))
+      (when (> nrevs num-args)
+        (setq args (cons (format "HEAD~%d.." (1- nrevs))
+                         args))))
+    args))
+
 (defun magit-insert-recent-commits (&optional collapse)
   "Insert section showing recent commits.
 Show the last `magit-log-section-commit-count' commits."
   (magit-insert-section (recent nil collapse)
     (magit-insert-heading "Recent commits:")
-    (magit-insert-log nil (cons (format "-%d" magit-log-section-commit-count)
-                                magit-log-section-arguments))))
+    (magit-insert-log nil (nconc (magit-commit-count-limiting-args magit-log-section-commit-count)
+                                 magit-log-section-arguments))))
 
 (defun magit-insert-unpulled-cherries ()
   "Insert section showing unpulled commits.


### PR DESCRIPTION
Changes since v1 (ea4fffb98ea2332cc5c5423b3628da09e41d4892):

  - Addressed comments from @tarsius
  - Removed dependency on 97d25c4ada8ec268890750fb9536a42b26a33427, which is being dropped.

---

`--graph` is slow on large repositories [1], even when using `--max-count`
since `--graph` computes the entire history before doing its decoration.
We can speed things up a bit ourselves by limiting the number of commits
with a git revision [2].

This is especially useful for users who would like to use `--graph` in
their `magit-log-section-args`.

[1] http://www.spinics.net/lists/git/msg232230.html
[2] http://www.spinics.net/lists/git/msg232226.html