### PR TITLE
Show default file in the interactive prompt for magit-am-apply-patches

### DIFF
--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -238,8 +238,12 @@ without prompting."
 (defun magit-am-apply-patches (&optional files args)
   "Apply the patches FILES."
   (interactive (list (or (magit-region-values 'file)
-                         (list (read-file-name "Apply patch: " nil
-                                               (magit-file-at-point))))
+                         (list (let ((default (magit-file-at-point)))
+                                 (read-file-name
+                                  (if default
+                                      (format "Apply patch (%s): " default)
+                                    "Apply patch: ")
+                                  nil default))))
                      (magit-am-arguments)))
   (magit-run-git-sequencer "am" args "--" (mapcar 'expand-file-name files)))
 


### PR DESCRIPTION
read-file-name doesn't display the DEFAULT-FILENAME value, so we ought to generate a prompt which does so.