### PR TITLE
Improve docstring of magit-stash-index

### DIFF
--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -68,7 +68,10 @@ while two prefix arguments are equivalent to `--all'."
 ;;;###autoload
 (defun magit-stash-index (message)
   "Create a stash of the index only.
-Unstaged and untracked changes are not stashed."
+Unstaged and untracked changes are not stashed.  The stashed
+changes are applied in reverse to both the index and the
+worktree.  This command can fail when the worktree is not clean.
+Applying the resulting stash has the inverse effect."
   (interactive (list (magit-stash-read-message)))
   (magit-stash-save message t nil nil t 'worktree))
 


### PR DESCRIPTION
Clarify how this command effects index and worktree.

This fixes #2397.