### PR TITLE
Adds recommended magit-status keybinding

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -2120,7 +2120,10 @@ library getting in the way.  Then restart Emacs.\n"
     (progn (magit-startup-asserts)
            (magit-version))
   (add-hook 'after-init-hook #'magit-startup-asserts t)
-  (add-hook 'after-init-hook #'magit-version t))
+  (add-hook 'after-init-hook #'magit-version t)
+  (let ((recommended-key-binding  (kbd "C-x C-g")))
+		 (when (not (lookup-key (current-global-map) recommended-key-binding))
+		    (global-set-key recommended-key-binding 'magit-status))))
 
 ;; Local Variables:
 ;; coding: utf-8


### PR DESCRIPTION
If `C-x C-g` is not already bound, we bind `magit-status` to it