### PR TITLE
magit use hard-coded mount prefix

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -509,11 +509,23 @@ range.  Otherwise, it can be any revision or range accepted by
         (setq pos (point)))
       status)))
 
+(defcustom magit-cygwin-prefix
+  (when (eq system-type 'windows-nt)
+    (ignore-errors
+      (--when-let (process-lines "mount" "--show-cygdrive-prefix")
+        (car (split-string (cadr it))))))
+  "Prefix used for \"/cygdrive/X/\" style Cygwin paths.
+The result is either \"/\", \"/<string>\" or nil if not on a
+`windowws-nt' system."
+  :package-version '(magit . "2.3.0")
+  :group 'magit-process
+  :type '(choice (const :tag "None" nil) string))
+
 (defun magit-expand-git-file-name (filename)
   (unless (file-name-absolute-p filename)
     (setq filename (expand-file-name filename)))
   (if (and (eq system-type 'windows-nt) ; together with cygwin git, see #1318
-           (string-match "^/\\(cygdrive/\\)?\\([a-z]\\)/\\(.*\\)" filename))
+           (string-match (concat "^\\(" magit-cygwin-prefix "/\\)?\\([a-z]\\)/\\(.*\\)") filename))
       (concat (match-string 2 filename) ":/"
               (match-string 3 filename))
     filename))


### PR DESCRIPTION
* lisp/magit-git.el magit-cygwin-prefix magit-expand-git-file-name

Use `magit-cygwin-prefix` in `magit-expand-git-file-name` instead of hard-coded cygdrive prefix.
Use `defcustom` for `magit-cygwin-prefix` and add extra checks for default value.
Set return value to `nil` when the system isn't `windows-nt`.