### PR TITLE
Always use RFC2822 format for GIT_COMMITTER_DATE

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -143,7 +143,7 @@ used to inverse the meaning of the prefix argument.
   (when (setq args (magit-commit-assert args (not override-date)))
     (let ((process-environment process-environment))
       (unless override-date
-        (setenv "GIT_COMMITTER_DATE" (magit-rev-format "%cd")))
+        (setenv "GIT_COMMITTER_DATE" (magit-rev-format "%cD")))
       (magit-run-git-with-editor "commit" "--amend" "--no-edit" args))))
 
 ;;;###autoload
@@ -163,7 +163,7 @@ and ignore the option.
                        magit-commit-reword-override-date)))
   (let ((process-environment process-environment))
     (unless override-date
-      (setenv "GIT_COMMITTER_DATE" (magit-rev-format "%cd")))
+      (setenv "GIT_COMMITTER_DATE" (magit-rev-format "%cD")))
     (magit-run-git-with-editor "commit" "--amend" "--only" args)))
 
 ;;;###autoload


### PR DESCRIPTION
Fixes issue mentioned here: https://github.com/magit/magit/issues/1645#issuecomment-117636222