### PR TITLE
Double-check that directory is a directory

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -294,7 +294,8 @@ call function WASHER with no argument."
                (file-name-as-directory (if file
                                            (expand-file-name file)
                                          default-directory)))))
-       (while (not (file-accessible-directory-p default-directory))
+       (while (not (and (file-accessible-directory-p default-directory)
+                        (file-directory-p default-directory)))
          (when (string-equal default-directory "/")
            (throw 'unsafe-default-dir nil))
          (setq default-directory


### PR DESCRIPTION
For some reason, magit blame was failing with exactly one file that I
have, saying that I was not visiting a tracked file.

After some debugging, it looked like magit was setting
`default-directory' to `/path/to/file.py/' instead of `/path/to/'.

Something might be wrong with the way that emacs keeps track of whether
or not a node is a file or a directory on OSX.