### PR TITLE
fix magit-clone with cygwin git

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -542,6 +542,13 @@ Sorted from longest to shortest CYGWIN name."
       (concat win (substring filename (length cyg)))
     filename))
 
+(defun magit-convert-git-file-name (filename)
+  (-if-let ((cyg . win)
+            (cl-rassoc filename magit-cygwin-mount-points
+                       :test (lambda (f win) (string-prefix-p win f))))
+      (concat cyg (substring filename (length win)))
+    filename))
+
 (defun magit-decode-git-path (path)
   (if (eq (aref path 0) ?\")
       (string-as-multibyte (read path))

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -45,7 +45,6 @@ Then show the status buffer for the new repository."
                   "Clone to: " nil nil nil
                   (and (string-match "\\([^./]+\\)\\(\\.git\\)?$" url)
                        (match-string 1 url))))))))
-  (make-directory directory t)
   (message "Cloning %s..." repository)
   (when (= (magit-call-git "clone" repository directory) 0)
     (message "Cloning %s...done" repository)

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -46,7 +46,9 @@ Then show the status buffer for the new repository."
                   (and (string-match "\\([^./]+\\)\\(\\.git\\)?$" url)
                        (match-string 1 url))))))))
   (message "Cloning %s..." repository)
-  (when (= (magit-call-git "clone" repository directory) 0)
+  (when (= (magit-call-git "clone" repository
+                           ;; Stop cygwin git making a "c:" directory.
+                           (magit-convert-git-file-name directory)) 0)
     (message "Cloning %s...done" repository)
     (magit-status-internal directory)))
 


### PR DESCRIPTION
Based on the [strace output][1] it looks like git is already making the needed directories so the `make-directory` call in magit is redundant. Can't find it in the release notes, but https://github.com/git/git/commit/8e21d63b02f1b26f7695ca515e51e4622a995af2 seems to confirm this.

I decided it's a bit "safer" to use absolute paths, so I dropped the `file-relative-name` part from `magit-shrink-git-file-name` and called it `magit-convert-git-file-name` instead (by analogy with `convert-standard-filename`; should we call it `magit-convert-git-filename` to be consistent with Emacs, or keep `-file-name` to be consistent with `magit-expand-git-file-name`?).

Since `magit-clone`'s `interactive` form already calls `expand-file-name`, I think the `~` case should be covered. @PierreTechoueyres does this work ok for you?

Should fix #2357.

[1]: https://github.com/magit/magit/issues/2357#issuecomment-150979312