### PR TITLE
Enable --force flag in magit-branch-popup

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1006,7 +1006,9 @@ Non-interactively DIRECTORY is (re-)initialized unconditionally."
   "Popup console for branch commands."
   'magit-commands
   :man-page "git-branch"
-  :switches '((?t "Set upstream configuration" "--track"))
+  :switches '((?t "Set upstream configuration" "--track")
+              (?f "Force"                      "--force"))
+
   :actions  '((?b "Checkout"          magit-checkout)
               (?u "Set upstream"      magit-branch-set-upstream)
               (?k "Delete"            magit-branch-delete)


### PR DESCRIPTION
This enables doing `git branch --force some-branch origin/some-branch` without first checking out `some-branch`. While not the most common use-case of `git-branch`, it is something that I want to do from time to tome.