### PR TITLE
.travis.yml: never send email on success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,8 @@ script:
   - git config --global user.email a.u.thor@example.com
   - make lisp EMACSBIN=$EMACS DASH_DIR=$PWD
   - make test EMACSBIN=$EMACS DASH_DIR=$PWD
+notifications:
+  email:
+    # Default is change, but that includes a new branch's 1st success.
+    on_success: never
+    on_failure: always # The default.


### PR DESCRIPTION
```
The default is to send on change, but this includes the 1st success of a
new branch (i.e. a change from nothing -> success).  Generally success
is not surprising/interesting anyway.
```