### PR TITLE
magit-wip-log-get-tips: ignore non-existent refs

### DIFF
--- a/Documentation/RelNotes/2.2.2.txt
+++ b/Documentation/RelNotes/2.2.2.txt
@@ -34,4 +34,7 @@ This is a bugfix release.
 * After failing to clone, `magit-clone' also tried to show the status
   of the non-existent clone.  #2203
 
+* `magit-wip-log' did not display a log if the working tree or index
+  ref did not exist.
+
 This release also contains various documentation fixes.

--- a/lisp/magit-wip.el
+++ b/lisp/magit-wip.el
@@ -270,16 +270,17 @@ many \"branches\" of each wip ref are shown."
              args files))
 
 (defun magit-wip-log-get-tips (wipref count)
-  (let ((reflog (magit-git-lines "reflog" wipref)) tips)
-    (while (and reflog (> count 1))
-      (setq reflog (cl-member "^[^ ]+ [^:]+: restart autosaving"
-                              reflog :test #'string-match-p))
-      (when (and (cadr reflog)
-                 (string-match "^[^ ]+ \\([^:]+\\)" (cadr reflog)))
-        (push (match-string 1 (cadr reflog)) tips))
-      (setq reflog (cddr reflog))
-      (cl-decf count))
-    (cons wipref (nreverse tips))))
+  (-when-let (reflog (magit-git-lines "reflog" wipref))
+    (let (tips)
+      (while (and reflog (> count 1))
+        (setq reflog (cl-member "^[^ ]+ [^:]+: restart autosaving"
+                                reflog :test #'string-match-p))
+        (when (and (cadr reflog)
+                   (string-match "^[^ ]+ \\([^:]+\\)" (cadr reflog)))
+          (push (match-string 1 (cadr reflog)) tips))
+        (setq reflog (cddr reflog))
+        (cl-decf count))
+      (cons wipref (nreverse tips)))))
 
 ;;; magit-wip.el ends soon
 (provide 'magit-wip)


### PR DESCRIPTION
Return nil if the reflog for WIPREF does not exist to prevent 'git log'
from failing on the unknown revision, resulting in magit-wip-log showing
an empty log.