### PR TITLE
Clarify magit-popup-use-prefix-argument options

### DIFF
--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -117,8 +117,8 @@ that without users being aware of it could lead to tears.
 `nil'      Ignore prefix arguments."
   :group 'magit-popup
   :type '(choice
-          (const :tag "Use default action, else show popup" default)
-          (const :tag "Show popup, else use default action" popup)
+          (const :tag "With prefix use default action (without prefix show popup)" default)
+          (const :tag "With prefix show popup (without prefix use default action)" popup)
           (const :tag "Ignore prefix argument" nil)
           (const :tag "Abort and show usage information" disabled)))
 


### PR DESCRIPTION
The value options in the Customize interface for `magit-popup-use-prefix-argument` can be confusing at first glance, because the menu of options does not show the context for the "if-then-else" values.

It's not ambiguous as such, but a small wording tweak means no one will have to double-check the name of the variable to be certain of what each value means.

n.b. I can see that the code base is pretty good at sticking within 80 column lines, and this change makes these lines longer, but I wasn't sure what your preferred format would be if that was to be avoided. Happy to re-roll as required.