### PR TITLE
Fix bug where magit-status wouldn't work because of files in working directory

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -809,8 +809,8 @@ Return a list of two integers: (A>B B>A)."
         (magit-git-success "update-ref" "-m" "enable reflog" ref oldrev "")))))
 
 (defun magit-rev-format (format &optional rev)
-  "Return output of `git show -s --format=FORMAT [REV]'."
-  (magit-git-string "show" "-s" (concat "--format=" format) rev))
+  "Return output of `git show -s --format=FORMAT [REV]' --."
+  (magit-git-string "show" "-s" (concat "--format=" format) rev "--"))
 
 (defun magit-format-rev-summary (rev)
   (--when-let (magit-rev-format "%h %s" rev)


### PR DESCRIPTION
In some working directories `magit-status` would only open an empty buffer and display the message

    magit-process-insert-section: Wrong type argument: arrayp, nil

The problem was in `magit-rev-format`. Enabling `magit-git-debug` revealed that its git invocation failed with this message:

    128 git … show -s --format=%h %s FOO
    fatal: ambiguous argument 'FOO': both revision and filename
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'

This fix adds the disambiguating "--", which makes `magit-status` work even if there are unfortunately named files in the working directory.