### PR TITLE
docs: fix broken link to bug report about emacs hanging due to tramp

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -4491,9 +4491,9 @@ also affects the diffs displayed inside Magit.
 ** Emacs 24.5 hangs when loading Magit
 
 This is actually triggered by loading Tramp.  See
-https://debbugs.gnu.org/cgi/bugreport.cgi?bug~20015 for details. You
-can work around the problem by setting
-~tramp-ssh-controlmaster-options~. Changing your DNS server (e.g. to
+https://lists.gnu.org/archive/html/bug-gnu-emacs/2015-03/msg00203.html
+for details. You can work around the problem by setting
+~tramp-ssh-controlmaster-options~.  Changing your DNS server (e.g. to
 Google's ~8.8.8.8~) may also be sufficient to work around the issue.
 
 * Keystroke Index


### PR DESCRIPTION
---

I'm getting a broken link [here](https://debbugs.gnu.org/cgi/bugreport.cgi?bug~20015):

>  An error occurred. Error was: No bug number 

However, I'm not 100% I found the correct replacement link because it [mentions emacs 25.0.50](https://lists.gnu.org/archive/html/bug-gnu-emacs/2015-03/msg00203.html), whereas the faq mentions emacs 24.5. But it *seems* to be the correct bug report?

(Original link has a robots.txt apparently, so it seems as though it was not archived anywhere.)