### PR TITLE
[RFC] Diff actions to switch range arguments and type

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -509,6 +509,7 @@ The following `format'-like specs are supported:
                 (?s "Set defaults"  magit-diff-set-default-arguments)
                 (?w "Save defaults" magit-diff-save-default-arguments)
                 (?t "Toggle hunk refinement" magit-diff-toggle-refine-hunk)
+                (?f "Flip revisions" magit-diff-flip-revs)
                 (?r "Switch range type" magit-diff-switch-range-type))))
 
 (defadvice magit-diff-refresh-popup (around get-current-arguments activate)
@@ -749,6 +750,22 @@ Change \"revA..revB\" to \"revB...revA\", or vice versa."
                           (match-string 3 range)))
           (magit-refresh))
       (user-error "No range to change"))))
+
+(defun magit-diff-flip-revs (args)
+  "Swap revisions in diff range.
+Change \"revA..revB\" to \"revB..revA\"."
+  (interactive (list (magit-diff-refresh-arguments)))
+  (let ((range (car magit-refresh-args)))
+    (if (and range
+             (derived-mode-p 'magit-diff-mode)
+             (string-match magit-diff-range-re range))
+        (progn
+          (setcar magit-refresh-args
+                  (concat (match-string 3 range)
+                          (match-string 2 range)
+                          (match-string 1 range)))
+          (magit-refresh))
+      (user-error "No range to swap"))))
 
 (defun magit-diff-less-context (&optional count)
   "Decrease the context for diff hunks by COUNT lines."


### PR DESCRIPTION
These commits add two actions to the magit-diff-refresh-popup: one that switches the range type (back and forth between ".." and "...") and one that swaps the revision arguments in a range.  What do you think?

(somewhat related to #2006)
