### PR TITLE
Allow switching to toplevel directory from a subdirectory of repo.

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -142,7 +142,9 @@ The following `format'-like specs are supported:
   :type 'string)
 
 (defcustom magit-status-prompt-for-init nil
-  "Prompt for initializing a git repo when current directory is not a git repo."
+  "Prompt for initializing a git repo when current directory is not a git repo.
+When top level directory is not found prompt for creation even if
+`magit-status-prompt-for-init' is nil."
   :package-version '(magit . "2.1.0")
   :group 'magit-status
   :type 'boolean)
@@ -372,14 +374,15 @@ then offer to initialize it as a new repository."
         (setq directory (file-name-as-directory (expand-file-name directory)))
         (if (and toplevel (string-equal directory toplevel))
             (magit-status-internal directory)
-          (if (and magit-status-prompt-for-init
+          (if (and (or magit-status-prompt-for-init
+                       (null toplevel))
                    (y-or-n-p
                     (if toplevel
                         (format "%s is a repository.  Create another in %s? "
                                 toplevel directory)
                         (format "Create repository in %s? " directory))))
               (magit-init directory)
-              (magit-status-internal toplevel))))
+              (and toplevel (magit-status-internal toplevel)))))
     (magit-status-internal default-directory)))
 
 (put 'magit-status 'interactive-only 'magit-status-internal)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -141,6 +141,12 @@ The following `format'-like specs are supported:
   :group 'magit-status
   :type 'string)
 
+(defcustom magit-status-prompt-for-init nil
+  "Prompt for initializing a git repo when current directory is not a git repo."
+  :package-version '(magit . "2.1.0")
+  :group 'magit-status
+  :type 'boolean)
+
 ;;;; Refs Mode
 
 (defgroup magit-refs nil
@@ -366,12 +372,14 @@ then offer to initialize it as a new repository."
         (setq directory (file-name-as-directory (expand-file-name directory)))
         (if (and toplevel (string-equal directory toplevel))
             (magit-status-internal directory)
-          (when (y-or-n-p
-                 (if toplevel
-                     (format "%s is a repository.  Create another in %s? "
-                             toplevel directory)
-                   (format "Create repository in %s? " directory)))
-            (magit-init directory))))
+          (if (and magit-status-prompt-for-init
+                   (y-or-n-p
+                    (if toplevel
+                        (format "%s is a repository.  Create another in %s? "
+                                toplevel directory)
+                        (format "Create repository in %s? " directory))))
+              (magit-init directory)
+              (magit-status-internal toplevel))))
     (magit-status-internal default-directory)))
 
 (put 'magit-status 'interactive-only 'magit-status-internal)


### PR DESCRIPTION
Hi, 

with 1.4.2 I was able to open magit-status from helm, now it is possible only from toplevel directory.
Now I am prompted for creation of a new repo:

.../github/magit/ is a repository.  Create another in .../github/magit/lisp/? (y or n)

I added a new var to not be prompted when toplevel dir exists, otherwise if it doesn't exists
you are anyway prompted.

Perhaps you will want to change the var name which is not the best, I hope also my changes don't modify the original behavior too much.

Thanks.

