### PR TITLE
Basic blob navigation

### DIFF
--- a/Documentation/RelNotes/2.3.0.txt
+++ b/Documentation/RelNotes/2.3.0.txt
@@ -98,7 +98,8 @@ THIS IS NOT COMPLETE.
 * Renamed `magit-file-buffer-mode' to `magit-file-mode'.  Related
   symbols were renamed accordingly.
 
-* Added new minor mode `magit-blob-mode'.  #2195
+* Added new minor mode `magit-blob-mode' and new commands
+  `magit-blob-previous' and `magit-blob-next'.  #2195
 
 Authors
 -------

--- a/Documentation/RelNotes/2.3.0.txt
+++ b/Documentation/RelNotes/2.3.0.txt
@@ -98,5 +98,7 @@ THIS IS NOT COMPLETE.
 * Renamed `magit-file-buffer-mode' to `magit-file-mode'.  Related
   symbols were renamed accordingly.
 
+* Added new minor mode `magit-blob-mode'.  #2195
+
 Authors
 -------

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3875,6 +3875,17 @@ few key bindings, but this might be extended in the future.
   This prefix command shows suffix commands along with the appropriate
   infix arguments in a popup buffer.  See [[*Initiating a commit]].
 
+** Minor mode for buffers visiting blobs
+
+The ~magit-blob-mode~ enables certain Magit features in blob-visiting
+buffers.  Such buffers can be created using ~magit-find-file~ and some
+of the commands mentioned below, which also take care of turning on
+this minor mode.  Currently this mode only establishes a few key
+bindings, but this might be e
+
+- Key: q, magit-kill-this-buffer
+
+  Kill the current buffer.
 
 * Customizing
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3845,6 +3845,10 @@ few key bindings, but this might be extended in the future.
   bindings suggested in [[*Getting started]] (but only for file-visiting
   buffers), and additionally binds ~C-c M-g~ to ~magit-file-popup~.
 
+- Key: p, magit-blob-previous
+
+  Visit the previous blob which modified the current file.
+
 - Key: C-c M-g, magit-file-popup
 
   This prefix command shows a popup buffer featuring suffix commands
@@ -3882,6 +3886,14 @@ buffers.  Such buffers can be created using ~magit-find-file~ and some
 of the commands mentioned below, which also take care of turning on
 this minor mode.  Currently this mode only establishes a few key
 bindings, but this might be e
+
+- Key: p, magit-blob-previous
+
+  Visit the previous blob which modified the current file.
+
+- Key: n, magit-blob-next
+
+  Visit the next blob which modified the current file.
 
 - Key: q, magit-kill-this-buffer
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -5541,6 +5541,12 @@ buffers), and additionally binds @code{C-c M-g} to @code{magit-file-popup}.
 @end defopt
 
 @table @asis
+@kindex p
+@cindex magit-blob-previous
+@item @kbd{p} @tie{}@tie{}@tie{}@tie{}(@code{magit-blob-previous})
+
+Visit the previous blob which modified the current file.
+
 @kindex C-c M-g
 @cindex magit-file-popup
 @item @kbd{C-c M-g} @tie{}@tie{}@tie{}@tie{}(@code{magit-file-popup})
@@ -5593,6 +5599,18 @@ this minor mode.  Currently this mode only establishes a few key
 bindings, but this might be e
 
 @table @asis
+@kindex p
+@cindex magit-blob-previous
+@item @kbd{p} @tie{}@tie{}@tie{}@tie{}(@code{magit-blob-previous})
+
+Visit the previous blob which modified the current file.
+
+@kindex n
+@cindex magit-blob-next
+@item @kbd{n} @tie{}@tie{}@tie{}@tie{}(@code{magit-blob-next})
+
+Visit the next blob which modified the current file.
+
 @kindex q
 @cindex magit-kill-this-buffer
 @item @kbd{q} @tie{}@tie{}@tie{}@tie{}(@code{magit-kill-this-buffer})

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -190,6 +190,7 @@ Miscellaneous
 * Submodules::
 * Wip modes::
 * Minor mode for buffers visiting files::
+* Minor mode for buffers visiting blobs::
 
 Customizing
 
@@ -5122,6 +5123,7 @@ changes made since the sequence started.
 * Submodules::
 * Wip modes::
 * Minor mode for buffers visiting files::
+* Minor mode for buffers visiting blobs::
 @end menu
 
 @node Tagging
@@ -5579,6 +5581,23 @@ the appropriate infix arguments in a popup buffer.  See @ref{Initiating a commit
 
 This prefix command shows suffix commands along with the appropriate
 infix arguments in a popup buffer.  See @ref{Initiating a commit,Initiating a commit}.
+@end table
+
+@node Minor mode for buffers visiting blobs
+@section Minor mode for buffers visiting blobs
+
+The @code{magit-blob-mode} enables certain Magit features in blob-visiting
+buffers.  Such buffers can be created using @code{magit-find-file} and some
+of the commands mentioned below, which also take care of turning on
+this minor mode.  Currently this mode only establishes a few key
+bindings, but this might be e
+
+@table @asis
+@kindex q
+@cindex magit-kill-this-buffer
+@item @kbd{q} @tie{}@tie{}@tie{}@tie{}(@code{magit-kill-this-buffer})
+
+Kill the current buffer.
 @end table
 
 @node Customizing

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -839,6 +839,15 @@ Return a list of two integers: (A>B B>A)."
 (defun magit-abbrev-arg ()
   (format "--abbrev=%d" (magit-abbrev-length)))
 
+(defun magit-commit-children (commit &optional args)
+  (-map #'car
+        (--filter (member commit (cdr it))
+                  (--map (split-string it " ")
+                         (magit-git-lines
+                          "log" "--format=%H %P"
+                          (or args (list "--branches" "--tags" "--remotes"))
+                          "--not" commit)))))
+
 (defun magit-commit-parents (commit)
   (--when-let (magit-git-string "rev-list" "-1" "--parents" commit)
     (cdr (split-string it))))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -929,18 +929,17 @@ alist in `magit-log-format-unicode-graph-alist'."
        (propertize (make-string (1- width) ?\s) 'face 'default)
        (propertize " " 'face 'fringe)))))
 
-(defun magit-format-duration (duration spec width)
+(defun magit-format-duration (duration spec &optional width)
   (cl-destructuring-bind (char unit units weight)
       (car spec)
     (let ((cnt (round (/ duration weight 1.0))))
       (if (or (not (cdr spec))
               (>= (/ duration weight) 1))
-          (if (= width 1)
+          (if (eq width 1)
               (format "%3i%c" cnt char)
-            (format (format "%%3i %%-%is" width) cnt
-                    (if (= cnt 1) unit units)))
+            (format (if width (format "%%3i %%-%is" width) "%i %s")
+                    cnt (if (= cnt 1) unit units)))
         (magit-format-duration duration (cdr spec) width)))))
-
 
 (defun magit-log-maybe-show-more-commits (section)
   "Automatically insert more commit sections in a log.

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1022,6 +1022,7 @@ FILE must be relative to the top directory of the repository."
         (setq buffer-read-only t)
         (set-buffer-modified-p nil)
         (goto-char (point-min))
+        (magit-blob-mode 1)
         (run-hooks 'magit-find-file-hook)
         (current-buffer))))
 
@@ -1946,6 +1947,26 @@ Currently this only adds the following key bindings.
 
 (define-obsolete-function-alias 'global-magit-file-buffer-mode
   'global-magit-file-mode "2.3.0")
+
+;;;; Blob Mode
+
+(defvar magit-blob-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "q" 'magit-kill-this-buffer)
+    map)
+  "Keymap for `magit-blob-mode'.")
+
+(define-minor-mode magit-blob-mode
+  "Enable some Magit features in blob-visiting buffers.
+
+Currently this only adds the following key bindings.
+\n\\{magit-blob-mode-map}"
+  :package-version '(magit . "2.3.0"))
+
+(defun magit-kill-this-buffer ()
+  "Kill the current buffer."
+  (interactive)
+  (kill-buffer (current-buffer)))
 
 ;;;; Dispatch Popup
 


### PR DESCRIPTION
This allows navigating blobs similar to how `git-timemachine` does it. From a buffer visiting a tracked file use `C-c p` to go to the latest blob for that file, then `p` and `n` to navigate between blobs. Unlike `git-timemachine` which uses a some sort of session and displays all blobs in the same buffer, this simple implementation uses a separate buffer for each blob and there is no command to quit the session (i.e. kill all the created buffers). Therefore it is better to move "forward" using `q` instead of `n`, as the former kills the currently visited blob.