### PR TITLE
WIP always show revision header but make it selectable

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1334,7 +1334,8 @@ Type \\[magit-reverse] to reverse the change at point in the worktree.
         (and (> window-start-pos 48)
              (concat
               (propertize " " 'display
-                          `((space :width (,(+ (car (window-fringes)) 2)))))
+                          `((space :width (,(+ (car (window-fringes))
+                                               2))))) ; FIXME get from face :box
               (propertize (concat "Commit "
                                   (magit-rev-parse (car magit-refresh-args)))
                           'face 'magit-header-line)))))
@@ -1355,8 +1356,9 @@ Type \\[magit-reverse] to reverse the change at point in the worktree.
       (magit-delete-line)
       (magit-insert-section (headers)
         (magit-insert-heading
-          (propertize (concat "Commit " rev)
-                      'face '(magit-header-line header-line)))
+          (propertize (concat "Commit " rev
+                              "\n") ; FIXME underline display line
+                      'face 'magit-header-line))
         (when refs
           (magit-insert (format "References: %s\n"
                                 (magit-format-ref-labels refs))))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1326,12 +1326,12 @@ Type \\[magit-apply] to apply the change at point to the worktree.
 Type \\[magit-reverse] to reverse the change at point in the worktree.
 \n\\{magit-revision-mode-map}"
   :group 'magit-revision
-  (add-hook 'post-command-hook 'magit-revision-hideshow-header-line nil t)
+  (add-hook 'window-scroll-functions #'magit-revision-hideshow-header-line nil t)
   (hack-dir-local-variables-non-file-buffer))
 
-(defun magit-revision-hideshow-header-line ()
+(defun magit-revision-hideshow-header-line (window window-start-pos)
   (setq header-line-format
-        (and (not (pos-visible-in-window-p 1))
+        (and (> window-start-pos 48)
              (concat
               (propertize " " 'display
                           `((space :width (,(+ (car (window-fringes)) 2)))))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1326,7 +1326,18 @@ Type \\[magit-apply] to apply the change at point to the worktree.
 Type \\[magit-reverse] to reverse the change at point in the worktree.
 \n\\{magit-revision-mode-map}"
   :group 'magit-revision
+  (add-hook 'post-command-hook 'magit-revision-hideshow-header-line nil t)
   (hack-dir-local-variables-non-file-buffer))
+
+(defun magit-revision-hideshow-header-line ()
+  (setq header-line-format
+        (and (not (pos-visible-in-window-p 1))
+             (concat
+              (propertize " " 'display
+                          `((space :width (,(+ (car (window-fringes)) 2)))))
+              (propertize (concat "Commit "
+                                  (magit-rev-parse (car magit-refresh-args)))
+                          'face 'magit-header-line)))))
 
 (defun magit-revision-refresh-buffer (commit args)
   (magit-insert-section (commitbuf)
@@ -1342,10 +1353,10 @@ Type \\[magit-reverse] to reverse the change at point in the worktree.
     (looking-at "^commit \\([a-z0-9]+\\)\\(?: \\(.+\\)\\)?$")
     (magit-bind-match-strings (rev refs) nil
       (magit-delete-line)
-      (setq header-line-format
-            (propertize (concat " Commit " rev) 'face 'magit-header-line))
       (magit-insert-section (headers)
-        (magit-insert-heading (char-to-string magit-ellipsis))
+        (magit-insert-heading
+          (propertize (concat "Commit " rev)
+                      'face '(magit-header-line header-line)))
         (when refs
           (magit-insert (format "References: %s\n"
                                 (magit-format-ref-labels refs))))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -228,7 +228,7 @@ deep."
 ;;;; Faces
 
 (defface magit-header-line
-  '((t :inherit magit-section-heading))
+  '((t :inherit (magit-section-heading magit-header-line)))
   "Face for the `header-line'."
   :group 'magit-faces)
 


### PR DESCRIPTION
Display the same information in the `header-line` and the first line
of the buffer text, but make sure only one of them is every actually
displayed.

When the `window-start` is visible, then don't show the `header-line`.

There are still some minor issues, but I generally like it.