### PR TITLE
magit-diff-{unpushed,unpulled}: Update error calls

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -592,7 +592,7 @@ a commit read from the minibuffer."
   (interactive (magit-diff-read-args))
   (-if-let (tracked (magit-get-tracked-ref))
       (magit-diff (concat tracked "...") args files)
-    (error "Detached HEAD or upstream unset")))
+    (user-error "No upstream set")))
 
 ;;;###autoload
 (defun magit-diff-unpulled (&optional args files)
@@ -600,7 +600,7 @@ a commit read from the minibuffer."
   (interactive (magit-diff-read-args))
   (-if-let (tracked (magit-get-tracked-ref))
       (magit-diff (concat "..." tracked) args files)
-    (error "Detached HEAD or upstream unset")))
+    (user-error "No upstream set")))
 
 ;;;###autoload
 (defun magit-diff-while-committing (&optional args)


### PR DESCRIPTION
* Replace error with user-error.

* Reduce the message down to the common problem.  In the case of a
  detached HEAD, which cannot have an upstream branch, the problem is
  still that an upstream branch is not set.