### PR TITLE
Push like Git would

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -981,6 +981,11 @@ Return a list of two integers: (A>B B>A)."
                                nil nil nil 'magit-revision-history default)
         (user-error "Nothing selected"))))
 
+(defun magit-read-another-local-branch (prompt)
+  (magit-completing-read prompt (magit-list-local-branch-names)
+                         nil t nil 'magit-revision-history
+                         (magit-branch-at-point)))
+
 (defun magit-read-tag (prompt &optional require-match)
   (magit-completing-read prompt (magit-list-tags) nil
                          require-match nil 'magit-revision-history

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -172,6 +172,9 @@ then read the remote."
               (?p "Set publish"   "++set-publish"))
   :actions  '(
               (?e "Explicit..."   magit-push-explicit)
+              (?p "Publish"       magit-push-publish)
+              (?r "Publish..."    magit-push-publish-another)
+              nil
               (?t "Tip"           magit-push-tip)
               (?T "Tip..."        magit-push-tip-to)
               nil nil nil
@@ -195,6 +198,19 @@ then read the remote."
   (magit-run-git-async-no-revert
    (and mode (list "-c" (format "push.default=%s" mode)))
    "push" "-v" args refspec*))
+
+;;;; Publish
+
+;;;###autoload
+(defun magit-push-publish (args)
+  (interactive (list (magit-push-arguments)))
+  )
+
+;;;###autoload
+(defun magit-push-publish-another (branch args)
+  (interactive (list (magit-read-another-local-branch "Publish")
+                     (magit-push-arguments)))
+  )
 
 ;;;; Explicit
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -2093,12 +2093,14 @@ Git, and Emacs in the echo area."
       (message "Cannot determine Magit's version"))
     magit-version))
 
+(defun magit-git-version ()
+  (let ((output (substring (magit-git-string "version") 12)))
+    (string-match "^\\([0-9]+\\.[0-9]+\\.[0-9]+\\)" output)
+    (match-string 1 output)))
+
 (defun magit-startup-asserts ()
-  (let* ((magit-git-global-arguments nil)
-         (version (ignore-errors (substring (magit-git-string "version") 12))))
-    (when version
-      (when (string-match "^\\([0-9]+\\.[0-9]+\\.[0-9]+\\)" version)
-        (setq version (match-string 1 version)))
+  (let ((magit-git-global-arguments nil))
+    (-when-let (version (ignore-errors (magit-git-version)))
       (when (version< version "1.9.4")
         (display-warning 'magit (format "\
 Magit requires Git >= 1.9.4, you are using %s.


### PR DESCRIPTION
The first commit replaces the old push variants with new ones which do what Git would do. This is not finished. It hasn't been tested and some commands don't do anything at all yet. But it gives an idea of what variants will be available once I have completed this.

The second commit adds stubs for the push variants which push to the planned publish remote. This requires work elsewhere too. I am adding this here so that we now have a list of all push variants that are currently in planning.