### PR TITLE
Use uniquify.el for uniquifiying buffer names

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -74,9 +74,7 @@
 (defcustom magit-diff-buffer-name-format "*magit-diff: %a*"
   "Name format for buffers used to display a diff.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :package-version '(magit . "2.1.0")
   :group 'magit-diff
   :type 'string)
@@ -243,9 +241,7 @@ many spaces.  Otherwise, highlight neither."
 (defcustom magit-revision-buffer-name-format "*magit-rev: %a*"
   "Name format for buffers used to display a commit.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :package-version '(magit . "2.1.0")
   :group 'magit-revision
   :type 'string)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -59,9 +59,7 @@
 (defcustom magit-log-buffer-name-format "*magit-log: %a*"
   "Name format for buffers used to display log entries.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :package-version '(magit . "2.1.0")
   :group 'magit-log
   :type 'string)
@@ -204,9 +202,7 @@ be nil, in which case no usage information is shown."
 (defcustom magit-cherry-buffer-name-format "*magit-cherry: %a*"
   "Name format for buffers used to display commits not merged upstream.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :group 'magit-log
   :type 'string)
 
@@ -223,9 +219,7 @@ The following `format'-like specs are supported:
 (defcustom magit-reflog-buffer-name-format "*magit-reflog: %a*"
   "Name format for buffers used to display reflog entries.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :package-version '(magit . "2.1.0")
   :group 'magit-log
   :type 'string)

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -459,6 +459,8 @@ the function `magit-toplevel'."
                    (equal default-directory topdir)))
             (buffer-list)))
 
+(add-to-list 'uniquify-list-buffers-directory-modes 'magit-status-mode)
+
 (defun magit-mode-get-buffer (format mode &optional topdir create)
   (if (not (string-match-p "%[ab]" format))
       (funcall (if create #'get-buffer-create #'get-buffer) format)
@@ -477,7 +479,12 @@ the function `magit-toplevel'."
                           (string-match-p (format "^%s$" (regexp-quote name))
                                           (buffer-name))))
                    (buffer-list))
-          (and create (generate-new-buffer name))))))
+          (and create (let ((buf (generate-new-buffer name)))
+                        (with-current-buffer buf
+                          (setq list-buffers-directory default-directory))
+                        (uniquify-rationalize-file-buffer-names
+                         name (file-name-directory (directory-file-name topdir)) buf)
+                        buf))))))
 
 (defun magit-mode-get-buffer-create (format mode &optional topdir)
   (magit-mode-get-buffer format mode topdir t))

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -465,6 +465,18 @@ the function `magit-toplevel'."
               'magit-stash-mode 'magit-stashes-mode 'magit-status-mode ))
 
 (defun magit-mode-get-buffer (format mode &optional topdir create)
+  "Get or create new MODE buffer with name chosen based on FORMAT.
+
+FORMAT may contain one of the following `format'-like specs in
+order to create per-repository buffers:
+%a the absolute filename of the repository toplevel.
+%b the basename of the repository toplevel.
+
+If two repositories have the same basename, then it will be made
+unique according to `uniquify-buffer-name-style'.
+
+If FORMAT contains no specs, then magit will use a single buffer
+of this type for all repositories."
   (if (not (string-match-p "%[ab]" format))
       (funcall (if create #'get-buffer-create #'get-buffer) format)
     (unless topdir

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -459,7 +459,10 @@ the function `magit-toplevel'."
                    (equal default-directory topdir)))
             (buffer-list)))
 
-(add-to-list 'uniquify-list-buffers-directory-modes 'magit-status-mode)
+(mapcar (apply-partially #'add-to-list 'uniquify-list-buffers-directory-modes)
+        (list 'magit-cherry-mode 'magit-diff-mode 'magit-log-mode
+              'magit-reflog-mode 'magit-refs-mode 'magit-revision-mode
+              'magit-stash-mode 'magit-stashes-mode 'magit-status-mode ))
 
 (defun magit-mode-get-buffer (format mode &optional topdir create)
   (if (not (string-match-p "%[ab]" format))

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -479,12 +479,15 @@ the function `magit-toplevel'."
                           (string-match-p (format "^%s$" (regexp-quote name))
                                           (buffer-name))))
                    (buffer-list))
-          (and create (let ((buf (generate-new-buffer name)))
-                        (with-current-buffer buf
-                          (setq list-buffers-directory default-directory))
-                        (uniquify-rationalize-file-buffer-names
-                         name (file-name-directory (directory-file-name topdir)) buf)
-                        buf))))))
+          (and create
+               (let ((buf (generate-new-buffer name)))
+                 (when topdir
+                   (with-current-buffer buf
+                     (setq list-buffers-directory default-directory))
+                   (uniquify-rationalize-file-buffer-names
+                    name (file-name-directory (directory-file-name topdir))
+                    buf))
+                 buf))))))
 
 (defun magit-mode-get-buffer-create (format mode &optional topdir)
   (magit-mode-get-buffer format mode topdir t))

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -51,9 +51,7 @@
 (defcustom magit-process-buffer-name-format "*magit-process: %a*"
   "Name format for buffers where output of processes is put.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :package-version '(magit . "2.1.0")
   :group 'magit-process
   :type 'string)

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -301,9 +301,7 @@ instead of \"Stashes:\"."
 (defcustom magit-stashes-buffer-name-format "*magit-stashes: %a*"
   "Name format for buffers used to list stashes.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :package-version '(magit . "2.1.0")
   :group 'magit-modes
   :type 'string)
@@ -343,9 +341,7 @@ The following `format'-like specs are supported:
 (defcustom magit-stash-buffer-name-format "*magit-stash: %a*"
   "Name format for buffers used to show stash diffs.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :package-version '(magit . "2.1.0")
   :group 'magit-modes
   :type 'string)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -134,9 +134,7 @@ The function is given one argument, the status buffer."
 (defcustom magit-status-buffer-name-format "*magit: %a*"
   "Name format for buffers used to display a repository's status.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :package-version '(magit . "2.1.0")
   :group 'magit-status
   :type 'string)
@@ -166,9 +164,7 @@ The following `format'-like specs are supported:
 (defcustom magit-refs-buffer-name-format "*magit-refs: %a*"
   "Name format for buffers used to display and manage refs.
 
-The following `format'-like specs are supported:
-%a the absolute filename of the repository toplevel.
-%b the basename of the repository toplevel."
+See `magit-mode-get-buffer' for an explanation of formats."
   :package-version '(magit . "2.1.0")
   :group 'magit-refs
   :type 'string)

--- a/t/magit-tests.el
+++ b/t/magit-tests.el
@@ -139,6 +139,22 @@
      (should (equal nil (magit-get-next-tag)))
      (magit-call-git "tag" "-d" "FIRST"))))
 
+(ert-deftest magit-uniquified-buffer-names ()
+  "Test magit buffer name handling."
+  (magit-tests--with-temp-dir
+    (magit-call-git "init" "sub1/repo")
+    (magit-call-git "init" "sub2/repo")
+    (let ((dir default-directory)
+          (magit-status-buffer-name-format "*magit-status: %b*"))
+      (magit-status (concat dir "sub1/repo"))
+      (should (equal (buffer-name) "*magit-status: repo*"))
+      (magit-status (concat dir "sub2/repo")) ; should be uniquified
+      (should-not (equal (buffer-name) "*magit-status: repo*"))
+      ;; Buffer should be reused despite uniquifiying.
+      (let ((sub2-status (current-buffer)))
+        (magit-status (concat dir "sub2/repo"))
+        (should (equal (current-buffer) sub2-status))))))
+
 ;;;; config
 
 (ert-deftest magit-config-get-boolean ()


### PR DESCRIPTION
(Re-roll of  #2056) @npostavs said:

There might be a problem if `topdir` is `nil`. I couldn't remember under what scenario that happens.