### PR TITLE
magit-mode-get-buffer: avoid default-directory test

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -392,7 +392,7 @@ then offer to initialize it as a new repository."
 ;;;###autoload
 (defun magit-status-internal (directory)
   (magit-tramp-asserts directory)
-  (let ((magit-mode-get-buffer--topdir directory))
+  (let ((default-directory directory))
     (magit-mode-setup #'magit-status-mode)))
 
 (defun ido-enter-magit-status ()


### PR DESCRIPTION
If default-directory is used to check for an existing buffer, an
inappropriate magit buffer may be returned if its default-directory is
let-bound.  This is a similar problem as discussed in #2054 and #2060.
01cf031 (don’t bind default-directory to pass topdir to
magit-mode-setup, 2015-07-13) changed magit-status-internal to bind
magit-mode-setup--topdir instead of default-directory.  This fixes the
corner case with C-u C-u magit-status, but can still fail on third-party
code that let-binds default-directory.

One example of this is switching projectile projects with projectile-vc
as the action.  To switch to a new project, default-directory is
let-bound to the new project's root and then projectile-vc calls
magit-status-internal.  But if this is done from a status buffer that
doesn't belong to the new project, magit-mode-get-buffer mistakenly
thinks the current status buffer belongs to that new project and updates
it with the status of the new project.

To avoid this, add a new buffer-local variable,
magit--default-directory, and set it to the value of default-directory
when the buffer is created.  This makes the magit-mode-setup--topdir
variable (now called magit-mode-get-buffer--topdir) unnecessary.