### PR TITLE
test user, in case not set in chroot during testing

### DIFF
--- a/t/magit-tests.el
+++ b/t/magit-tests.el
@@ -26,7 +26,11 @@
 
 (defmacro magit-with-test-repository (&rest body)
   (declare (indent 0) (debug t))
-  `(magit-with-test-directory (magit-git "init" ".") ,@body))
+  `(magit-with-test-directory
+    (magit-git "init" ".")
+    (magit-git "config" "--local" "user.name" "Chester T. Tester")
+    (magit-git "config" "--local" "user.email" "ctt@example.com")
+    ,@body))
 
 ;;; Git
 


### PR DESCRIPTION
Set user.name and user.email in repo created during "make test".
This is necessary on, e.g., autobuilders using chroots, where these are in general not set.