### PR TITLE
make: fix compilation with Cygwin Emacs

### DIFF
--- a/default.mk
+++ b/default.mk
@@ -71,7 +71,10 @@ ifeq "$(DASH_DIR)" ""
   DASH_DIR = $(TOP)../dash
 endif
 
-CYGPATH := $(shell cygpath --version 2>/dev/null)
+SYSTYPE := $(shell $(EMACSBIN) -Q --batch --eval "(princ system-type)")
+ifeq ($(SYSTYPE), windows-nt)
+  CYGPATH := $(shell cygpath --version 2>/dev/null)
+endif
 
 ifdef CYGPATH
   LOAD_PATH ?= -L $(TOP)/lisp -L $(shell cygpath --mixed $(DASH_DIR))


### PR DESCRIPTION
Adjust default.mk so that `cygpath` is only called when compiling on Cygwin but with NT Emacs. Using `cygpath` is unnecessary when compiling with Cygwin Emacs, and can cause errors when used with the `--mixed` argument.


Fixes #2392