### PR TITLE
Underline using :align-to

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2021,11 +2021,11 @@ are highlighted."
       (when magit-diff-unmarked-lines-keep-foreground
         (setq face (list :background (face-attribute face :background))))
       (cl-flet ((ov (start end &rest args)
-                  (let ((ov (make-overlay start end nil t)))
-                    (overlay-put ov 'evaporate t)
-                    (while args (overlay-put ov (pop args) (pop args)))
-                    (push ov magit-region-overlays)
-                    ov)))
+                    (let ((ov (make-overlay start end nil t)))
+                      (overlay-put ov 'evaporate t)
+                      (while args (overlay-put ov (pop args) (pop args)))
+                      (push ov magit-region-overlays)
+                      ov)))
         (ov sbeg cbeg 'face 'magit-diff-lines-heading
             'display (concat (magit-diff-hunk-region-header section) "\n"))
         (ov cbeg rbeg 'face face 'priority 2)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2018,7 +2018,8 @@ are highlighted."
           (face (if magit-diff-highlight-hunk-body
                     'magit-diff-context-highlight
                   'magit-diff-context))
-          (align (list 'space :align-to (list (window-body-width nil t)))))
+          (align (list 'space :align-to `(+ (,(window-body-width nil t))
+                                            ,(window-hscroll)))))
       (when magit-diff-unmarked-lines-keep-foreground
         (setq face (list :background (face-attribute face :background))))
       (cl-flet ((ov (start end &rest args)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2034,10 +2034,10 @@ are highlighted."
         (ov cbeg rbeg 'face face 'priority 2)
         (when (and magit-diff-show-lines-boundary
                    (window-system))
-          (let ((eol (save-excursion (goto-char rbeg) (line-end-position)))
-                (bol (save-excursion (goto-char rend) (line-beginning-position)))
-                (color (face-background 'magit-diff-lines-boundary nil t))
-                (face  (list :overline color :underline color)))
+          (let* ((eol (save-excursion (goto-char rbeg) (line-end-position)))
+                 (bol (save-excursion (goto-char rend) (line-beginning-position)))
+                 (color (face-background 'magit-diff-lines-boundary nil t))
+                 (face  (list :overline color :underline color)))
             (if (= rbeg bol)
                 (ov rbeg eol 'face face
                     'after-string (propertize "\s" 'face face 'display align))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2027,7 +2027,13 @@ are highlighted."
                       (overlay-put ov 'evaporate t)
                       (while args (overlay-put ov (pop args) (pop args)))
                       (push ov magit-region-overlays)
-                      ov)))
+                      ov))
+                (need-after (pos)
+                            (save-excursion
+                              (goto-char pos)
+                              (> (+ (line-beginning-position)
+                                    (window-body-width) (window-hscroll))
+                                 (line-end-position)))))
         (ov sbeg (1- cbeg) 'face 'magit-diff-lines-heading
             'display (magit-diff-hunk-region-header section)
             'after-string (propertize "\s" 'face 'magit-diff-lines-heading
@@ -2040,12 +2046,15 @@ are highlighted."
                  (color (face-background 'magit-diff-lines-boundary nil t))
                  (face  (list :overline color :underline color)))
             (if (= rbeg bol)
-                (ov rbeg eol 'face face
-                    'after-string (propertize "\s" 'face face 'display align 'cursor t))
-              (ov rbeg eol 'face (setq face (list :overline color))
-                  'after-string (propertize "\s" 'face face 'display align 'cursor t))
-              (ov bol rend 'face (setq face (list :underline color))
-                  'after-string (propertize "\s\n" 'face face 'display align 'cursor t)))))
+                (apply #'ov rbeg eol 'face face
+                       (when (need-after rbeg)
+                         (list 'after-string (propertize "\s" 'face face 'display align 'cursor t))))
+              (apply #' ov rbeg eol 'face (setq face (list :overline color))
+                        (when (need-after rbeg)
+                          (list 'after-string (propertize "\s" 'face face 'display align 'cursor t))))
+              (apply #'ov bol rend 'face (setq face (list :underline color))
+                     (when (need-after rend)
+                       (list 'after-string (propertize "\s\n" 'face face 'display align 'cursor t)))))))
         (ov (1+ rend) send 'face face 'priority 2)))))
 
 ;;; Diff Extract

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2030,14 +2030,16 @@ are highlighted."
             'display (concat (magit-diff-hunk-region-header section) "\n"))
         (ov cbeg rbeg 'face face 'priority 2)
         (when (and (window-system) magit-diff-show-lines-boundary)
-          (ov rbeg (1+ rbeg) 'before-string
-              (propertize (concat (propertize "\s" 'display '(space :height (1)))
-                                  (propertize "\n" 'line-height t))
-                          'face 'magit-diff-lines-boundary))
-          (ov rend (1+ rend) 'after-string
-              (propertize (concat (propertize "\s" 'display '(space :height (1)))
-                                  (propertize "\n" 'line-height t))
-                          'face 'magit-diff-lines-boundary)))
+          (ov rbeg (save-excursion (goto-char rbeg) (line-end-position))
+              'face `(:overline ,(face-background 'magit-diff-lines-boundary nil t))
+              'after-string
+              (propertize (propertize "\s" 'display `(space :align-to ,(window-width)))
+                          'face `(:overline ,(face-background 'magit-diff-lines-boundary nil t))))
+          (ov (save-excursion (goto-char rend) (line-beginning-position)) rend
+              'face `(:underline ,(face-background 'magit-diff-lines-boundary nil t))
+              'after-string
+              (propertize (propertize "\s" 'display `(space :align-to ,(window-width)))
+                          'face `(:underline ,(face-background 'magit-diff-lines-boundary nil t)))))
         (ov (1+ rend) send 'face face 'priority 2)))))
 
 ;;; Diff Extract

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2029,17 +2029,23 @@ are highlighted."
         (ov sbeg cbeg 'face 'magit-diff-lines-heading
             'display (concat (magit-diff-hunk-region-header section) "\n"))
         (ov cbeg rbeg 'face face 'priority 2)
-        (when (and (window-system) magit-diff-show-lines-boundary)
-          (ov rbeg (save-excursion (goto-char rbeg) (line-end-position))
-              'face `(:overline ,(face-background 'magit-diff-lines-boundary nil t))
-              'after-string
-              (propertize (propertize "\s" 'display `(space :align-to ,(window-width)))
-                          'face `(:overline ,(face-background 'magit-diff-lines-boundary nil t))))
-          (ov (save-excursion (goto-char rend) (line-beginning-position)) rend
-              'face `(:underline ,(face-background 'magit-diff-lines-boundary nil t))
-              'after-string
-              (propertize (propertize "\s" 'display `(space :align-to ,(window-width)))
-                          'face `(:underline ,(face-background 'magit-diff-lines-boundary nil t)))))
+        (when (and magit-diff-show-lines-boundary
+                   ;; TODO when was that added?
+                   ;; TODO use old approach for older Emacsen
+                   (fboundp 'window-body-width)
+                   (window-system))
+          (let* ((eol (save-excursion (goto-char rbeg) (line-end-position)))
+                 (bol (save-excursion (goto-char rend) (line-beginning-position)))
+                 (color (face-background 'magit-diff-lines-boundary nil t))
+                 (face  (list :overline color :underline color))
+                 (align (list 'space :align-to (list (window-body-width nil t)))))
+            (if (= rbeg bol)
+                (ov rbeg eol 'face face
+                    'after-string (propertize "\s" 'face face 'display align))
+              (ov rbeg eol 'face (setq face (list :overline color))
+                  'after-string (propertize "\s" 'face face 'display align))
+              (ov bol rend 'face (setq face (list :underline color))
+                  'after-string (propertize "\s\n" 'face face 'display align)))))
         (ov (1+ rend) send 'face face 'priority 2)))))
 
 ;;; Diff Extract

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2027,7 +2027,7 @@ are highlighted."
                       (while args (overlay-put ov (pop args) (pop args)))
                       (push ov magit-region-overlays)
                       ov)))
-        (ov sbeg cbeg 'face 'magit-diff-lines-heading
+        (ov sbeg (1- cbeg) 'face 'magit-diff-lines-heading
             'display (magit-diff-hunk-region-header section)
             'after-string (propertize "\s" 'face 'magit-diff-lines-heading
                                       'display align))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2041,11 +2041,11 @@ are highlighted."
                  (face  (list :overline color :underline color)))
             (if (= rbeg bol)
                 (ov rbeg eol 'face face
-                    'after-string (propertize "\s" 'face face 'display align))
+                    'after-string (propertize "\s" 'face face 'display align 'cursor t))
               (ov rbeg eol 'face (setq face (list :overline color))
-                  'after-string (propertize "\s" 'face face 'display align))
+                  'after-string (propertize "\s" 'face face 'display align 'cursor t))
               (ov bol rend 'face (setq face (list :underline color))
-                  'after-string (propertize "\s\n" 'face face 'display align)))))
+                  'after-string (propertize "\s\n" 'face face 'display align 'cursor t)))))
         (ov (1+ rend) send 'face face 'priority 2)))))
 
 ;;; Diff Extract

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2027,13 +2027,7 @@ are highlighted."
                       (overlay-put ov 'evaporate t)
                       (while args (overlay-put ov (pop args) (pop args)))
                       (push ov magit-region-overlays)
-                      ov))
-                (need-after (pos)
-                            (save-excursion
-                              (goto-char pos)
-                              (> (+ (line-beginning-position)
-                                    (window-body-width) (window-hscroll))
-                                 (line-end-position)))))
+                      ov)))
         (ov sbeg (1- cbeg) 'face 'magit-diff-lines-heading
             'display (magit-diff-hunk-region-header section)
             'after-string (propertize "\s" 'face 'magit-diff-lines-heading
@@ -2046,15 +2040,12 @@ are highlighted."
                  (color (face-background 'magit-diff-lines-boundary nil t))
                  (face  (list :overline color :underline color)))
             (if (= rbeg bol)
-                (apply #'ov rbeg eol 'face face
-                       (when (need-after rbeg)
-                         (list 'after-string (propertize "\s" 'face face 'display align 'cursor t))))
-              (apply #' ov rbeg eol 'face (setq face (list :overline color))
-                        (when (need-after rbeg)
-                          (list 'after-string (propertize "\s" 'face face 'display align 'cursor t))))
-              (apply #'ov bol rend 'face (setq face (list :underline color))
-                     (when (need-after rend)
-                       (list 'after-string (propertize "\s\n" 'face face 'display align 'cursor t)))))))
+                (ov rbeg eol 'face face
+                    'after-string (propertize "\s" 'face face 'display align 'cursor t))
+              (ov rbeg eol 'face (setq face (list :overline color))
+                  'after-string (propertize "\s" 'face face 'display align 'cursor t))
+              (ov bol rend 'face (setq face (list :underline color))
+                  'after-string (propertize "\s\n" 'face face 'display align 'cursor t)))))
         (ov (1+ rend) send 'face face 'priority 2)))))
 
 ;;; Diff Extract

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2017,7 +2017,8 @@ are highlighted."
           (send (magit-section-end section))
           (face (if magit-diff-highlight-hunk-body
                     'magit-diff-context-highlight
-                  'magit-diff-context)))
+                  'magit-diff-context))
+          (align (list 'space :align-to (list (window-body-width nil t)))))
       (when magit-diff-unmarked-lines-keep-foreground
         (setq face (list :background (face-attribute face :background))))
       (cl-flet ((ov (start end &rest args)
@@ -2027,18 +2028,16 @@ are highlighted."
                       (push ov magit-region-overlays)
                       ov)))
         (ov sbeg cbeg 'face 'magit-diff-lines-heading
-            'display (concat (magit-diff-hunk-region-header section) "\n"))
+            'display (magit-diff-hunk-region-header section)
+            'after-string (propertize "\s" 'face 'magit-diff-lines-heading
+                                      'display align))
         (ov cbeg rbeg 'face face 'priority 2)
         (when (and magit-diff-show-lines-boundary
-                   ;; TODO when was that added?
-                   ;; TODO use old approach for older Emacsen
-                   (fboundp 'window-body-width)
                    (window-system))
-          (let* ((eol (save-excursion (goto-char rbeg) (line-end-position)))
-                 (bol (save-excursion (goto-char rend) (line-beginning-position)))
-                 (color (face-background 'magit-diff-lines-boundary nil t))
-                 (face  (list :overline color :underline color))
-                 (align (list 'space :align-to (list (window-body-width nil t)))))
+          (let ((eol (save-excursion (goto-char rbeg) (line-end-position)))
+                (bol (save-excursion (goto-char rend) (line-beginning-position)))
+                (color (face-background 'magit-diff-lines-boundary nil t))
+                (face  (list :overline color :underline color)))
             (if (= rbeg bol)
                 (ov rbeg eol 'face face
                     'after-string (propertize "\s" 'face face 'display align))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2035,8 +2035,10 @@ are highlighted."
         (ov cbeg rbeg 'face face 'priority 2)
         (when (and magit-diff-show-lines-boundary
                    (window-system))
-          (let* ((eol (save-excursion (goto-char rbeg) (line-end-position)))
-                 (bol (save-excursion (goto-char rend) (line-beginning-position)))
+          (let* ((eol (save-excursion (goto-char rbeg)
+                                      (end-of-visual-line) (point)))
+                 (bol (save-excursion (goto-char rend)
+                                      (beginning-of-visual-line) (point)))
                  (color (face-background 'magit-diff-lines-boundary nil t))
                  (face  (list :overline color :underline color)))
             (if (= rbeg bol)


### PR DESCRIPTION
Open pr so that we have a place to talk about it. Edit: for previous discussions see #2094.

If Eli says one should not use newlines in overlays then we should try to follow his advise but unfortunately I have run into several issues with his approach too, which are just as much beyond our control as the issue with the old newline-approach, which I fixed for us. We might end up having to ask him for workarounds to be able to follow his advice.

Since the current approach works and I want to get a release out, I see no reason to rush this. But I would like to work with Eli to address the issues that are coming up here - they have bothered me in different contexts before.

There also were two issues with you implementation which I addressed in v2. When both the overline and the underline overlays were on the same line, then the underlining did not work. And you didn't account for pixel-wise resizing of windows.