### PR TITLE
Set safe default-directory variable for magit-git-insert function

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -230,7 +230,8 @@ message and add a section in the respective process buffer."
                     (message "%s" msg)))
                 exit))
           (ignore-errors (delete-file log))))
-    (apply #'process-file magit-git-executable nil (list t nil) nil args)))
+    (let ((default-directory (magit-toplevel)))
+      (apply #'process-file magit-git-executable nil (list t nil) nil args))))
 
 (defun magit-git-string (&rest args)
   "Execute Git with ARGS, returning the first line of its output.


### PR DESCRIPTION
Calling function `magit-status`always crashes on my laptop if I deleted any directory in my repo before. Here is example of trace I'm getting:

```
Debugger entered--Lisp error: (file-error "Setting current directory" "no such file or directory" "/Users/rmuslimov/projects/playground/testrepo/dir1/")
  call-process("git" nil (t nil) nil "--no-pager" "--literal-pathspecs" "-c" "core.preloadindex=true" "symbolic-ref" "--short" "HEAD")
  apply(call-process "git" nil (t nil) nil ("--no-pager" "--literal-pathspecs" "-c" "core.preloadindex=true" "symbolic-ref" "--short" "HEAD"))
  process-file("git" nil (t nil) nil "--no-pager" "--literal-pathspecs" "-c" "core.preloadindex=true" "symbolic-ref" "--short" "HEAD")
  apply(process-file "git" nil (t nil) nil ("--no-pager" "--literal-pathspecs" "-c" "core.preloadindex=true" "symbolic-ref" "--short" "HEAD"))
  (if magit-git-debug (let (log) (unwind-protect (progn (setq log (make-temp-file "magit-stderr")) (delete-file log) (let ((exit (apply ... magit-git-executable nil ... nil args))) (if (> exit 0) (progn (let ... ... ...))) exit)) (condition-case nil (progn (delete-file log)) (error nil)))) (apply (function process-file) magit-git-executable nil (list t nil) nil args))
  magit-git-insert("symbolic-ref" "--short" "HEAD")
  apply(magit-git-insert ("symbolic-ref" "--short" "HEAD"))
  magit-git-string("symbolic-ref" "--short" "HEAD")
  magit-get-current-branch()
  magit-refresh-vc-mode-line()
  run-hooks(magit-not-reverted-hook)
  magit-revert-buffer(#<buffer textfile.txt>)
  mapcar(magit-revert-buffer (#<buffer .gitignore> #<buffer textfile.txt>))
  magit-revert-buffers()
  magit-refresh()
  magit-process-sentinel(#<process git> "exited abnormally with code 1\n")
  read-event(nil t 5)
  sit-for(5)
  #[0 "\302\300\303\304\305\301!!P\"\210\306\305\301!\300\"\210\307\310!\210\311\300!\207" [#<process server <18>> (file-error "Setting current directory" "no such file or directory" "/Users/rmuslimov/projects/playground/testrepo/dir1/") server-send-string "-error " server-quote-arg error-message-string server-log sit-for 5 delete-process] 6 "\n\n(fn)"]()
  funcall(#[0 "\302\300\303\304\305\301!!P\"\210\306\305\301!\300\"\210\307\310!\210\311\300!\207" [#<process server <18>> (file-error "Setting current directory" "no such file or directory" "/Users/rmuslimov/projects/playground/testrepo/dir1/") server-send-string "-error " server-quote-arg error-message-string server-log sit-for 5 delete-process] 6 "\n\n(fn)"])
  server-return-error(#<process server <18>> (file-error "Setting current directory" "no such file or directory" "/Users/rmuslimov/projects/playground/testrepo/dir1/"))
  #[257 "\211@\301=\203 \302\303!\210\304\300\"\207" [#<process server <18>> quit message "Quit emacsclient request" server-return-error] 4 "\n\n(fn ERR)"]((file-error "Setting current directory" "no such file or directory" "/Users/rmuslimov/projects/playground/testrepo/dir1/"))
  funcall(#[257 "\211@\301=\203 \302\303!\210\304\300\"\207" [#<process server <18>> quit message "Quit emacsclient request" server-return-error] 4 "\n\n(fn ERR)"] (file-error "Setting current directory" "no such file or directory" "/Users/rmuslimov/projects/playground/testrepo/dir1/"))
  #[0 "\307\310\311\312\313\314\315\316\300\301\302\303\304\305\306&\317\"\320\321%D\322\311\312\323\324\315\316\300!\325\"\326\327%\310EDC\217)\207" [#<process server <18>> (("/Users/rmuslimov/projects/playground/testrepo/.git/COMMIT_EDITMSG")) nil nil nil nil nil nil err funcall make-byte-code 0 "\307\301\300\302#\310\311\303\237\"\210\301\204< \303\204<  ;\203  \312 !\202* \313 !\205*   \314\315!\2035 \2028 \316\317!\320\"\266\302\203L \321\322\300\"\210\323\300!\210\202] \304\204] \211\204] \321\324\300\"\210\323\300!\210!\204\225 \325 \204\225 \305\203y \211\204y \326\327\330\331!\"\210\202\225 \211\203\225 \332@\333\301@A#\210\334\335!\210\302\204\225 \326\327\330\336!\"\210\305\205\241 \306?\205\241 \337\305!\207" vconcat vector [server-visit-files mapc funcall find-file-noselect functionp switch-to-buffer buffer-live-p get-buffer-create "*scratch*" norecord server-log "Close nowait client" server-delete-client "Close empty client" minibufferp message "%s" substitute-command-keys "When done with this frame, type \\[delete-frame]" server-switch-buffer nil run-hooks server-switch-hook "When done with a buffer, type \\[server-edit]" server-unselect-display initial-buffer-choice isearch-mode] 5 "\n\n(fn)" (quit error) 257 "\211@\301=\203 \302\303!\210\304\300\"\207" [quit message "Quit emacsclient request" server-return-error] 4 "\n\n(fn ERR)" inhibit-quit] 14 "\n\n(fn)"]()
  funcall(#[0 "\307\310\311\312\313\314\315\316\300\301\302\303\304\305\306&\317\"\320\321%D\322\311\312\323\324\315\316\300!\325\"\326\327%\310EDC\217)\207" [#<process server <18>> (("/Users/rmuslimov/projects/playground/testrepo/.git/COMMIT_EDITMSG")) nil nil nil nil nil nil err funcall make-byte-code 0 "\307\301\300\302#\310\311\303\237\"\210\301\204< \303\204<  ;\203  \312 !\202* \313 !\205*   \314\315!\2035 \2028 \316\317!\320\"\266\302\203L \321\322\300\"\210\323\300!\210\202] \304\204] \211\204] \321\324\300\"\210\323\300!\210!\204\225 \325 \204\225 \305\203y \211\204y \326\327\330\331!\"\210\202\225 \211\203\225 \332@\333\301@A#\210\334\335!\210\302\204\225 \326\327\330\336!\"\210\305\205\241 \306?\205\241 \337\305!\207" vconcat vector [server-visit-files mapc funcall find-file-noselect functionp switch-to-buffer buffer-live-p get-buffer-create "*scratch*" norecord server-log "Close nowait client" server-delete-client "Close empty client" minibufferp message "%s" substitute-command-keys "When done with this frame, type \\[delete-frame]" server-switch-buffer nil run-hooks server-switch-hook "When done with a buffer, type \\[server-edit]" server-unselect-display initial-buffer-choice isearch-mode] 5 "\n\n(fn)" (quit error) 257 "\211@\301=\203 \302\303!\210\304\300\"\207" [quit message "Quit emacsclient request" server-return-error] 4 "\n\n(fn ERR)" inhibit-quit] 14 "\n\n(fn)"])
  server-execute(#<process server <18>> (("/Users/rmuslimov/projects/playground/testrepo/.git/COMMIT_EDITMSG")) nil nil nil nil nil)
  #[0 "r\310!q\210\305\242\203 \311\305\242!\203 \305\242\202 \f\f\312\300\307\242\301\242\304\242\303\242\302\242\306\242&*\207" [#<process server <18>> (nil) (nil) (nil) (nil) ("/Users/rmuslimov/projects/playground/testrepo/") (nil) ((("/Users/rmuslimov/projects/playground/testrepo/.git/COMMIT_EDITMSG"))) get-buffer-create file-directory-p server-execute server-buffer default-directory] 8 "\n\n(fn)"]()
  #[0 "\300 \207" [#[0 "r\310!q\210\305\242\203 \311\305\242!\203 \305\242\202 \f\f\312\300\307\242\301\242\304\242\303\242\302\242\306\242&*\207" [#<process server <18>> (nil) (nil) (nil) (nil) ("/Users/rmuslimov/projects/playground/testrepo/") (nil) ((("/Users/rmuslimov/projects/playground/testrepo/.git/COMMIT_EDITMSG"))) get-buffer-create file-directory-p server-execute server-buffer default-directory] 8 "\n\n(fn)"]] 1 "\n\n(fn)"]()
  funcall(#[0 "\300 \207" [#[0 "r\310!q\210\305\242\203 \311\305\242!\203 \305\242\202 \f\f\312\300\307\242\301\242\304\242\303\242\302\242\306\242&*\207" [#<process server <18>> (nil) (nil) (nil) (nil) ("/Users/rmuslimov/projects/playground/testrepo/") (nil) ((("/Users/rmuslimov/projects/playground/testrepo/.git/COMMIT_EDITMSG"))) get-buffer-create file-directory-p server-execute server-buffer default-directory] 8 "\n\n(fn)"]] 1 "\n\n(fn)"])
  server-execute-continuation(#<process server <18>>)
  #[0 "\306\300!\210\307\300\310\311\312 !\313Q\"\210\314\313\301\242\"\204& \301\242G\315V\205\231\316\300\317\301\242#\207\315\225\301\242G=\2045 \320\321\322C\"\210\301\242\315\211\224O\323\324!\205F \n\206F \325C\325C\325\211\211C\325C\325C\325\211\211C\325\211C\325\211\301\211\242\315\225\325O\240\210\326\327\330\331\332#\"\262\211\203\327\211A\262\242\211\333\232\203\210 \211A\262\210\202\323\211\334\232\203\226 \332\240\210\202\323\211\335\232\203\242 \332\262\202\323\211\336\232\203\304 \211A\262\242\203\272 \337\"\262\340!@\262\210\202\323\211\341\232\203\340 \211A\262\242\262
\342
G!\203\323\325\262
\202\323\211\343\232\203\374 \211A\262\242\262\f\342\fG!\203\323\325\262\f\202\323\211\344\232\203\345\346!\203\323\n\332\240\210\305\240\210\202\323\211\347\232\203<\350\300\351\"\332\240\210\n\352\315\353\354\355!\356\"\357\360%\f\242B\240\266\202\323\211\361\232\203d\350\300\351\"\332\240\210\n\352\315\353\354\355!\362\"\357\360%\f\242B\240\266\202\323\211\363\232\203x\n\332\240\210\211A\262\210\202\323\211\364\232\203\257\211A\262\242\240\210\211A\262\242\262\n\211\242\206\231?\240\210\f\365=\203\323
\366=\203\323\344B\262\202\323\211\367\232\203\336\314\370@\"\204\301\371\372!\210\211A\262\242\373\374\375\"!\373\374\357\"\206\326\376!B\262\210\202\323\211\377\232\203%\211A\262\242\203\366\337\"\262\201A \242\"\262B\242B\240\210\201B \201C \201D \206\376#\300\"\266\325\262\202\323\211\201E \232\203o\2037\201F \262\211A\262\242C\203L\211\337\242\"\240\210\n\352\315\201G \354\355\300\"\201H \"\201I \360%\f\242B\240\210\325\262\210\202\323\211\201J \232\203\220\211A\262\242\316\300\201K \350\300\201K \"B#\266\202\323\211\201L \232\203\312\211A\262\242\240\210\203\262\337\n\242\"\240\210\201M \n\242!\240\210\316\300\201N \242#\210\202\323\211\371\201O \"\266\210\202o 
\242\203\362\242\305=\204\362\242\204\357\242\203\362\332\262\f\2030\201F =\204\201P  \203\201Q  A\204\201R  @=\2040\325\240\210\325\262\f\205W\201S 
!\202W\242\305=\203H\201T 
\242\300%\202W\242\205W\201U \242\300#\240\210\316\300\201V \352\315\201W \354\355\300&\201X \"\201Y \360%#\210\f\242\204\214\242\203\222\201Z \300!\210\201[ \300!\266\220\207" [#<process server <18>> ("") file-name-coding-system default-file-name-coding-system system-type window-system server-add-client server-send-string "-emacs-pid " number-to-string emacs-pid "\n" string-match 0 process-put previous-string signal cl-assertion-failed (eq (match-end 0) (length string)) default-value enable-multibyte-characters nil mapcar server-unquote-arg split-string " " t "-version" "-nowait" "-current-frame" "-frame-parameters" decode-coding-string read-from-string "-display" zerop "-parent-id" "-window-system" fboundp x-create-frame "-resume" process-get terminal make-byte-code "\301\300!\302=\205 \303\300!\207" vconcat vector [terminal-live-p t resume-tty] 2 "\n\n(fn)" "-suspend" ...] 32 "\n\n(fn)"]()
  funcall(#[0 "\306\300!\210\307\300\310\311\312 !\313Q\"\210\314\313\301\242\"\204& \301\242G\315V\205\231\316\300\317\301\242#\207\315\225\301\242G=\2045 \320\321\322C\"\210\301\242\315\211\224O\323\324!\205F \n\206F \325C\325C\325\211\211C\325C\325C\325\211\211C\325\211C\325\211\301\211\242\315\225\325O\240\210\326\327\330\331\332#\"\262\211\203\327\211A\262\242\211\333\232\203\210 \211A\262\210\202\323\211\334\232\203\226 \332\240\210\202\323\211\335\232\203\242 \332\262\202\323\211\336\232\203\304 \211A\262\242\203\272 \337\"\262\340!@\262\210\202\323\211\341\232\203\340 \211A\262\242\262
\342
G!\203\323\325\262
\202\323\211\343\232\203\374 \211A\262\242\262\f\342\fG!\203\323\325\262\f\202\323\211\344\232\203\345\346!\203\323\n\332\240\210\305\240\210\202\323\211\347\232\203<\350\300\351\"\332\240\210\n\352\315\353\354\355!\356\"\357\360%\f\242B\240\266\202\323\211\361\232\203d\350\300\351\"\332\240\210\n\352\315\353\354\355!\362\"\357\360%\f\242B\240\266\202\323\211\363\232\203x\n\332\240\210\211A\262\210\202\323\211\364\232\203\257\211A\262\242\240\210\211A\262\242\262\n\211\242\206\231?\240\210\f\365=\203\323
\366=\203\323\344B\262\202\323\211\367\232\203\336\314\370@\"\204\301\371\372!\210\211A\262\242\373\374\375\"!\373\374\357\"\206\326\376!B\262\210\202\323\211\377\232\203%\211A\262\242\203\366\337\"\262\201A \242\"\262B\242B\240\210\201B \201C \201D \206\376#\300\"\266\325\262\202\323\211\201E \232\203o\2037\201F \262\211A\262\242C\203L\211\337\242\"\240\210\n\352\315\201G \354\355\300\"\201H \"\201I \360%\f\242B\240\210\325\262\210\202\323\211\201J \232\203\220\211A\262\242\316\300\201K \350\300\201K \"B#\266\202\323\211\201L \232\203\312\211A\262\242\240\210\203\262\337\n\242\"\240\210\201M \n\242!\240\210\316\300\201N \242#\210\202\323\211\371\201O \"\266\210\202o 
\242\203\362\242\305=\204\362\242\204\357\242\203\362\332\262\f\2030\201F =\204\201P  \203\201Q  A\204\201R  @=\2040\325\240\210\325\262\f\205W\201S 
!\202W\242\305=\203H\201T 
\242\300%\202W\242\205W\201U \242\300#\240\210\316\300\201V \352\315\201W \354\355\300&\201X \"\201Y \360%#\210\f\242\204\214\242\203\222\201Z \300!\210\201[ \300!\266\220\207" [#<process server <18>> ("") file-name-coding-system default-file-name-coding-system system-type window-system server-add-client server-send-string "-emacs-pid " number-to-string emacs-pid "\n" string-match 0 process-put previous-string signal cl-assertion-failed (eq (match-end 0) (length string)) default-value enable-multibyte-characters nil mapcar server-unquote-arg split-string " " t "-version" "-nowait" "-current-frame" "-frame-parameters" decode-coding-string read-from-string "-display" zerop "-parent-id" "-window-system" fboundp x-create-frame "-resume" process-get terminal make-byte-code "\301\300!\302=\205 \303\300!\207" vconcat vector [terminal-live-p t resume-tty] 2 "\n\n(fn)" "-suspend" ...] 32 "\n\n(fn)"])
  #[0 "\302\303\301\242P\300\"\210\304\300\305\"\204V \306\307\301\242\"\203; \310\311\301\242\"\304\300\312\"\232\203; \301\211\242\313\225\314O\240\210\315\300\305\316#\210\302\317\300\"\210\202V \302\320\300\"\210\321\300\322\323\320!P\"\210\324\311!\210\325\300!\210\326\327\314\"\210\304\300\330\"\211\203k \301\301\242P\240\210\315\300\330\314#\210\210\331\332\333\313\334\335\336\300\301\"\337\"\340\341%D\342\332\333\343\344\335\336\300!\345\"\346\347%\331EDC\217\207" [#<process server <18>> ("") server-log "Received " process-get :authenticated string-match "-auth \\([!-~]+\\)\n?" match-string 1 :auth-key 0 nil process-put t "Authentication successful" "Authentication failed" server-send-string "-error " server-quote-arg sit-for delete-process throw --cl-block-server-process-filter-- previous-string err funcall make-byte-code "\306\300!\210\307\300\310\311\312 !\313Q\"\210\314\313\301\242\"\204& \301\242G\315V\205\231\316\300\317\301\242#\207\315\225\301\242G=\2045 \320\321\322C\"\210\301\242\315\211\224O\323\324!\205F \n\206F \325C\325C\325\211\211C\325C\325C\325\211\211C\325\211C\325\211\301\211\242\315\225\325O\240\210\326\327\330\331\332#\"\262\211\203\327\211A\262\242\211\333\232\203\210 \211A\262\210\202\323\211\334\232\203\226 \332\240\210\202\323\211\335\232\203\242 \332\262\202\323\211\336\232\203\304 \211A\262\242\203\272 \337\"\262\340!@\262\210\202\323\211\341\232\203\340 \211A\262\242\262
\342
G!\203\323\325\262
\202\323\211\343\232\203\374 \211A\262\242\262\f\342\fG!\203\323\325\262\f\202\323\211\344\232\203\345\346!\203\323\n\332\240\210\305\240\210\202\323\211\347\232\203<\350\300\351\"\332\240\210\n\352\315\353\354\355!\356\"\357\360%\f\242B\240\266\202\323\211\361\232\203d\350\300\351\"\332\240\210\n\352\315\353\354\355!\362\"\357\360%\f\242B\240\266\202\323\211\363\232\203x\n\332\240\210\211A\262\210\202\323\211\364\232\203\257\211A\262\242\240\210\211A\262\242\262\n\211\242\206\231?\240\210\f\365=\203\323
\366=\203\323\344B\262\202\323\211\367\232\203\336\314\370@\"\204\301\371\372!\210\211A\262\242\373\374\375\"!\373\374\357\"\206\326\376!B\262\210\202\323\211\377\232\203%\211A\262\242\203\366\337\"\262\201A \242\"\262B\242B\240\210\201B \201C \201D \206\376#\300\"\266\325\262\202\323\211\201E \232\203o\2037\201F \262\211A\262\242C\203L\211\337\242\"\240\210\n\352\315\201G \354\355\300\"\201H \"\201I \360%\f\242B\240\210\325\262\210\202\323\211\201J \232\203\220\211A\262\242\316\300\201K \350\300\201K \"B#\266\202\323\211\201L \232\203\312\211A\262\242\240\210\203\262\337\n\242\"\240\210\201M \n\242!\240\210\316\300\201N \242#\210\202\323\211\371\201O \"\266\210\202o 
\242\203\362\242\305=\204\362\242\204\357\242\203\362\332\262\f\2030\201F =\204\201P  \203\201Q  A\204\201R  @=\2040\325\240\210\325\262\f\205W\201S 
!\202W\242\305=\203H\201T 
\242\300%\202W\242\205W\201U \242\300#\240\210\316\300\201V \352\315\201W \354\355\300&\201X \"\201Y \360%#\210\f\242\204\214\242\203\222\201Z \300!\210\201[ \300!\266\220\207" vconcat vector [file-name-coding-system default-file-name-coding-system system-type window-system server-add-client server-send-string "-emacs-pid " number-to-string emacs-pid "\n" string-match 0 process-put previous-string signal cl-assertion-failed (eq (match-end 0) (length string)) default-value enable-multibyte-characters nil mapcar server-unquote-arg split-string " " t "-version" "-nowait" "-current-frame" "-frame-parameters" decode-coding-string read-from-string "-display" zerop "-parent-id" "-window-system" fboundp x-create-frame "-resume" process-get terminal make-byte-code "\301\300!\302=\205 \303\300!\207" vconcat vector [terminal-live-p t resume-tty] 2 "\n\n(fn)" "-suspend" [terminal-live-p t suspend-tty] "-ignore" ...] 32 "\n\n(fn)" error 257 "\301\300\"\207" [server-return-error] 4 "\n\n(fn ERR)"] 10 "\n\n(fn)"]()
  funcall(#[0 "\302\303\301\242P\300\"\210\304\300\305\"\204V \306\307\301\242\"\203; \310\311\301\242\"\304\300\312\"\232\203; \301\211\242\313\225\314O\240\210\315\300\305\316#\210\302\317\300\"\210\202V \302\320\300\"\210\321\300\322\323\320!P\"\210\324\311!\210\325\300!\210\326\327\314\"\210\304\300\330\"\211\203k \301\301\242P\240\210\315\300\330\314#\210\210\331\332\333\313\334\335\336\300\301\"\337\"\340\341%D\342\332\333\343\344\335\336\300!\345\"\346\347%\331EDC\217\207" [#<process server <18>> ("") server-log "Received " process-get :authenticated string-match "-auth \\([!-~]+\\)\n?" match-string 1 :auth-key 0 nil process-put t "Authentication successful" "Authentication failed" server-send-string "-error " server-quote-arg sit-for delete-process throw --cl-block-server-process-filter-- previous-string err funcall make-byte-code "\306\300!\210\307\300\310\311\312 !\313Q\"\210\314\313\301\242\"\204& \301\242G\315V\205\231\316\300\317\301\242#\207\315\225\301\242G=\2045 \320\321\322C\"\210\301\242\315\211\224O\323\324!\205F \n\206F \325C\325C\325\211\211C\325C\325C\325\211\211C\325\211C\325\211\301\211\242\315\225\325O\240\210\326\327\330\331\332#\"\262\211\203\327\211A\262\242\211\333\232\203\210 \211A\262\210\202\323\211\334\232\203\226 \332\240\210\202\323\211\335\232\203\242 \332\262\202\323\211\336\232\203\304 \211A\262\242\203\272 \337\"\262\340!@\262\210\202\323\211\341\232\203\340 \211A\262\242\262
\342
G!\203\323\325\262
\202\323\211\343\232\203\374 \211A\262\242\262\f\342\fG!\203\323\325\262\f\202\323\211\344\232\203\345\346!\203\323\n\332\240\210\305\240\210\202\323\211\347\232\203<\350\300\351\"\332\240\210\n\352\315\353\354\355!\356\"\357\360%\f\242B\240\266\202\323\211\361\232\203d\350\300\351\"\332\240\210\n\352\315\353\354\355!\362\"\357\360%\f\242B\240\266\202\323\211\363\232\203x\n\332\240\210\211A\262\210\202\323\211\364\232\203\257\211A\262\242\240\210\211A\262\242\262\n\211\242\206\231?\240\210\f\365=\203\323
\366=\203\323\344B\262\202\323\211\367\232\203\336\314\370@\"\204\301\371\372!\210\211A\262\242\373\374\375\"!\373\374\357\"\206\326\376!B\262\210\202\323\211\377\232\203%\211A\262\242\203\366\337\"\262\201A \242\"\262B\242B\240\210\201B \201C \201D \206\376#\300\"\266\325\262\202\323\211\201E \232\203o\2037\201F \262\211A\262\242C\203L\211\337\242\"\240\210\n\352\315\201G \354\355\300\"\201H \"\201I \360%\f\242B\240\210\325\262\210\202\323\211\201J \232\203\220\211A\262\242\316\300\201K \350\300\201K \"B#\266\202\323\211\201L \232\203\312\211A\262\242\240\210\203\262\337\n\242\"\240\210\201M \n\242!\240\210\316\300\201N \242#\210\202\323\211\371\201O \"\266\210\202o 
\242\203\362\242\305=\204\362\242\204\357\242\203\362\332\262\f\2030\201F =\204\201P  \203\201Q  A\204\201R  @=\2040\325\240\210\325\262\f\205W\201S 
!\202W\242\305=\203H\201T 
\242\300%\202W\242\205W\201U \242\300#\240\210\316\300\201V \352\315\201W \354\355\300&\201X \"\201Y \360%#\210\f\242\204\214\242\203\222\201Z \300!\210\201[ \300!\266\220\207" vconcat vector [file-name-coding-system default-file-name-coding-system system-type window-system server-add-client server-send-string "-emacs-pid " number-to-string emacs-pid "\n" string-match 0 process-put previous-string signal cl-assertion-failed (eq (match-end 0) (length string)) default-value enable-multibyte-characters nil mapcar server-unquote-arg split-string " " t "-version" "-nowait" "-current-frame" "-frame-parameters" decode-coding-string read-from-string "-display" zerop "-parent-id" "-window-system" fboundp x-create-frame "-resume" process-get terminal make-byte-code "\301\300!\302=\205 \303\300!\207" vconcat vector [terminal-live-p t resume-tty] 2 "\n\n(fn)" "-suspend" [terminal-live-p t suspend-tty] "-ignore" ...] 32 "\n\n(fn)" error 257 "\301\300\"\207" [server-return-error] 4 "\n\n(fn ERR)"] 10 "\n\n(fn)"])
  server-process-filter(#<process server <18>> "-dir /Users/rmuslimov/projects/playground/testrepo/ -current-frame -file /Users/rmuslimov/projects/playground/testrepo/.git/COMMIT_EDITMSG \n")
 ```

So, here is small changes I'm proposing to fix this bug. Thanks!
