### PR TITLE
Use a slightly lighter grey on light background for sections and highlighting

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -407,7 +407,7 @@ and https://debbugs.gnu.org/cgi/bugreport.cgi?bug=7847."
 
 (defface magit-diff-context-highlight
   '((((class color) (background light))
-     :background "grey85"
+     :background "grey95"
      :foreground "grey50")
     (((class color) (background dark))
      :background "grey20"

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -103,7 +103,7 @@ section specific default (see `magit-insert-section')."
   :options '(magit-diff-expansion-threshold magit-revision-set-visibility))
 
 (defface magit-section-highlight
-  '((((class color) (background light)) :background "grey85")
+  '((((class color) (background light)) :background "grey95")
     (((class color) (background  dark)) :background "grey20"))
   "Face for highlighting the current section."
   :group 'magit-faces)


### PR DESCRIPTION
This PR changes the background color of the section and context highlights to a slightly lighter grey on light backgrounds, giving a more contrast with the content of the section.

![screenshot from 2015-10-19 12-36-41](https://cloud.githubusercontent.com/assets/123539/10575637/20235380-765e-11e5-9df6-1e0695f81ec5.png)
