### PR TITLE
Replace magit-remote-update with magit-fetch-all

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -298,7 +298,7 @@ has to confirm each save."
     "---"
     ["Push" magit-push t]
     ["Pull" magit-pull t]
-    ["Remote update" magit-remote-update t]
+    ["Remote update" magit-fetch-all t]
     ("Submodule"
      ["Submodule update" magit-submodule-update t]
      ["Submodule update and init" magit-submodule-update-init t]


### PR DESCRIPTION
magit-remote-update was renamed to magit-fetch-all in 9f873f6f1c694330.

Fixes #2021.