### PR TITLE
Document magit-push-always-verify in functions.

### DIFF
--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -189,14 +189,20 @@ then read the remote."
 ;;;###autoload
 (defun magit-push-current (branch remote &optional remote-branch args)
   "Push the current branch to its upstream branch.
-If the upstream isn't set, then read the remote branch."
+If the upstream isn't set, then read the remote branch.
+
+If `magit-push-always-verify' is not nil, however, always read
+the remote branch."
   (interactive (magit-push-read-args t t))
   (magit-push branch remote remote-branch args))
 
 ;;;###autoload
 (defun magit-push (branch remote &optional remote-branch args)
   "Push a branch to its upstream branch.
-If the upstream isn't set, then read the remote branch."
+If the upstream isn't set, then read the remote branch.
+
+If `magit-push-always-verify' is not nil, however, always read
+the remote branch."
   (interactive (magit-push-read-args t))
   (magit-run-git-async-no-revert
    "push" "-v" args remote


### PR DESCRIPTION
The functions which change behavior based on `magit-push-always-verify` still only describe the case where it is nil, which it is not by default. I don't know if the wording is great, but I'd love to have something in there that makes this clear.

This should help with confusion like #2115.