### PR TITLE
In terminal C-return is sent as C-j due to some terminal limitations

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1266,6 +1266,7 @@ Staging and applying changes is documented in info node
 (defvar magit-file-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map [C-return] 'magit-diff-visit-file-worktree)
+    (define-key map "\C-j" 'magit-diff-visit-file-worktree)
     (define-key map "\r" 'magit-diff-visit-file)
     (define-key map "a"  'magit-apply)
     (define-key map "C"  'magit-commit-add-log)
@@ -1281,6 +1282,7 @@ Staging and applying changes is documented in info node
 (defvar magit-hunk-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map [C-return] 'magit-diff-visit-file-worktree)
+    (define-key map "\C-j" 'magit-diff-visit-file-worktree)
     (define-key map "\r" 'magit-diff-visit-file)
     (define-key map "a"  'magit-apply)
     (define-key map "C"  'magit-commit-add-log)


### PR DESCRIPTION
It looks like it is safe to allow C-j work as C-return for diff-related commands