### PR TITLE
magit-toggle-buffer-lock: fix locked diff name

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -664,8 +664,8 @@ latter is displayed in its place."
                                     magit-stashes-mode))
                  (car magit-refresh-args))
                 ((eq major-mode 'magit-diff-mode)
-                 (append (or (car magit-refresh-args) '(unstaged))
-                         (cadr magit-refresh-args)))))
+                 (-let [(from to . _) (-flatten magit-refresh-args)]
+                   (list (or from 'unstaged) to)))))
     (if magit-buffer-locked-p
         (rename-buffer (funcall magit-generate-buffer-name-function
                                 major-mode magit-buffer-locked-p))


### PR DESCRIPTION
```
Before:

   *magit-diff(72 69 65 68 94 --cached): magit

After:

   *magit-diff(HEAD^ --cached): magit
```

I'm not entirely sure whether I've got this right, because it's a bit unclear to me what the format of `magit-refresh-args` is supposed to be.