### PR TITLE
magit-popup.org: Add example for `magit-define-popup-action'

### DIFF
--- a/Documentation/magit-popup.org
+++ b/Documentation/magit-popup.org
@@ -246,6 +246,17 @@ commands to an existing popup using the following functions.
   of another switch already defined for POPUP, the argument is then
   placed before or after AT, depending on PREPEND.
 
+  Example:
+  #+BEGIN_SRC emacs-lisp
+    (defun m/magit-reset-author (&optional args)
+      "Resets the authorship information for the last commit"
+      (interactive)
+      (magit-run-git-async "commit" "--amend" "--no-edit" "--reset-author"))
+
+    (magit-define-popup-action 'magit-commit-popup
+      ?R "Reset author" 'm/magit-reset-author)
+  #+END_SRC
+
 - Function: magit-define-popup-option popup key desc option &optional reader value at prepend
 
   In POPUP, define KEY as OPTION.


### PR DESCRIPTION
Requests for customizing the default magit popups are a large source of
support requests on the issue tracker (see #2276, for example).  Add an
example for `magit-define-popup-action` to enable more users to
customize things on their own rather than requesting changes to magit
core.