### PR TITLE
depend on async to guarantee untainted builds

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -11,7 +11,7 @@
 ;;	Marius Vollmer <marius.vollmer@gmail.com>
 ;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
 
-;; Package-Requires: ((emacs "24.4") (dash "2.10.0") (with-editor "2.1.0"))
+;; Package-Requires: ((emacs "24.4") (dash "2.11.0") (with-editor "20150808"))
 ;; Keywords: git tools vc
 ;; Homepage: https://github.com/magit/magit
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -47,12 +47,6 @@
 (defvar magit-blame-mode)
 (defvar git-rebase-line)
 
-;; Work around the dreaded Elpa issue.
-(cl-eval-when (compile)
-  (cl-defstruct magit-section
-    type value start content end hidden washer refined
-    source diff-header process parent children))
-
 (require 'diff-mode)
 (require 'smerge-mode)
 

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -12,7 +12,7 @@
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
 
-;; Package-Requires: ((emacs "24.4") (dash "2.10.0"))
+;; Package-Requires: ((emacs "24.4") (async "20150807") (dash "2.11.0"))
 ;; Keywords: bindings
 ;; Homepage: https://github.com/magit/magit
 
@@ -52,6 +52,10 @@
 (require 'cl-lib)
 (require 'dash)
 (require 'format-spec)
+
+(and (require 'async-bytecomp nil t)
+     (fboundp 'async-bytecomp-package-mode)
+     (async-bytecomp-package-mode 1))
 
 (declare-function info 'info)
 (declare-function Man-find-section 'man)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -14,7 +14,7 @@
 ;;	Rémi Vanicat      <vanicat@debian.org>
 ;;	Yann Hodique      <yann.hodique@gmail.com>
 
-;; Package-Requires: ((emacs "24.4") (dash "2.10.0") (with-editor "2.1.0") (git-commit "2.1.0") (magit-popup "2.1.0"))
+;; Package-Requires: ((emacs "24.4") (async "20150807") (dash "2.11.0") (with-editor "20150808") (git-commit "20150808") (magit-popup "20150808"))
 ;; Keywords: git tools vc
 ;; Homepage: https://github.com/magit/magit
 

--- a/lisp/with-editor.el
+++ b/lisp/with-editor.el
@@ -8,7 +8,7 @@
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
 
-;; Package-Requires: ((emacs "24.4") (dash "2.10.0"))
+;; Package-Requires: ((emacs "24.4") (async "20150807") (dash "2.11.0"))
 ;; Keywords: tools
 ;; Homepage: https://github.com/magit/magit
 
@@ -83,6 +83,10 @@
 (require 'server)
 (require 'tramp)
 (require 'tramp-sh nil t)
+
+(and (require 'async-bytecomp nil t)
+     (fboundp 'async-bytecomp-package-mode)
+     (async-bytecomp-package-mode 1))
 
 (eval-when-compile
   (progn (require 'dired nil t)


### PR DESCRIPTION
Usually building a new version of Magit does not require a clean environment (one in which no older version of Magit has been loaded yet). But when updating from `v1.*` to `v2.*` then it is required. Unfortunately many users who get Magit from Melpa never saw the update instructions, which explain that they have to do the uninstall-restart-reinstall dance.

That's not their fault because when they updated to `>=20150701` there was nothing that indicated that this would be different from previous updates. Likewise it's not the fault of the Melpa maintainers, because they are not responsible for `package.el` itself. It's nobodies fault, but we still have to fix it - I've had it with those "impossible bugs" where the user and the code don't agree about what can possibly happen.

So I have added `magit` to `async-bytecomp-allowed-packages` in https://github.com/jwiegley/emacs-async/pull/50. Once that has been merged and hit Melpa, I will update the `async` snapshot version `magit` depends on, and then merge this.

Before the Magit `2.2.0` release we have to ask @jwiegley to create a `async` release because that is the only way for this to also take effect for users of Melpa-Stable. Then after the release we have to set back the `async` version we depend on to a snapshot version, because not all Melpa (unstable) users will have updated between now and then. Sight.

Also see http://emacs.stackexchange.com/questions/13574 where Stefan acknowledges that the issue is real and cannot always be blamed on bad development practices.