### PR TITLE
Respect .mailmap for git log commands

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -550,7 +550,7 @@ Type \\[magit-reset-head] to reset HEAD to the commit at point.
   "Insert a oneline log section.
 For internal use; don't add to a hook."
   (magit-git-wash (apply-partially 'magit-log-wash-log 'oneline)
-    "log" (magit-log-format-max-count) "--use-mailmap"
+    "log" (magit-log-format-max-count)
     (format "--format=%%h%s %s[%%aN][%%at]%%s"
             (if (member "--decorate" args) "%d" "")
             (if (member "--show-signature" args)
@@ -559,6 +559,7 @@ For internal use; don't add to a hook."
     (if (member "--decorate" args)
         (cons "--decorate=full" (remove "--decorate" args))
       args)
+    "--use-mailmap"
     revs "--" files))
 
 (defun magit-insert-log-verbose (revs &optional args files)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -550,8 +550,8 @@ Type \\[magit-reset-head] to reset HEAD to the commit at point.
   "Insert a oneline log section.
 For internal use; don't add to a hook."
   (magit-git-wash (apply-partially 'magit-log-wash-log 'oneline)
-    "log" (magit-log-format-max-count)
-    (format "--format=%%h%s %s[%%an][%%at]%%s"
+    "log" (magit-log-format-max-count) "--use-mailmap"
+    (format "--format=%%h%s %s[%%aN][%%at]%%s"
             (if (member "--decorate" args) "%d" "")
             (if (member "--show-signature" args)
                 (progn (setq args (remove "--show-signature" args)) "%G?")
@@ -993,7 +993,7 @@ Type \\[magit-reset-head] to reset HEAD to the commit at point.
         (propertize (concat " Reflog for " ref) 'face 'magit-header-line))
   (magit-insert-section (reflogbuf)
     (magit-git-wash (apply-partially 'magit-log-wash-log 'reflog)
-      "reflog" "show" "--format=%h [%an] %ct %gd %gs"
+      "reflog" "show" "--format=%h [%aN] %ct %gd %gs"
       (magit-log-format-max-count) ref)))
 
 (defvar magit-reflog-labels

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -842,7 +842,7 @@ Refs are compared with a branch read form the user."
 (defun magit-refs-format-margin (commit)
   (save-excursion
     (goto-char (line-beginning-position 0))
-    (let ((line (magit-rev-format "%ct%cn" commit)))
+    (let ((line (magit-rev-format "%ct%cN" commit)))
       (magit-format-log-margin (substring line 10)
                                (substring line 0 10)))))
 


### PR DESCRIPTION
Fix for  #1991.

This fix assumes that when a .mailmap file is present it should always be applied. It might be preferable to make this behavior configurable instead.