### PR TITLE
magit-log-refresh-buffer: don't drop first commit

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -677,10 +677,10 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
                    (not (member revs '("--all" "--branches")))
                    (magit-git-string "rev-list" "--count"
                                      "--first-parent" revs))
-    (setq revs (format "%s~%s..%s" revs
-                       (min (1- (string-to-number it))
-                            (max 1024 (* 2 magit-log-cutoff-length)))
-                       revs)))
+    (setq revs (let ((cutoff (max 1024 (* 2 magit-log-cutoff-length))))
+                 (if (< (string-to-number it) cutoff)
+                     revs
+                   (format "%s~%s..%s" revs cutoff revs)))))
   (magit-insert-section (logbuf)
     (magit-insert-log revs args files)))
 


### PR DESCRIPTION
When the entire ancestry path is being shown, forming the log revision
as "M~N..M" loses the earliest commit (M~N).  Extending to N+1 will
error because it refers to an unknown revision.  Pass the non-range
revision instead.