### PR TITLE
magit-rebase-unpushed: start from merge-base

### DIFF
--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -360,7 +360,8 @@ selected from a list of recent commits.
 (defun magit-rebase-unpushed (commit &optional args)
   "Start an interactive rebase sequence of all unpushed commits.
 \n(git rebase -i UPSTREAM [ARGS])"
-  (interactive (list (magit-get-tracked-branch)
+  (interactive (list (--when-let (magit-get-tracked-branch)
+                       (magit-git-string "merge-base" it "HEAD")) 
                      (magit-rebase-arguments)))
   (if (setq commit (magit-rebase-interactive-assert commit))
       (magit-run-git-sequencer "rebase" "-i" commit args)


### PR DESCRIPTION
Replica of the magit-rebase-autosquash fix from commit
f1afebf6b6e6128c701f87f6bfa3d9ffca938de3. See #2011.
