### PR TITLE
add backtab binding for magit-section-cycle-global

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -322,6 +322,7 @@ starts complicating other things, then it will be removed."
     (define-key map [C-tab] 'magit-section-cycle)
     (define-key map [M-tab] 'magit-section-cycle-diffs)
     (define-key map [s-tab] 'magit-section-cycle-global)
+    (define-key map [backtab] 'magit-section-cycle-global)
     (define-key map "^"    'magit-section-up)
     (define-key map "n"    'magit-section-forward)
     (define-key map "p"    'magit-section-backward)


### PR DESCRIPTION
On my machine (Ubuntu 14.04 running Emacs 24.5.1) pressing `<S-tab>` gets registered as `<S-iso-lefttab>` which gets translated to `<backtab>`, so keybinding for `magit-section-cycle-global` doesn't work.

This change fixes it by also binding `<backtab>`.