### PR TITLE
Support showing log for the region (-L)

### DIFF
--- a/Documentation/RelNotes/2.3.0.txt
+++ b/Documentation/RelNotes/2.3.0.txt
@@ -112,5 +112,7 @@ THIS IS NOT COMPLETE.
 
 * Added new option `magit-log-remove-graph-args'.  #2226
 
+* Added support for showing actionable diffs inside logs.  #2226
+
 Authors
 -------

--- a/Documentation/RelNotes/2.3.0.txt
+++ b/Documentation/RelNotes/2.3.0.txt
@@ -110,5 +110,7 @@ THIS IS NOT COMPLETE.
   `magit-copy-as-kill' and `magit-copy-buffer-thing-as-kill' have been
   removed.  #2225
 
+* Added new option `magit-log-remove-graph-args'.  #2226
+
 Authors
 -------

--- a/Documentation/RelNotes/2.3.0.txt
+++ b/Documentation/RelNotes/2.3.0.txt
@@ -114,5 +114,7 @@ THIS IS NOT COMPLETE.
 
 * Added support for showing actionable diffs inside logs.  #2226
 
+* Added basic support for tracing the evolution of a region.  #2226
+
 Authors
 -------

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1451,6 +1451,19 @@ the status buffer.
 
 *** Log Buffer
 
+- Key: L, magit-log-refresh-popup
+
+  This prefix command shows the following suffix commands along with
+  the appropriate infix arguments in a popup buffer.  See [[*Refreshing
+  logs]].
+
+- Key: q, magit-log-bury-buffer
+
+  Bury the current buffer or the revision buffer in the same frame.
+  Like ~magit-mode-bury-buffer~ (which see) but with a negative prefix
+  argument instead bury the revision buffer, provided it is displayed
+  in the current frame.
+
 - Key: C-c C-b, magit-go-backward
 
   Move backward in current buffer's history.
@@ -1479,32 +1492,25 @@ the status buffer.
   scroll the buffer down.  If there is no commit or stash at point,
   then prompt for a commit.
 
-- Key: q, magit-log-bury-buffer
+- Key: =, magit-log-toggle-commit-limit
 
-  Bury the current buffer or the revision buffer in the same frame.
-  Like ~magit-mode-bury-buffer~ (which see) but with a negative prefix
-  argument instead bury the revision buffer, provided it is displayed
-  in the current frame.
+  Toggle the number of commits the current log buffer is limited to.
+  If the number of commits is currently limited, then remove that
+  limit.  Otherwise set it to 256.
+
+- Key: +, magit-log-double-commit-limit
+
+  Double the number of commits the current log buffer is limited to.
+
+- Key: =, magit-log-half-commit-limit
+
+  Half the number of commits the current log buffer is limited to.
 
 - User Option: magit-log-auto-more
 
   Insert more log entries automatically when moving past the last
   entry.  Only considered when moving past the last entry with
   ~magit-goto-*-section~ commands.
-
-- Key: +, magit-log-show-more-commits
-
-  Increase the number of commits shown in current log.
-
-  With no prefix argument, show twice as many commits as before.
-  With a numerical prefix argument, show this many additional
-  commits.  With a non-numeric prefix argument, show all commits.
-
-  When no limit was previously imposed in the current buffer, set the
-  local limit to the default limit instead (or if that is nil then
-  100), regardless of the prefix argument.
-
-  By default ~magit-log-cutoff-length~ commits are shown.
 
 - User Option: magit-log-show-margin
 
@@ -1517,16 +1523,6 @@ the status buffer.
   When a log buffer contains a verbose log, then the margin is never
   displayed.  In status buffers this option is ignored, but it is
   possible to show the margin using the mentioned command.
-
-- Key: L, magit-log-refresh-popup
-
-  This prefix command shows the following suffix commands along with
-  the appropriate infix arguments in a popup buffer.  See [[*Refreshing
-  logs]].
-
-- User Option: magit-log-cutoff-length
-
-  The maximum number of commits to show in log and reflog buffers.
 
 - User Option: magit-log-show-refname-after-summary
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -2002,6 +2002,22 @@ Show or hide the margin.
 @subsection Log Buffer
 
 @table @asis
+@kindex L
+@cindex magit-log-refresh-popup
+@item @kbd{L} @tie{}@tie{}@tie{}@tie{}(@code{magit-log-refresh-popup})
+
+This prefix command shows the following suffix commands along with
+the appropriate infix arguments in a popup buffer.  See @ref{Refreshing logs,Refreshing logs}.
+
+@kindex q
+@cindex magit-log-bury-buffer
+@item @kbd{q} @tie{}@tie{}@tie{}@tie{}(@code{magit-log-bury-buffer})
+
+Bury the current buffer or the revision buffer in the same frame.
+Like @code{magit-mode-bury-buffer} (which see) but with a negative prefix
+argument instead bury the revision buffer, provided it is displayed
+in the current frame.
+
 @kindex C-c C-b
 @cindex magit-go-backward
 @item @kbd{C-c C-b} @tie{}@tie{}@tie{}@tie{}(@code{magit-go-backward})
@@ -2038,14 +2054,25 @@ and contains information about that commit or stash, then instead
 scroll the buffer down.  If there is no commit or stash at point,
 then prompt for a commit.
 
-@kindex q
-@cindex magit-log-bury-buffer
-@item @kbd{q} @tie{}@tie{}@tie{}@tie{}(@code{magit-log-bury-buffer})
+@kindex =
+@cindex magit-log-toggle-commit-limit
+@item @kbd{=} @tie{}@tie{}@tie{}@tie{}(@code{magit-log-toggle-commit-limit})
 
-Bury the current buffer or the revision buffer in the same frame.
-Like @code{magit-mode-bury-buffer} (which see) but with a negative prefix
-argument instead bury the revision buffer, provided it is displayed
-in the current frame.
+Toggle the number of commits the current log buffer is limited to.
+If the number of commits is currently limited, then remove that
+limit.  Otherwise set it to 256.
+
+@kindex +
+@cindex magit-log-double-commit-limit
+@item @kbd{+} @tie{}@tie{}@tie{}@tie{}(@code{magit-log-double-commit-limit})
+
+Double the number of commits the current log buffer is limited to.
+
+@kindex =
+@cindex magit-log-half-commit-limit
+@item @kbd{=} @tie{}@tie{}@tie{}@tie{}(@code{magit-log-half-commit-limit})
+
+Half the number of commits the current log buffer is limited to.
 
 @end table
 
@@ -2055,25 +2082,6 @@ Insert more log entries automatically when moving past the last
 entry.  Only considered when moving past the last entry with
 @code{magit-goto-*-section} commands.
 @end defopt
-
-@table @asis
-@kindex +
-@cindex magit-log-show-more-commits
-@item @kbd{+} @tie{}@tie{}@tie{}@tie{}(@code{magit-log-show-more-commits})
-
-Increase the number of commits shown in current log.
-
-With no prefix argument, show twice as many commits as before.
-With a numerical prefix argument, show this many additional
-commits.  With a non-numeric prefix argument, show all commits.
-
-When no limit was previously imposed in the current buffer, set the
-local limit to the default limit instead (or if that is nil then
-100), regardless of the prefix argument.
-
-By default @code{magit-log-cutoff-length} commits are shown.
-
-@end table
 
 @defopt magit-log-show-margin
 
@@ -2086,21 +2094,6 @@ current buffer using the command @code{magit-toggle-margin}.
 When a log buffer contains a verbose log, then the margin is never
 displayed.  In status buffers this option is ignored, but it is
 possible to show the margin using the mentioned command.
-@end defopt
-
-@table @asis
-@kindex L
-@cindex magit-log-refresh-popup
-@item @kbd{L} @tie{}@tie{}@tie{}@tie{}(@code{magit-log-refresh-popup})
-
-This prefix command shows the following suffix commands along with
-the appropriate infix arguments in a popup buffer.  See @ref{Refreshing logs,Refreshing logs}.
-
-@end table
-
-@defopt magit-log-cutoff-length
-
-The maximum number of commits to show in log and reflog buffers.
 @end defopt
 
 @defopt magit-log-show-refname-after-summary

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -186,7 +186,7 @@ bisect run'."
                                       'magit-section-secondary-heading))
             (magit-insert-heading)
             (magit-wash-sequence
-             (apply-partially 'magit-log-wash-line 'bisect-log
+             (apply-partially 'magit-log-wash-rev 'bisect-log
                               (magit-abbrev-length)))
             (insert ?\n)))))
     (when (re-search-forward

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1444,6 +1444,11 @@ section or a child thereof."
       (when orig
         (setq orig (magit-decode-git-path orig)))
       (setq file (magit-decode-git-path file))
+      ;; KLUDGE `git-log' ignores `--no-prefix' when `-L' is used.
+      (when (derived-mode-p 'magit-log-mode)
+        (setq file (substring file 2))
+        (when orig
+          (setq orig (substring orig 2))))
       (magit-diff-insert-file-section file orig status modes header)))))
 
 (defun magit-diff-insert-file-section (file orig status modes header)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1893,7 +1893,7 @@ are highlighted."
       t)))
 
 (defun magit-diff-highlight-recursive (section &optional selection)
-  (if (magit-section-match '(module-commit diffstat) section)
+  (if (magit-section-match '(module-commit diffstat commit-header) section)
       (magit-section-highlight section nil)
     (pcase (magit-diff-scope section)
       (`list (magit-diff-highlight-list section selection))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1862,8 +1862,7 @@ actually a `diff' but a `diffstat' section."
         (`(hunk  ,_  ,_  ,_) 'hunk)
         (`(file   t   t nil) 'files)
         (`(file  ,_  ,_  ,_) 'file)
-        (`(,(or `staged `unstaged `untracked
-                `stashed-index `stashed-worktree `stashed-untracked)
+        (`(,(or `staged `unstaged `untracked)
            nil ,_ ,_) 'list)))))
 
 ;;; Diff Highlight

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -74,12 +74,12 @@ The following `format'-like specs are supported:
   :group 'magit-commands
   :type '(repeat (string :tag "Argument")))
 
-(defcustom magit-log-remove-graph-args '("--follow" "--grep" "-G")
+(defcustom magit-log-remove-graph-args '("--follow" "--grep" "-G" "-S")
   "The log arguments that cause the `--graph' argument to be dropped."
   :package-version '(magit . "2.3.0")
   :group 'magit-log
   :type '(repeat (string :tag "Argument"))
-  :options '("--follow" "--grep" "-G"))
+  :options '("--follow" "--grep" "-G" "-S"))
 
 (defcustom magit-log-revision-headers-format "\
 %+b
@@ -345,8 +345,9 @@ are no unpulled commits) show."
     :options  ((?n "Limit number of commits" "-n"        read-from-minibuffer)
                (?f "Limit to files"          "-- "       magit-read-files)
                (?a "Limit to author"         "--author=" read-from-minibuffer)
-               (?m "Search messages"         "--grep="   read-from-minibuffer)
-               (?p "Search patches"          "-G"        read-from-minibuffer))
+               (?g "Search messages"         "--grep="   read-from-minibuffer)
+               (?G "Search changes"          "-G"        read-from-minibuffer)
+               (?S "Search occurences"       "-S"        read-from-minibuffer))
     :actions  ((?l "Log current"             magit-log-current)
                (?L "Log local branches"      magit-log-branches)
                (?r "Reflog current"          magit-reflog-current)
@@ -373,8 +374,9 @@ are no unpulled commits) show."
     :options  ((?n "Limit number of commits" "-n"        read-from-minibuffer)
                (?f "Limit to files"          "-- "       magit-read-files)
                (?a "Limit to author"         "--author=" read-from-minibuffer)
-               (?m "Search messages"         "--grep="   read-from-minibuffer)
-               (?p "Search patches"          "-G"        read-from-minibuffer))
+               (?g "Search messages"         "--grep="   read-from-minibuffer)
+               (?G "Search changes"          "-G"        read-from-minibuffer)
+               (?S "Search occurences"       "-S"        read-from-minibuffer))
     :actions  ((?g "Refresh"       magit-log-refresh)
                (?t "Toggle margin" magit-toggle-margin)
                (?s "Set defaults"  magit-log-set-default-arguments) nil

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1022,11 +1022,13 @@ another window, using `magit-show-commit'."
                                                    (magit-file-relative-name
                                                     magit-buffer-file-name))
                                              (line-number-at-pos)))))
-                   (when (or (and (magit-diff-auto-show-p 'log-follow)
-                                  (magit-mode-get-buffer
-                                   nil 'magit-revision-mode nil nil t))
-                             (and (magit-diff-auto-show-p 'log-oneline)
-                                  (derived-mode-p 'magit-log-mode)))
+                   (when (and (not (magit-section-children
+                                    (magit-current-section)))
+                              (or (and (magit-diff-auto-show-p 'log-follow)
+                                       (magit-mode-get-buffer
+                                        nil 'magit-revision-mode nil nil t))
+                                  (and (magit-diff-auto-show-p 'log-oneline)
+                                       (derived-mode-p 'magit-log-mode))))
                      (apply #'magit-show-commit rev t nil
                             (magit-diff-arguments))))))
              (setq magit-update-other-window-timer nil))))))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -74,6 +74,13 @@ The following `format'-like specs are supported:
   :group 'magit-commands
   :type '(repeat (string :tag "Argument")))
 
+(defcustom magit-log-remove-graph-args '("--follow" "--grep" "-G")
+  "The log arguments that cause the `--graph' argument to be dropped."
+  :package-version '(magit . "2.3.0")
+  :group 'magit-log
+  :type '(repeat (string :tag "Argument"))
+  :options '("--follow" "--grep" "-G"))
+
 (defcustom magit-log-auto-more nil
   "Insert more log entries automatically when moving past the last entry.
 Only considered when moving past the last entry with
@@ -687,10 +694,6 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
   (magit-set-buffer-margin magit-log-show-margin)
   (hack-dir-local-variables-non-file-buffer))
 
-(defvar magit-log-remove-graph-re
-  (concat "^" (regexp-opt '("-G" "--grep" "--follow")))
-  "Regexp matching arguments which are not compatible with `--graph'.")
-
 (defvar magit-log-disable-graph-hack-args
   '("-G" "--grep" "--author")
   "Arguments which disable the graph speedup hack.")
@@ -708,7 +711,9 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
          'face 'magit-header-line))
   (unless (= (length files) 1)
     (setq args (remove "--follow" args)))
-  (when (--any-p (string-match-p magit-log-remove-graph-re it) args)
+  (when (--any-p (string-match-p
+                  (concat "^" (regexp-opt magit-log-remove-graph-args)) it)
+                 args)
     (setq args (remove "--graph" args)))
   (--when-let (and magit-log-cutoff-length
                    (= (length revs) 1)

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -327,8 +327,7 @@ The following `format'-like specs are supported:
 ;;; Show Stash
 
 (defcustom magit-stash-sections-hook
-  '(magit-insert-stash-message
-    magit-insert-stash-index
+  '(magit-insert-stash-index
     magit-insert-stash-worktree
     magit-insert-stash-untracked)
   "Hook run to insert sections into stash buffers."
@@ -368,16 +367,12 @@ The following `format'-like specs are supported:
   (hack-dir-local-variables-non-file-buffer))
 
 (defun magit-stash-refresh-buffer (stash _const args files)
+  (setq header-line-format
+        (concat
+         "\s" (propertize (capitalize stash) 'face 'magit-section-heading)
+         "\s" (magit-rev-format "%s" stash)))
   (magit-insert-section (stash)
     (run-hooks 'magit-stash-sections-hook)))
-
-(defun magit-insert-stash-message ()
-  "Insert section showing the message of the stash."
-  (let ((stash (car magit-refresh-args)))
-    (magit-insert-section (stash-message)
-      (magit-insert
-       (concat (propertize (capitalize stash) 'face 'magit-section-heading) "\s"
-               (magit-rev-format "%s" stash) "\n")))))
 
 (defmacro magit-stash-insert-section (subtype format &optional files)
   (declare (debug (sexp form &optional form)))


### PR DESCRIPTION
`-L` was supported until 9c2b8a87ef38122f733fda973be7d19766d7b955. I'll comment on what has changed since then some other time.