### PR TITLE
Create a separate status section for unmerged changes

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1734,7 +1734,8 @@ or a ref which is not a branch, then it inserts nothing."
   (magit-insert-section (unstaged)
     (magit-insert-heading "Unstaged changes:")
     (magit-git-wash #'magit-diff-wash-diffs
-      "diff" magit-diff-section-arguments "--no-prefix"
+      "diff" magit-diff-section-arguments
+      "--diff-filter=ACDMRTXB" "--no-prefix"
       "--" magit-diff-section-file-args)))
 
 (defvar magit-staged-section-map
@@ -1754,7 +1755,17 @@ or a ref which is not a branch, then it inserts nothing."
   (magit-insert-section (staged)
     (magit-insert-heading "Staged changes:")
     (magit-git-wash #'magit-diff-wash-diffs
-      "diff" "--cached" magit-diff-section-arguments "--no-prefix"
+      "diff" "--cached" magit-diff-section-arguments
+      "--diff-filter=ACDMRTXB" "--no-prefix"
+      "--" magit-diff-section-file-args)))
+
+(defun magit-insert-unmerged-changes ()
+  "Insert section showing unmerged changes."
+  (magit-insert-section (unmerged)
+    (magit-insert-heading "Unmerged changes:")
+    (magit-git-wash #'magit-diff-wash-diffs
+      "diff" "--cached" magit-diff-section-arguments
+      "--diff-filter=U" "--no-prefix"
       "--" magit-diff-section-file-args)))
 
 ;;; Diff Type

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -108,6 +108,7 @@ at all."
     magit-insert-bisect-rest
     magit-insert-bisect-log
     magit-insert-untracked-files
+    magit-insert-unmerged-changes
     magit-insert-unstaged-changes
     magit-insert-staged-changes
     magit-insert-stashes


### PR DESCRIPTION
This is an naive early implementation, for demonstration purposes.

* Can we assume that `git diff --cached --diff-filter=U` always includes all unmerged changes? Or do you have to *also* use `git diff --diff-filter=U`?
* For easier parsing we should also use `--name-status`.
* Many commands that behave differently based on the "diff type" of a file have to be adjusted due to this.