### PR TITLE
magit-rebase-interactive-1: don't drop rebase args

### DIFF
--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -368,8 +368,9 @@ START has to be selected from a list of recent commits."
                                  (unless (member "--root" args) commit)
                                  (magit-rebase-arguments)))
     (magit-log-select
-      `(lambda (commit) (magit-rebase-interactive-1 commit ,message ,editor
-                                                    (list ,@args)))
+      `(lambda (commit)
+         (magit-rebase-interactive-1 commit ,message ,editor
+                                     (list ,@args ,@(magit-rebase-arguments))))
       message)))
 
 ;;;###autoload


### PR DESCRIPTION
I'm not sure if this is a good way to fix this.