### PR TITLE
Hunk file posititioning

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -928,12 +928,19 @@ or `HEAD'."
 (defun magit-diff-hunk-line (section)
   (let* ((value  (magit-section-value section))
          (prefix (- (length value) 2))
+         (cpos   (marker-position (magit-section-content section)))
          (stop   (line-number-at-pos))
+         (cstart (save-excursion (goto-char cpos) (line-number-at-pos)))
          (line   (car (last value))))
     (string-match "^\\+\\([0-9]+\\)" line)
     (setq line (string-to-number (match-string 1 line)))
+    (when (> cstart stop)
+      (save-excursion
+        (goto-char cpos)
+        (re-search-forward "^[-+]")
+        (setq stop (line-number-at-pos))))
     (save-excursion
-      (goto-char (magit-section-content section))
+      (goto-char cpos)
       (while (< (line-number-at-pos) stop)
         (unless (string-match-p
                  "-" (buffer-substring (point) (+ (point) prefix)))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -942,7 +942,8 @@ or `HEAD'."
     line))
 
 (defun magit-diff-hunk-column (section)
-  (if (looking-at "-")
+  (if (or (< (point) (magit-section-content section))
+          (save-excursion (beginning-of-line) (looking-at-p "-")))
       0
     (max 0 (- (+ (current-column) 2)
               (length (magit-section-value section))))))


### PR DESCRIPTION
re: the second commit

When point is on the file or hunk header, I think it is more useful to
go to the first changed line rather than the first context line.
Thoughts?