### PR TITLE
magit-commit-diff: respect diff arguments

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -283,14 +283,15 @@ depending on the value of option `magit-commit-squash-confirm'."
   (--when-let (and git-commit-mode
                    (magit-diff-auto-show-p 'commit)
                    (pcase last-command
-                     (`magit-commit        'magit-diff-staged)
+                     (`magit-commit
+                      (apply-partially 'magit-diff-staged nil))
                      (`magit-commit-amend  'magit-diff-while-amending)
                      (`magit-commit-reword 'magit-diff-while-amending)))
     (setq with-editor-previous-winconf (current-window-configuration))
     (let ((magit-inhibit-save-previous-winconf 'unset)
           (magit-diff-switch-buffer-function
            (lambda (buffer) (display-buffer buffer t))))
-      (funcall it))))
+      (funcall it (car (magit-diff-arguments))))))
 
 (add-hook 'server-switch-hook 'magit-commit-diff)
 


### PR DESCRIPTION
If the diff arguments aren't passed, the return value of
magit-diff-arguments is unintentionally affected in future calls.  For
example, even if the magit-diff-arguments return value included --stat
before the commit, a revision buffer created after a magit-commit-diff
call will not have a diffstat section (assuming the diff buffer is still
around and the arguments haven't been explicitly changed since the
commit).

Drop file restrictions so that the commit diff always shows the full set
of changes.  The act of committing probably shouldn't reset file
restrictions that would otherwise be carried over between non-commit
diff calls, but this was already the situation before this change, and
it seems better than limiting the commit diff to a set a files from a
previous diff, which is unlikely to be what the user intended.