### PR TITLE
cache daemon hack

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -88,6 +88,41 @@ When this is nil, no sections are ever removed."
   :group 'magit-process
   :type '(choice (const :tag "Never remove old sections" nil) integer))
 
+(defcustom magit-credential-cache-daemon-socket
+  (--some (-let [(prog . args) (split-string it)]
+            (if (string-match-p
+                 "\\`\\(?:\\(?:/.*/\\)?git-credential-\\)?cache\\'" prog)
+                (or (cl-loop for (opt val) on args
+                             if (string= opt "--socket")
+                             return val)
+                    (expand-file-name "~/.git-credential-cache/socket"))))
+          ;; Note: `magit-process-file' is not yet defined when
+          ;; evaluating this form, so we use `process-lines'.
+          (ignore-errors
+            (process-lines magit-git-executable
+                           "config" "--get-all" "credential.helper")))
+  "If non-nil, start a credential cache daemon using this socket.
+
+When using Git's cache credential helper in the normal way, Emacs
+sends a SIGHUP to the credential daemon after the git subprocess
+has exited, causing the daemon to also quit.  This can be avoided
+by starting the `git-credential-cache--daemon' process directly
+from Emacs.
+
+The function `magit-maybe-start-credential-cache-daemon' takes
+care of starting the daemon if necessary, using the value of this
+option as the socket.  If this option is nil, then it does not
+start any daemon.  Likewise if another daemon is already running,
+then it starts no new daemon.  This function has to be a member
+of the hook variable `magit-credential-hook' for this to work.
+If an error occurs while starting the daemon, most likely because
+the necessary executable is missing, then the function removes
+itself from the hook, to avoid further futile attempts."
+  :package-version '(magit . "2.3.0")
+  :group 'magit-process
+  :type '(choice (file  :tag "Socket")
+                 (const :tag "Don't start a cache daemon" nil)))
+
 (defcustom magit-process-yes-or-no-prompt-regexp
   " [\[(]\\([Yy]\\(?:es\\)?\\)[/|]\\([Nn]o?\\)[\])] ?[?:] ?$"
   "Regexp matching Yes-or-No prompts of Git and its subprocesses."
@@ -687,6 +722,39 @@ Return the matched string suffixed with \": \", if needed."
 
 (defvar magit-credential-hook nil
   "Hook run before Git needs credentials.")
+
+(defvar magit-credential-cache-daemon-process nil)
+
+(defun magit-maybe-start-credential-cache-daemon ()
+  "Maybe start a `git-credential-cache--daemon' process.
+
+If such a process is already running or if the value of option
+`magit-credential-cache-daemon-socket' is nil, then do nothing.
+Otherwise start the process passing the value of that options
+as argument."
+  (unless (or (not magit-credential-cache-daemon-socket)
+              (process-live-p magit-credential-cache-daemon-process)
+              (memq magit-credential-cache-daemon-process
+                    (list-system-processes)))
+    (setq magit-credential-cache-daemon-process
+          (or (--first (-let (((&alist 'comm comm 'user user)
+                               (process-attributes it)))
+                         (and (string= comm "git-credential-cache--daemon")
+                              (string= user user-login-name)))
+                       (list-system-processes))
+              (condition-case err
+                  (start-process "git-credential-cache--daemon"
+                                 " *git-credential-cache--daemon*"
+                                 magit-git-executable
+                                 "credential-cache--daemon"
+                                 magit-credential-cache-daemon-socket)
+                ;; Some Git implementations (e.g. Windows) won't have
+                ;; this program; if we fail the first time, stop trying.
+                ((debug error)
+                 (remove-hook 'magit-credential-hook
+                              #'magit-maybe-start-credential-cache-daemon)))))))
+
+(add-hook 'magit-credential-hook #'magit-maybe-start-credential-cache-daemon)
 
 (defun magit-process-wait ()
   (while (and magit-this-process

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -685,6 +685,9 @@ Return the matched string suffixed with \": \", if needed."
             ((string-suffix-p ":"  prompt) (concat prompt " "))
             (t                             (concat prompt ": "))))))
 
+(defvar magit-credential-hook nil
+  "Hook run before Git needs credentials.")
+
 (defun magit-process-wait ()
   (while (and magit-this-process
               (eq (process-status magit-this-process) 'run))

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -116,6 +116,7 @@ then read the remote."
   (interactive (list (or (magit-get-remote)
                          (magit-read-remote "Fetch remote"))
                      (magit-fetch-arguments)))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert "fetch" remote args))
 
 ;;;###autoload
@@ -123,12 +124,14 @@ then read the remote."
   "Fetch from another repository."
   (interactive (list (magit-read-remote "Fetch remote")
                      (magit-fetch-arguments)))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert "fetch" remote args))
 
 ;;;###autoload
 (defun magit-fetch-all (&optional args)
   "Fetch from all configured remotes."
   (interactive (list (magit-fetch-arguments)))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert "remote" "update" args))
 
 ;;; Pull
@@ -147,6 +150,7 @@ then read the remote."
 (defun magit-pull-current (remote branch &optional args)
   "Fetch and merge into current branch."
   (interactive (magit-pull-read-args t))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-with-editor "pull" args
                              (and (not (equal remote (magit-get-remote)))
                                   (not (equal branch (magit-get-remote-branch)))
@@ -156,6 +160,7 @@ then read the remote."
 (defun magit-pull (remote branch &optional args)
   "Fetch from another repository and merge a fetched branch."
   (interactive (magit-pull-read-args))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-with-editor "pull" args remote branch))
 
 (defun magit-pull-read-args (&optional use-upstream)
@@ -204,6 +209,7 @@ If the upstream isn't set, then read the remote branch.
 If `magit-push-always-verify' is not nil, however, always read
 the remote branch."
   (interactive (magit-push-read-args t))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert
    "push" "-v" args remote
    (if remote-branch
@@ -304,6 +310,7 @@ not exist, then push to \"origin\".  If that also doesn't exist
 then raise an error.  The local branch is pushed to the remote
 branch with the same name."
   (interactive (list (magit-push-arguments)))
+  (run-hooks 'magit-credential-hook)
   (-if-let (branch (magit-get-current-branch))
       (-if-let (remote (or (magit-remote-p (magit-get "magit.pushRemote"))
                            (magit-remote-p "origin")))
@@ -318,6 +325,7 @@ This runs `git push -v'.  What is being pushed depends on various
 Git variables as described in the `git-push(1)' and `git-config(1)'
 manpages."
   (interactive (list (magit-push-arguments)))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert "push" "-v" args))
 
 ;;;###autoload
@@ -326,6 +334,7 @@ manpages."
 If multiple remotes exit, then read one from the user.
 If just one exists, use that without requiring confirmation."
   (interactive (list (magit-read-remote "Push matching branches to" nil t)))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert "push" "-v" args remote ":"))
 
 (defun magit-push-tags (remote &optional args)
@@ -335,6 +344,7 @@ for a remote, offering the remote configured for the current
 branch as default."
   (interactive (list (magit-read-remote "Push tags to remote" nil t)
                      (magit-push-arguments)))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert "push" remote "--tags" args))
 
 ;;;###autoload
@@ -343,8 +353,8 @@ branch as default."
   (interactive
    (let  ((tag (magit-read-tag "Push tag")))
      (list tag (magit-read-remote (format "Push %s to remote" tag) nil t))))
+  (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert "push" remote tag))
-
 
 ;;; Email
 


### PR DESCRIPTION
Work around for #2309

---

I think this is basically ready to merge now. Note that `magit-credential-hook` is no longer a defcustom; the `--socket` argument needs to be customizable anyway, and this neatly avoids the `add/remove-hook` vs `defcustom` problem too.
