### PR TITLE
Make magit-clone expand relative file names.

### DIFF
--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -38,10 +38,11 @@
   "Clone the REPOSITORY to DIRECTORY."
   (interactive
    (let  ((url (magit-read-string "Clone repository")))
-     (list url (read-directory-name
-                "Clone to: " nil nil nil
-                (and (string-match "\\([^./]+\\)\\(\\.git\\)?$" url)
-                     (match-string 1 url))))))
+     (list url (expand-file-name
+                (read-directory-name
+                 "Clone to: " nil nil nil
+                 (and (string-match "\\([^./]+\\)\\(\\.git\\)?$" url)
+                      (match-string 1 url)))))))
   (make-directory directory t)
   (magit-run-git "clone" repository directory))
 


### PR DESCRIPTION
Invoking magit-clone from /home/user/subdir with a request to clone a
repo into ~/subdir/repo results in a repo in
/home/user/subdir/~/subdir/repo.

Expand the directory name to an absolute path before passing to git-clone.