### PR TITLE
Fix elisp error.

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -89,7 +89,7 @@ When this is nil, no sections are ever removed."
   :type '(choice (const :tag "Never remove old sections" nil) integer))
 
 (defcustom magit-credential-cache-daemon-socket
-  (--some (-let [(prog . args) (split-string it)]
+  (--some? (-let [(prog . args) (split-string it)]
             (if (string-match-p
                  "\\`\\(?:\\(?:/.*/\\)?git-credential-\\)?cache\\'" prog)
                 (or (cl-loop for (opt val) on args


### PR DESCRIPTION
So I really don't know if this is the correct fix but I don't seem to have a --some function defined in my environment. I use dash.el from trunk and GNU Emacs 24.5.1 (x86_64-apple-darwin13.4.0, NS apple-appkit-1265.21) of 2015-04-10 on builder10-9.porkrind.org [2 times].