### PR TITLE
stop faking negative overlay property priorities

### DIFF
--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -182,8 +182,7 @@ bisect run'."
           (narrow-to-region beg (point))
           (goto-char (point-min))
           (magit-insert-section (bisect-log heading t)
-            (magit-insert (propertize heading 'face
-                                      'magit-section-secondary-heading))
+            (insert (propertize heading 'face 'magit-section-secondary-heading))
             (magit-insert-heading)
             (magit-wash-sequence
              (apply-partially 'magit-log-wash-rev 'bisect-log
@@ -194,7 +193,7 @@ bisect run'."
       (magit-bind-match-strings (hash) nil
         (magit-delete-match)
         (magit-insert-section (bisect-log)
-          (magit-insert (concat hash " is the first bad commit\n")))))))
+          (insert hash " is the first bad commit\n"))))))
 
 ;;; magit-bisect.el ends soon
 (provide 'magit-bisect)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -858,13 +858,15 @@ Do not add this to a hook variable."
           (when (and (derived-mode-p 'magit-refs-mode)
                      magit-refs-show-commit-count)
             (insert (make-string magit-refs-indent-cherry-lines ?\s)))
-          (magit-insert cherry (if (string= cherry "-")
-                                   'magit-cherry-equivalent
-                                 'magit-cherry-unmatched) ?\s))
+          (insert (propertize cherry 'face (if (string= cherry "-")
+                                               'magit-cherry-equivalent
+                                             'magit-cherry-unmatched)))
+          (insert ?\s))
         (when side
-          (magit-insert side (if (string= side "<")
-                                 'magit-diff-removed
-                               'magit-diff-added) ?\s))
+          (insert (propertize side 'face (if (string= side "<")
+                                             'magit-diff-removed
+                                           'magit-diff-added)))
+          (insert ?\s))
         (when align
           (insert (propertize hash 'face 'magit-hash) ?\s))
         (when graph
@@ -872,21 +874,21 @@ Do not add this to a hook variable."
         (unless align
           (insert (propertize hash 'face 'magit-hash) ?\s))
         (when (and refs (not magit-log-show-refname-after-summary))
-          (magit-insert (magit-format-ref-labels refs) nil ?\s))
+          (insert (magit-format-ref-labels refs) ?\s))
         (when refsub
           (insert (format "%-2s " (1- magit-log-count)))
-          (magit-insert
-           (magit-reflog-format-subject
-            (substring refsub 0 (if (string-match-p ":" refsub) -2 -1)))))
+          (insert (magit-reflog-format-subject
+                   (substring refsub 0 (if (string-match-p ":" refsub) -2 -1)))))
         (when msg
-          (magit-insert msg
-                        (pcase (and gpg (aref gpg 0))
-                          (?G 'magit-signature-good)
-                          (?B 'magit-signature-bad)
-                          (?U 'magit-signature-untrusted))))
+          (insert (propertize msg 'face
+                              (pcase (and gpg (aref gpg 0))
+                                (?G 'magit-signature-good)
+                                (?B 'magit-signature-bad)
+                                (?U 'magit-signature-untrusted))))
+          (insert ?\s))
         (when (and refs magit-log-show-refname-after-summary)
           (insert ?\s)
-          (magit-insert (magit-format-ref-labels refs)))
+          (insert (magit-format-ref-labels refs)))
         (insert ?\n)
         (when (memq style '(log reflog stash))
           (goto-char (line-beginning-position))

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -812,12 +812,12 @@ as argument."
         (save-excursion
           (delete-char 3)
           (set-marker-insertion-type marker nil)
-          (insert (propertize (format "%3s" arg) 'magit-section section))
-          (set-marker-insertion-type marker t)
-          (magit-put-face-property (- (point) 3) (point)
-                                   (if (= arg 0)
-                                       'magit-process-ok
-                                     'magit-process-ng)))
+          (insert (propertize (format "%3s" arg)
+                              'magit-section section
+                              'face (if (= arg 0)
+                                        'magit-process-ok
+                                      'magit-process-ng)))
+          (set-marker-insertion-type marker t))
         (if (= (magit-section-end section)
                (+ (line-end-position) 2))
             (save-excursion


### PR DESCRIPTION
Face attributes set in overlays always have a higher priority than the
corresponding text properties.  Magit highlights the current section
with an overlay whose face sets the background color, as a result all
text in the current section would lose its background color.

We used to fake negative priorities for such text which has a background
color, by using an overlay to set the face where one would usually use a
text property.  So instead of giving the highlighting overlay a negative
priority, i.e. one lower than the 1 priority of text properties (because
that's impossible) we instead gave the text properties a higher priority
(by using overlay properties instead).  Conceptually that was equivalent
to giving the highlighting overlay a negative priority.

But we should not have done that for three reasons:

- Giving ref labels (and a few other things) a background color caused
  the buffer to be much noisier than it otherwise would have been.  So
  at least in my opinion, giving labels a background color was not only
  a hack, and difficult and expensive, it was also undesirable.  In the
  v2.1.0 release I dropped the background color of all ref labels and a
  few other faces.  This was generally well received.

- Using overlays is inefficient, and should therefore be avoided when
  not necessary.  Every time Magit comes up Eli tells us about it.

- Using overlays complicates the code and makes necessary changes more
  difficult.

Dropping support for faked negative overlay priorities, might mean that
some third-party themes have to be adjusted.  Which is why I did not do
it in v2.1.0, but now the time has come.