### PR TITLE
magit-{change,remove}-popup-key: fix doc :keywords

### DIFF
--- a/Documentation/magit-popup.org
+++ b/Documentation/magit-popup.org
@@ -290,14 +290,15 @@ commands to an existing popup using the following functions.
 - Function: magit-change-popup-key popup type from to
 
   In POPUP, bind TO to what FROM was bound to.  TYPE is one of
-  ~:action~, ~:switch~, or ~:option~.  Bind TO and unbind FROM, both are
-  characters.
+  ~:actions~, ~:switches~, or ~:options~.  Bind TO and unbind FROM,
+  both are characters.
 
 - Function: magit-remove-popup-key popup type key
 
   In POPUP, remove KEY's binding of TYPE.  POPUP is a popup command
-  defined using ~magit-define-popup~.  TYPE is one of ~:action~, ~:switch~,
-  or ~:option~.  KEY is the character which is to be unbound.
+  defined using ~magit-define-popup~.  TYPE is one of ~:actions~,
+  ~:switches~, or ~:options~.  KEY is the character which is to be
+  unbound.
 
 It is also possible to change other aspects of a popup by setting a
 property using ~plist-put~.  See [[*Defining prefix commands]] for valid

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -614,7 +614,7 @@ It's better to use one of the specialized functions
 
 (defun magit-change-popup-key (popup type from to)
   "In POPUP, bind TO to what FROM was bound to.
-TYPE is one of `:action', `:switch', or `:option'.
+TYPE is one of `:actions', `:switches', or `:options'.
 Bind TO and unbind FROM, both are characters."
   (--if-let (assoc from (plist-get (symbol-value popup) type))
       (setcar it to)
@@ -623,7 +623,7 @@ Bind TO and unbind FROM, both are characters."
 (defun magit-remove-popup-key (popup type key)
   "In POPUP, remove KEY's binding of TYPE.
 POPUP is a popup command defined using `magit-define-popup'.
-TYPE is one of `:action', `:switch', or `:option'.
+TYPE is one of `:actions', `:switches', or `:options'.
 KEY is the character which is to be unbound."
   (let* ((plist (symbol-value popup))
          (alist (plist-get plist type))


### PR DESCRIPTION
The docstrings and manual should refer to :actions, :switches, and
:options (not :action, :switch, and :option).

---

I didn't try to update the .texi as I understand some fancy hacks are needed.