### PR TITLE
New commands magit-branch-spinoff and magit-branch-reset

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2732,6 +2732,32 @@ Also see [[info:gitman#git-branch]] and [[info:gitman#git-checkout]].
   This command creates a new branch like ~magit-branch~, but then also
   checks it out.
 
+- Key: b s, magit-branch-spinoff
+
+  This command creates and checks out a new branch starting at and
+  tracking the current branch.  That branch in turn is reset to the
+  last commit it shares with its upstream.  If the current branch has
+  no upstream or no unpushed commits, then the new branch is created
+  anyway and the previously current branch is not touched.
+
+  This is useful to create a feature branch after work has already
+  began on the old branch (likely but not necessarily "master").
+
+- Key: b x, magit-branch-reset
+
+  This command resets a branch, defaulting to the branch at point, to
+  the tip of another branch or any other commit.
+
+  When resetting to another branch, then that branch is also set as
+  the upstream of the branch being reset.
+
+  When the branch being reset is the current branch, then a hard reset
+  is performed.  If there are any uncommitted changes, then the user
+  has to confirming the reset because those changes would be lost.
+
+  This is useful when you have started work on a feature branch but
+  realize it's all crap and want to start over.
+
 - Key: b d, magit-branch-delete
 
   Delete one or multiple branches.  If the region marks multiple

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -3822,6 +3822,36 @@ minibuffer.
 This command creates a new branch like @code{magit-branch}, but then also
 checks it out.
 
+@kindex b s
+@cindex magit-branch-spinoff
+@item @kbd{b s} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-spinoff})
+
+This command creates and checks out a new branch starting at and
+tracking the current branch.  That branch in turn is reset to the
+last commit it shares with its upstream.  If the current branch has
+no upstream or no unpushed commits, then the new branch is created
+anyway and the previously current branch is not touched.
+
+This is useful to create a feature branch after work has already
+began on the old branch (likely but not necessarily "master").
+
+@kindex b x
+@cindex magit-branch-reset
+@item @kbd{b x} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-reset})
+
+This command resets a branch, defaulting to the branch at point, to
+the tip of another branch or any other commit.
+
+When resetting to another branch, then that branch is also set as
+the upstream of the branch being reset.
+
+When the branch being reset is the current branch, then a hard reset
+is performed.  If there are any uncommitted changes, then the user
+has to confirming the reset because those changes would be lost.
+
+This is useful when you have started work on a feature branch but
+realize it's all crap and want to start over.
+
 @kindex b d
 @cindex magit-branch-delete
 @item @kbd{b d} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-delete})

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1151,7 +1151,9 @@ Non-interactively DIRECTORY is (re-)initialized unconditionally."
               (?r "Rename"            magit-branch-rename)
               (?B "Create & checkout" magit-branch-and-checkout)
               (?e "Set description"   magit-branch-edit-description)
-              (?v "(Branch Manager)"  magit-branch-manager))
+              (?v "(Branch Manager)"  magit-branch-manager)
+              (?s "Spin off"          magit-branch-spinoff) nil nil
+              (?x "Reset"             magit-branch-reset))
   :default-arguments '("--track")
   :default-action 'magit-checkout
   :max-action-columns 3)
@@ -1201,6 +1203,69 @@ changes.
     (unless (magit-branch-p start)
       (setq args (delete "--track" args)))
     (list branch start args)))
+
+;;;###autoload
+(defun magit-branch-spinoff (branch &rest args)
+  "Create new branch from the unpushed commits.
+
+Create and checkout a new branch starting at and tracking the
+current branch.  That branch in turn is reset to the last commit
+it shares with its upstream.  If the current branch has no
+upstream or no unpushed commits, then the new branch is created
+anyway and the previously current branch is not touched.
+
+This is useful to create a feature branch after work has already
+began on the old branch (likely but not necessarily \"master\")."
+  (interactive (list (magit-read-string "Spin off branch")
+                     (magit-branch-arguments)))
+  (-if-let (current (magit-get-current-branch))
+      (let (tracked base)
+        (magit-call-git "checkout" args "-b" branch current)
+        (if (and (setq tracked (magit-get-tracked-branch current))
+                 (setq base (magit-git-string "merge-base" current tracked))
+                 (not (magit-rev-equal base current)))
+            (magit-run-git "update-ref" "-m"
+                           (format "reset: moving to %s" base)
+                           (concat "refs/heads/" current) base)
+          (magit-refresh)))
+    (magit-run-git "checkout" "-b" branch)))
+
+;;;###autoload
+(defun magit-branch-reset (branch to &optional args)
+  "Reset a branch to the tip of another branch or any other commit.
+
+When resetting to another branch, then also set that branch as
+the upstream of the branch being reset.
+
+When the branch being reset is the current branch, then do a
+hard reset.  If there are any uncommitted changes, then the user
+has to confirming the reset because those changes would be lost.
+
+This is useful when you have started work on a feature branch but
+realize it's all crap and want to start over."
+  (interactive
+   (let* ((atpoint (magit-branch-at-point))
+          (branch  (magit-read-local-branch "Reset branch" atpoint)))
+     (list branch
+           (magit-completing-read "Reset %s to"
+                                  (delete branch (magit-list-branch-names))
+                                  nil nil nil 'magit-revision-history
+                                  (or (and (not (equal branch atpoint)) atpoint)
+                                      (magit-get-tracked-branch branch)))
+           (magit-branch-arguments))))
+  (unless (member "--force" args)
+    (setq args (cons "--force" args)))
+  (if (magit-branch-p to)
+      (unless (member "--track" args)
+        (setq args (cons "--track" args)))
+    (setq args (delete "--track" args)))
+  (if (equal branch (magit-get-current-branch))
+      (if (and (magit-anything-modified-p)
+               (not (yes-or-no-p "Uncommitted changes will be lost.  Proceed?")))
+          (user-error "Abort")
+        (magit-reset-hard to)
+        (magit-branch-set-upstream branch to))
+    (magit-branch branch to args)))
 
 ;;;###autoload
 (defun magit-branch-delete (branches &optional force)


### PR DESCRIPTION
These are the broken implementations which were removed in cbb8c94aa8075770e3a56020688b6abc3d03f25b. I did not get around to implement non-broken ones yet.