### PR TITLE
Implement trivial parts of push-remote support

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -744,6 +744,13 @@ which is different from the current branch and still exists."
             merge
           (concat remote "/" merge))))))
 
+(cl-defun magit-get-push-branch
+    (&optional (branch (magit-get-current-branch)))
+  (when branch
+    (-when-let (remote (or (magit-get "branch" branch "pushRemote")
+                           (magit-get "remote.pushDefault")))
+      (concat remote "/" branch))))
+
 (defun magit-get-remote (&optional branch)
   (when (or branch (setq branch (magit-get-current-branch)))
     (let ((remote (magit-get "branch" branch "remote")))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1175,7 +1175,8 @@ Type \\[magit-cherry-pick-popup] to apply the commit at point.
   "Insert headers appropriate for `magit-cherry-mode' buffers."
   (magit-insert-head-branch-header (nth 1 magit-refresh-args))
   (magit-insert-pull-branch-header (nth 1 magit-refresh-args)
-                                   (nth 0 magit-refresh-args))
+                                   (nth 0 magit-refresh-args)
+                                   "Upstream: ")
   (insert ?\n))
 
 (defun magit-insert-cherry-commits ()

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -36,7 +36,7 @@
 (declare-function magit-blob-visit 'magit)
 (declare-function magit-find-file-noselect 'magit)
 (declare-function magit-insert-head-header 'magit)
-(declare-function magit-insert-upstream-header 'magit)
+(declare-function magit-insert-pull-branch-header 'magit)
 (declare-function magit-read-file-from-rev 'magit)
 (declare-function magit-show-commit 'magit)
 (defvar magit-refs-indent-cherry-lines)
@@ -1174,8 +1174,8 @@ Type \\[magit-cherry-pick-popup] to apply the commit at point.
 (defun magit-insert-cherry-headers ()
   "Insert headers appropriate for `magit-cherry-mode' buffers."
   (magit-insert-head-header (nth 1 magit-refresh-args))
-  (magit-insert-upstream-header (nth 1 magit-refresh-args)
-                                (nth 0 magit-refresh-args))
+  (magit-insert-pull-branch-header (nth 1 magit-refresh-args)
+                                   (nth 0 magit-refresh-args))
   (insert ?\n))
 
 (defun magit-insert-cherry-commits ()

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -35,7 +35,7 @@
 (declare-function magit-blame-chunk-get 'magit-blame)
 (declare-function magit-blob-visit 'magit)
 (declare-function magit-find-file-noselect 'magit)
-(declare-function magit-insert-head-header 'magit)
+(declare-function magit-insert-head-branch-header 'magit)
 (declare-function magit-insert-pull-branch-header 'magit)
 (declare-function magit-read-file-from-rev 'magit)
 (declare-function magit-show-commit 'magit)
@@ -1173,7 +1173,7 @@ Type \\[magit-cherry-pick-popup] to apply the commit at point.
 
 (defun magit-insert-cherry-headers ()
   "Insert headers appropriate for `magit-cherry-mode' buffers."
-  (magit-insert-head-header (nth 1 magit-refresh-args))
+  (magit-insert-head-branch-header (nth 1 magit-refresh-args))
   (magit-insert-pull-branch-header (nth 1 magit-refresh-args)
                                    (nth 0 magit-refresh-args))
   (insert ?\n))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -85,7 +85,7 @@
 
 (defcustom magit-status-headers-hook
   '(magit-insert-diff-filter-header
-    magit-insert-head-header
+    magit-insert-head-branch-header
     magit-insert-pull-branch-header
     magit-insert-tags-header)
   "Hook run to insert headers into the status buffer.
@@ -99,7 +99,7 @@ at all."
   :options '(magit-insert-diff-filter-header
              magit-insert-repo-header
              magit-insert-remote-header
-             magit-insert-head-header
+             magit-insert-head-branch-header
              magit-insert-pull-branch-header
              magit-insert-tags-header))
 
@@ -412,7 +412,7 @@ The sections are inserted by running the functions on the hook
       (magit-insert-headers magit-status-headers-hook)
     (insert "In the beginning there was darkness\n\n")))
 
-(cl-defun magit-insert-head-header
+(cl-defun magit-insert-head-branch-header
     (&optional (branch (magit-get-current-branch)))
   "Insert a header line about the current branch or detached `HEAD'."
   (let ((output (magit-rev-format "%h %s" "HEAD")))
@@ -2658,6 +2658,9 @@ where an absolute path is used for performance reasons.
 If the value already is just \"git\" but TRAMP never-the-less
 doesn't find the executable, then consult the info node
 `(tramp)Remote programs'.\n" remote) :error)))))
+
+(define-obsolete-function-alias 'magit-insert-head-header
+  'magit-insert-head-branch-header "Magit 2.4.0")
 
 (define-obsolete-function-alias 'magit-insert-upstream-header
   'magit-insert-pull-branch-header "Magit 2.4.0")

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -429,19 +429,22 @@ The sections are inserted by running the functions on the hook
           (insert ?\s summary ?\n))))))
 
 (cl-defun magit-insert-pull-branch-header
-    (&optional (branch   (magit-get-current-branch))
-               (upstream (magit-get-tracked-branch branch)))
+    (&optional (branch (magit-get-current-branch))
+               (pull   (magit-get-tracked-branch branch))
+               keyword)
   "Insert a header line about branch normally pulled into the current branch."
-  (when upstream
-    (magit-insert-section (branch upstream)
-      (insert (format "%-10s" "Upstream: "))
-      (when (magit-get-boolean "branch" branch "rebase")
-        (insert "onto "))
-      (insert (propertize upstream 'face
+  (when pull
+    (magit-insert-section (branch pull)
+      (insert (format "%-10s"
+                      (or keyword
+                          (if (magit-get-boolean "branch" branch "rebase")
+                              "Rebase: "
+                            "Merge: "))))
+      (insert (propertize pull 'face
                           (if (string= (magit-get "branch" branch "remote") ".")
                               'magit-branch-local
                             'magit-branch-remote)))
-      (insert ?\s (magit-rev-format "%s" upstream) ?\n))))
+      (insert ?\s (magit-rev-format "%s" pull) ?\n))))
 
 (defun magit-insert-tags-header ()
   "Insert a header line about the current and/or next tag."

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -421,7 +421,6 @@ The sections are inserted by running the functions on the hook
       (if branch
           (magit-insert-section (branch branch)
             (insert (format "%-10s" "Head: "))
-            (insert (propertize commit 'face 'magit-hash) ?\s)
             (insert (propertize branch 'face 'magit-branch-local))
             (insert ?\s summary ?\n))
         (magit-insert-section (commit commit)
@@ -433,21 +432,16 @@ The sections are inserted by running the functions on the hook
     (&optional (branch   (magit-get-current-branch))
                (upstream (magit-get-tracked-branch branch)))
   "Insert a header line about the upstream branch and its tip."
-  (-when-let (output (and upstream (magit-rev-format "%h %s" upstream)))
-    (string-match "^\\([^ ]+\\) \\(.*\\)" output)
-    (magit-bind-match-strings (commit summary) output
-      (magit-insert-section (branch upstream)
-        (insert (format "%-10s" "Upstream: "))
-        (when commit
-          (insert (propertize commit 'face 'magit-hash) ?\s))
-        (when (magit-get-boolean "branch" branch "rebase")
-          (insert "onto "))
-        (insert
-         (propertize upstream 'face
-                     (if (string= (magit-get "branch" branch "remote") ".")
-                         'magit-branch-local
-                       'magit-branch-remote)))
-        (insert ?\s summary ?\n)))))
+  (when upstream
+    (magit-insert-section (branch upstream)
+      (insert (format "%-10s" "Upstream: "))
+      (when (magit-get-boolean "branch" branch "rebase")
+        (insert "onto "))
+      (insert (propertize upstream 'face
+                          (if (string= (magit-get "branch" branch "remote") ".")
+                              'magit-branch-local
+                            'magit-branch-remote)))
+      (insert ?\s (magit-rev-format "%s" upstream) ?\n))))
 
 (defun magit-insert-tags-header ()
   "Insert a header line about the current and/or next tag."

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -86,7 +86,7 @@
 (defcustom magit-status-headers-hook
   '(magit-insert-diff-filter-header
     magit-insert-head-header
-    magit-insert-upstream-header
+    magit-insert-pull-branch-header
     magit-insert-tags-header)
   "Hook run to insert headers into the status buffer.
 
@@ -100,7 +100,7 @@ at all."
              magit-insert-repo-header
              magit-insert-remote-header
              magit-insert-head-header
-             magit-insert-upstream-header
+             magit-insert-pull-branch-header
              magit-insert-tags-header))
 
 (defcustom magit-status-sections-hook
@@ -428,10 +428,10 @@ The sections are inserted by running the functions on the hook
           (insert (propertize commit 'face 'magit-hash))
           (insert ?\s summary ?\n))))))
 
-(cl-defun magit-insert-upstream-header
+(cl-defun magit-insert-pull-branch-header
     (&optional (branch   (magit-get-current-branch))
                (upstream (magit-get-tracked-branch branch)))
-  "Insert a header line about the upstream branch and its tip."
+  "Insert a header line about branch normally pulled into the current branch."
   (when upstream
     (magit-insert-section (branch upstream)
       (insert (format "%-10s" "Upstream: "))
@@ -2658,6 +2658,9 @@ where an absolute path is used for performance reasons.
 If the value already is just \"git\" but TRAMP never-the-less
 doesn't find the executable, then consult the info node
 `(tramp)Remote programs'.\n" remote) :error)))))
+
+(define-obsolete-function-alias 'magit-insert-upstream-header
+  'magit-insert-pull-branch-header "Magit 2.4.0")
 
 (provide 'magit)
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -444,7 +444,11 @@ The sections are inserted by running the functions on the hook
                           (if (string= (magit-get "branch" branch "remote") ".")
                               'magit-branch-local
                             'magit-branch-remote)))
-      (insert ?\s (magit-rev-format "%s" pull) ?\n))))
+      (insert ?\s)
+      (if (magit-rev-verify pull)
+          (insert (magit-rev-format "%s" pull))
+        (insert (propertize "is missing" 'face 'font-lock-warning-face)))
+      (insert ?\n))))
 
 (defun magit-insert-tags-header ()
   "Insert a header line about the current and/or next tag."

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -87,6 +87,7 @@
   '(magit-insert-diff-filter-header
     magit-insert-head-branch-header
     magit-insert-pull-branch-header
+    magit-insert-push-branch-header
     magit-insert-tags-header)
   "Hook run to insert headers into the status buffer.
 
@@ -101,6 +102,7 @@ at all."
              magit-insert-remote-header
              magit-insert-head-branch-header
              magit-insert-pull-branch-header
+             magit-insert-push-branch-header
              magit-insert-tags-header))
 
 (defcustom magit-status-sections-hook
@@ -447,6 +449,19 @@ The sections are inserted by running the functions on the hook
       (insert ?\s)
       (if (magit-rev-verify pull)
           (insert (magit-rev-format "%s" pull))
+        (insert (propertize "is missing" 'face 'font-lock-warning-face)))
+      (insert ?\n))))
+
+(cl-defun magit-insert-push-branch-header
+    (&optional (branch (magit-get-current-branch))
+               (push   (magit-get-push-branch branch)))
+  "Insert a header line about the branch the current branch is pushed to"
+  (when push
+    (magit-insert-section (branch push)
+      (insert (format "%-10s" "Push: "))
+      (insert (propertize push 'face 'magit-branch-remote) ?\s)
+      (if (magit-rev-verify push)
+          (insert (magit-rev-format "%s" push))
         (insert (propertize "is missing" 'face 'font-lock-warning-face)))
       (insert ?\n))))
 


### PR DESCRIPTION
The only part that I expect might cause some protests, is no hasher appear anymore in the headers of status buffers. I hope that most users won't miss them once they have been told about `C-w`, but if that isn't the case, then I am willing to consider the addition of an option.