### PR TITLE
magit-toplevel: always follow links to repo subdirectories

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -290,10 +290,9 @@ call function WASHER with no argument."
   (declare (indent 1) (debug (form body)))
   `(catch 'unsafe-default-dir
      (let ((default-directory
-             (let ((file ,file))
-               (file-name-as-directory (if file
-                                           (expand-file-name file)
-                                         default-directory)))))
+             (file-name-as-directory (--if-let ,file
+                                         (expand-file-name it)
+                                       default-directory))))
        (while (not (file-accessible-directory-p default-directory))
          (when (string-equal default-directory "/")
            (throw 'unsafe-default-dir nil))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -302,9 +302,11 @@ call function WASHER with no argument."
        ,@body)))
 
 (defun magit-git-dir (&optional path)
-  "Return absolute path to the GIT_DIR for the current repository.
-If optional PATH is non-nil it has to be a path relative to the
-GIT_DIR and its absolute path is returned."
+  "Return absolute path to the control directory of the current repository.
+
+All symlinks are followed.  If optional PATH is non-nil, then
+it has to be a path relative to the control directory and its
+absolute path is returned."
   (magit--with-safe-default-directory nil
     (--when-let (magit-rev-parse-safe "--git-dir")
       (setq it (file-name-as-directory (magit-expand-git-file-name it)))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -313,10 +313,36 @@ absolute path is returned."
       (if path (expand-file-name (convert-standard-filename path) it) it))))
 
 (defun magit-toplevel (&optional file strict)
+  "Return absolute path to the toplevel of the current repository.
+
+The option `find-file-visit-truename' is respected.  The only
+exception is a symlink to a sub-directory of a repository; if
+such a link is involved, then we have no choice but to follow
+it in order to end up inside a repository."
   (magit--with-safe-default-directory file
-    (-if-let (cdup (magit-rev-parse-safe "--show-cdup"))
-        (magit-expand-git-file-name
-         (file-name-as-directory (expand-file-name cdup)))
+    (-if-let (topdir (magit-rev-parse-safe "--show-toplevel"))
+        (let (cdup)
+          (setq topdir (file-name-as-directory topdir))
+          (if (or find-file-visit-truename
+                  ;; ^ User wants to follow all links.
+                  ;; v There are no relevant links.
+                  (and (setq cdup (magit-rev-parse-safe "--show-cdup"))
+                       (equal (expand-file-name cdup) topdir)))
+              topdir
+            (if (equal cdup "")
+                ;; `default-directory' links to toplevel, don't follow.
+                default-directory
+              ;; A directory above `default-directory' is a link...
+              (while (not (file-symlink-p
+                           (directory-file-name default-directory)))
+                (when (string-equal default-directory "/")
+                  (error "Unexpected error while determining toplevel"))
+                (setq default-directory
+                      (file-name-directory
+                       (directory-file-name default-directory))))
+              (if (equal (magit-rev-parse-safe "--show-cdup") "")
+                  default-directory ; ...don't follow link to toplevel.
+                topdir))))          ; ...follow link to subdirectory.
       (unless strict
         (-when-let (gitdir (magit-git-dir))
           (if (magit-bare-repo-p)

--- a/t/magit-tests.el
+++ b/t/magit-tests.el
@@ -30,6 +30,59 @@
 
 ;;; Git
 
+(ert-deftest magit-toplevel ()
+  (magit-with-test-directory
+    (let ((find-file-visit-truename nil))
+      (magit-git "init" "repo")
+      ;; magit--with-safe-default-directory
+      (should (equal (magit-toplevel "repo/")
+                     (magit-toplevel (expand-file-name "repo/"))))
+      (should (equal (magit-toplevel "repo")
+                     (magit-toplevel (expand-file-name "repo/"))))
+      ;; repo
+      (make-directory "repo/subdir/subsubdir" t)
+      (should (equal (magit-toplevel   "repo/")
+                     (expand-file-name "repo/")))
+      (should (equal (magit-toplevel   "repo/")
+                     (expand-file-name "repo/")))
+      (should (equal (magit-toplevel   "repo/subdir/")
+                     (expand-file-name "repo/")))
+      (should (equal (magit-toplevel   "repo/subdir/subsubdir/")
+                     (expand-file-name "repo/")))
+      ;; repo-link
+      (make-symbolic-link "repo" "repo-link")
+      (should (equal (magit-toplevel   "repo-link/")
+                     (expand-file-name "repo-link/")))
+      (should (equal (magit-toplevel   "repo-link/subdir/")
+                     (expand-file-name "repo-link/")))
+      (should (equal (magit-toplevel   "repo-link/subdir/subsubdir/")
+                     (expand-file-name "repo-link/")))
+      ;; *subdir-link
+      (make-symbolic-link "repo/subdir"           "subdir-link")
+      (make-symbolic-link "repo/subdir/subsubdir" "subsubdir-link")
+      (should (equal (magit-toplevel   "subdir-link/")
+                     (expand-file-name "repo/")))
+      (should (equal (magit-toplevel   "subdir-link/subsubdir/")
+                     (expand-file-name "repo/")))
+      (should (equal (magit-toplevel   "subsubdir-link")
+                     (expand-file-name "repo/")))
+      ;; subdir-link-indirect
+      (make-symbolic-link "subdir-link" "subdir-link-indirect")
+      (should (equal (magit-toplevel   "subdir-link-indirect")
+                     (expand-file-name "repo/")))
+      ;; wrap/*link
+      (magit-git "init" "wrap")
+      (make-symbolic-link "../repo"                  "wrap/repo-link")
+      (make-symbolic-link "../repo/subdir"           "wrap/subdir-link")
+      (make-symbolic-link "../repo/subdir/subsubdir" "wrap/subsubdir-link")
+      (should (equal (magit-toplevel   "wrap/repo-link/")
+                     (expand-file-name "wrap/repo-link/")))
+      (should (equal (magit-toplevel   "wrap/subdir-link")
+                     (expand-file-name "repo/")))
+      (should (equal (magit-toplevel   "wrap/subsubdir-link")
+                     (expand-file-name "repo/")))
+      )))
+
 (ert-deftest magit-get-boolean ()
   (magit-with-test-repository
     (magit-git "config" "a.b" "true")


### PR DESCRIPTION
This is intended to be merged before v2.2.2 is released.