### PR TITLE
docs: U is now magit-unstage-all, not magit-reset-index

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3060,7 +3060,7 @@ Explicitly enabling ~--interactive~ won't have an effect on the
 following commands as they always use that argument anyway, even if it
 is not enabled in the popup.
 
-- Key: r e, magit-rebase-interactive
+- Key: r i, magit-rebase-interactive
 
   Start an interactive rebase sequence.
 
@@ -3077,7 +3077,7 @@ is not enabled in the popup.
 
   Combine squash and fixup commits with their intended targets.
 
-- Key: r s, magit-rebase-edit-commit
+- Key: r e, magit-rebase-edit-commit
 
   Edit a single older commit using rebase.
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2443,20 +2443,16 @@ apply variants are described in the next section.
 
   Remove the change at point from the staging area.
 
-- Key: U, magit-reset-index
+- Key: U, magit-unstage-all
+
+  Remove all changes from the staging area.
+
+- Key: M-x magit-reset-index, magit-reset-index
 
   Reset the index to some commit.  The commit is read from the user
   and defaults to the commit at point.  If there is no commit at
   point, then it defaults to ~HEAD~.
 
-  So ~U RET~ with no commit at point does the inverse of ~S~ (or actually
-  ~S yes RET~), i.e. "unstage all staged changes".  If you would rather
-  use a command which always does just that, then rebind ~U~ to
-  ~magit-unstage-all~.
-
-- Key: M-x magit-unstage-all, magit-unstage-all
-
-  Remove all changes from the staging area.
 
 To stage a smaller unit than a range of lines, similar to ~git add
 --patch~ followed by ~e~ would do, then you can use ~magit-ediff-stage~ to
@@ -3427,7 +3423,7 @@ Also see [[info:gitman#git-reset]].
   defaulting to the commit at point.  The working tree is kept as-is.
   With a prefix argument also reset the working tree.
 
-- Key: U, magit-reset-index
+- Key: M-x magit-reset-index, magit-reset-index
 
   Reset the index to some commit read from the user and defaulting to
   the commit at point.  Keep the ~HEAD~ and working tree as-is, so if

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -3400,18 +3400,23 @@ argument also stage previously untracked (but not ignored) files.
 Remove the change at point from the staging area.
 
 @kindex U
-@cindex magit-unstage-all
-@item @kbd{U} @tie{}@tie{}@tie{}@tie{}(@code{magit-unstage-all})
-
-Remove all changes from the staging area.
-
-@kindex M-x magit-reset-index
 @cindex magit-reset-index
-@item @kbd{M-x magit-reset-index} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
+@item @kbd{U} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
 
 Reset the index to some commit.  The commit is read from the user
 and defaults to the commit at point.  If there is no commit at
 point, then it defaults to @code{HEAD}.
+
+So @code{U RET} with no commit at point does the inverse of @code{S} (or actually
+@code{S yes RET}), i.e. "unstage all staged changes".  If you would rather
+use a command which always does just that, then rebind @code{U} to
+@code{magit-unstage-all}.
+
+@kindex M-x magit-unstage-all
+@cindex magit-unstage-all
+@item @kbd{M-x magit-unstage-all} @tie{}@tie{}@tie{}@tie{}(@code{magit-unstage-all})
+
+Remove all changes from the staging area.
 @end table
 
 To stage a smaller unit than a range of lines, similar to @code{git add
@@ -4799,9 +4804,9 @@ Reset the head and index to some commit read from the user and
 defaulting to the commit at point.  The working tree is kept as-is.
 With a prefix argument also reset the working tree.
 
-@kindex M-x magit-reset-index
+@kindex U
 @cindex magit-reset-index
-@item @kbd{M-x magit-reset-index} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
+@item @kbd{U} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
 
 Reset the index to some commit read from the user and defaulting to
 the commit at point.  Keep the @code{HEAD} and working tree as-is, so if

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -3407,7 +3407,7 @@ Remove all changes from the staging area.
 
 @kindex M-x magit-reset-index
 @cindex magit-reset-index
-@item @kbd{M-x magit-unstage-all} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
+@item @kbd{M-x magit-reset-index} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
 
 Reset the index to some commit.  The commit is read from the user
 and defaults to the commit at point.  If there is no commit at

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -3400,23 +3400,18 @@ argument also stage previously untracked (but not ignored) files.
 Remove the change at point from the staging area.
 
 @kindex U
+@cindex magit-unstage-all
+@item @kbd{U} @tie{}@tie{}@tie{}@tie{}(@code{magit-unstage-all})
+
+Remove all changes from the staging area.
+
+@kindex M-x magit-reset-index
 @cindex magit-reset-index
-@item @kbd{U} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
+@item @kbd{M-x magit-unstage-all} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
 
 Reset the index to some commit.  The commit is read from the user
 and defaults to the commit at point.  If there is no commit at
 point, then it defaults to @code{HEAD}.
-
-So @code{U RET} with no commit at point does the inverse of @code{S} (or actually
-@code{S yes RET}), i.e. "unstage all staged changes".  If you would rather
-use a command which always does just that, then rebind @code{U} to
-@code{magit-unstage-all}.
-
-@kindex M-x magit-unstage-all
-@cindex magit-unstage-all
-@item @kbd{M-x magit-unstage-all} @tie{}@tie{}@tie{}@tie{}(@code{magit-unstage-all})
-
-Remove all changes from the staging area.
 @end table
 
 To stage a smaller unit than a range of lines, similar to @code{git add
@@ -4804,9 +4799,9 @@ Reset the head and index to some commit read from the user and
 defaulting to the commit at point.  The working tree is kept as-is.
 With a prefix argument also reset the working tree.
 
-@kindex U
+@kindex M-x magit-reset-index
 @cindex magit-reset-index
-@item @kbd{U} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
+@item @kbd{M-x magit-reset-index} @tie{}@tie{}@tie{}@tie{}(@code{magit-reset-index})
 
 Reset the index to some commit read from the user and defaulting to
 the commit at point.  Keep the @code{HEAD} and working tree as-is, so if


### PR DESCRIPTION
Commit 4c16736 changed the binding of "U" from `magit-reset-index` to `magit-unstage-all`, but the docs weren't updated. I *think* this fixes them.. I don't know texinfo very well, so please render this to .info and eyeball the results before landing in case I screwed up the formatting somehow.
