### PR TITLE
Quit window without restoring previous window configuration

### DIFF
--- a/Documentation/RelNotes/2.3.0.txt
+++ b/Documentation/RelNotes/2.3.0.txt
@@ -21,5 +21,10 @@ Changes since v2.2.0
 
 THIS IS NOT COMPLETE.
 
+* Added new option `magit-bury-buffer-function' to give users more
+  control over how Magit buffers are buried, replacing the old binary
+  option `magit-restore-window-configuration'.  The default is still
+  the same, i.e. `magit-restore-window-configuration' is used.  #2193
+
 Authors
 -------

--- a/Documentation/RelNotes/2.3.0.txt
+++ b/Documentation/RelNotes/2.3.0.txt
@@ -26,5 +26,8 @@ THIS IS NOT COMPLETE.
   option `magit-restore-window-configuration'.  The default is still
   the same, i.e. `magit-restore-window-configuration' is used.  #2193
 
+* Added new function `magit-mode-quit-window' as a simpler variant to
+  `magit-restore-window-configuration'.  #2193
+
 Authors
 -------


### PR DESCRIPTION
Restoring the previous window configuration often means restoring a configuration we are no longer interested in. This is a better compromise between `quit-window` and restoring the configuration. But it might still have to be refined a bit.