### PR TITLE
magit-toplevel: ignore .git/gitdir

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -386,10 +386,15 @@ returning the truename."
                         (expand-file-name gitdir))))
         (if (magit-bare-repo-p)
             gitdir
-          (let ((link (expand-file-name "gitdir" gitdir)))
-            (if (file-exists-p link)
+          (let* ((link (expand-file-name "gitdir" gitdir))
+                 (wtree (and (file-exists-p link)
+                             (magit-file-line link))))
+            (if (and wtree
+                     ;; Ignore .git/gitdir files that result from a
+                     ;; Git bug.  See #2364.
+                     (not (equal wtree ".git")))
                 ;; Return the linked working tree.
-                (file-name-directory (magit-file-line link))
+                (file-name-directory wtree)
               ;; Step outside the control directory to enter the working tree.
               (file-name-directory (directory-file-name gitdir)))))))))
 


### PR DESCRIPTION
4d035b5 (magit-toplevel: return correct wtree from within
.git/worktrees/ID, 2015-10-15) taught magit-toplevel to look in
.git/worktrees/<name>/gitdir to find the worktree path.  However,
magit-toplevel now also reads .git/gitdir if it exists, which contains
".git" rather than a linked worktree.  In this case, magit-toplevel
fails to identify the top-level despite being inside a repo.

These .git/gitdir files are created in a repo when a .git file specifies
a gitdir path that points to the repo.  They result from a bug [1] that
is present in at least the version 2.6.2 release and that was likely
introduced in version 2.5.2.

Add a check to prevent this file from being processed as a worktree
gitdir file.

[1] http://thread.gmane.org/gmane.comp.version-control.git/280307/focus=280313

Re: #2364