### PR TITLE
Remove magit-diff-highlight-whitespace from documentation

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3555,7 +3555,6 @@ You should check the values of at least the following variables:
 - ~magit-diff-auto-show~
 - ~magit-diff-highlight-hunk-body~
 - ~magit-diff-highlight-indentation~
-- ~magit-diff-highlight-whitespace~
 - ~magit-diff-paint-whitespace~
 - ~magit-diff-refine-hunk~
 - ~magit-not-reverted-hook~

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -5158,9 +5158,6 @@ You should check the values of at least the following variables:
 @code{magit-diff-highlight-indentation}
 
 @item
-@code{magit-diff-highlight-whitespace}
-
-@item
 @code{magit-diff-paint-whitespace}
 
 @item


### PR DESCRIPTION
When trying to figure out how to turn of background highlighting in magit's diff view, I realized this variable doesn't seem to exist in the codebase.