### PR TITLE
WIP Log washing fixes

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1268,10 +1268,10 @@ Staging and applying changes is documented in info node
           "\\(contains \\(?:modified\\|untracked\\) content\\)\\|"
           "\\([^ :]+\\)\\( (rewind)\\)?:\\)$"))
 
-(defun magit-diff-wash-diffs (args)
+(defun magit-diff-wash-diffs (args &optional limit)
   (when (member "--stat" args)
     (magit-diff-wash-diffstat))
-  (when (re-search-forward magit-diff-headline-re nil t)
+  (when (re-search-forward magit-diff-headline-re limit t)
     (goto-char (line-beginning-position))
     (magit-wash-sequence (apply-partially 'magit-diff-wash-diff args))
     (insert ?\n)))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1323,9 +1323,7 @@ section or a child thereof."
                 (when del
                   (insert (propertize del 'face 'magit-diffstat-removed)))
                 (insert "\n")))))
-        (insert "\n"))
-      (unless (eobp)
-        (delete-char 1)))))
+        (if (looking-at "^$") (forward-line) (insert "\n"))))))
 
 (defun magit-diff-wash-diff (args)
   (cond

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -933,10 +933,13 @@ Do not add this to a hook variable."
               (insert ?\n))
             (delete-char 1))
           (if (looking-at "^\\(---\\|\n\s\\|\ndiff\\)")
-              (progn (unless (magit-section-content magit-insert-section--current)
-                       (magit-insert-heading))
-                     (delete-char (if (looking-at "\n") 1 4))
-                     (magit-diff-wash-diffs (list "--stat")))
+              (let ((limit (save-excursion
+                             (and (re-search-forward magit-log-heading-re nil t)
+                                  (match-beginning 0)))))
+                (unless (magit-section-content magit-insert-section--current)
+                  (magit-insert-heading))
+                (delete-char (if (looking-at "\n") 1 4))
+                (magit-diff-wash-diffs (list "--stat") limit))
             (when align
               (setq align (make-string (1+ abbrev) ? )))
             (while (and (not (eobp)) (not (looking-at magit-log-heading-re)))


### PR DESCRIPTION
I've run into a few issues with log washing.

* Calling log with --stat and without --graph deletes the first
  character in the hash of all entries after the first.

* Diff washing is log is not restricted to an entry.  To see this, run
  log with --stat and -h but not --graph.

*  Merge commits, which do not lead to magit-diff-wash-diffstat being
   called, are not separated from the next commit by a space.

These commits should fix the first two, but they are only lightly
tested at the moment.  An easy fix for the third issue hasn't jumped
out at me, but it is minor compared to the other two.