### PR TITLE
Refactor branch handling

### DIFF
--- a/Documentation/RelNotes/2.4.0.txt
+++ b/Documentation/RelNotes/2.4.0.txt
@@ -19,6 +19,43 @@ UNRELEASED.
 Changes since v2.3.0
 --------------------
 
+* All of Git's push-related variables are now honored.  #2414
+
+* In addition to the upstream branch, the push-remote (configured
+  using `branch.<name>.pushRemote' or `remote.pushDefault') is now
+  also fully supported.  #2414
+
+* The branching popup now shows the most important Git variables that
+  are in some way related to branches.  The values of these variables
+  can now be conveniently changed from that popup.  #2414
+
+* The fetching, pulling, pushing, and rebasing popups now feature an
+  action which acts on the push-remote, another which acts on the
+  upstream, and yet another which acts on any other source or target.
+  For each of these actions the respective branch is shown in the
+  popup.  If an action isn't currently usable, then it is omitted from
+  the popup.
+
+  Many key bindings were changed for consistency and safety reasons.
+  Likewise many commands were renamed and their behavior was adjusted.
+  Some new commands, related to the push-remote, were added.  #2414
+
+* The status buffer now features up to four logs listing unpulled and
+  unpushed commits.  Two for the upstream and two for the push-remote.
+  #2414
+
+* A new Git variable `branch.autoSetupPush' was added.  But Git itself
+  unfortunately does not know about this variable, so it only takes
+  effect when branches are created using Magit.  #2414
+
+* The option `magit-push-always-verify' was removed.  That was only a
+  temporary kludge to keep users from shooting themselves in the foot.
+  This is no longer necessary because one now always sees were one is
+  about to push to.  #2414
+
+* The command `magit-push-implicitly', Magit's equivalent of `git
+  push', was removed.  #2414
+
 * When Git is run for side-effects and exits with a non-zero status,
   then the respective error message is now inserted into the status
   buffer.  This should help those users who do not see that message

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3676,26 +3676,26 @@ Also see [[info:gitman#git-push]].
   This prefix command shows the following suffix commands along with
   the appropriate infix arguments in a popup buffer.
 
+- Key: P Q, magit-push-quickly
+
+  Push the current branch to ~branch.<name>.pushRemote~.  If that
+  variable is unset, then push to ~remote.pushDefault~.  If that
+  variable is unset too, then raise an error.
+
 - Key: P P, magit-push-current
 
   Push the current branch to its upstream branch.  If the upstream
   isn't set, then read the remote branch.
-
-- Key: P o, magit-push
-
-  Push a branch to its upstream branch.  If the upstream isn't set,
-  then read the remote branch.
 
 - Key: P e, magit-push-elsewhere
 
   Push a branch or commit to some remote branch.  Read the local and
   remote branch.
 
-- Key: P Q, magit-push-quickly
+- Key: P o, magit-push
 
-  Push the current branch to ~branch.<name>.pushRemote~.  If that
-  variable is unset, then push to ~remote.pushDefault~.  If that
-  variable is unset too, then raise an error.
+  Push a branch to its upstream branch.  If the upstream isn't set,
+  then read the remote branch.
 
 - Key: P m, magit-push-matching
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1423,13 +1423,25 @@ By default the following functions are also members of that hook:
   If optional HEADING is non-nil use that as section heading
   instead of "Stashes:".
 
-- Function: magit-insert-unpulled-commits
+- Function: magit-insert-unpulled-from-upstream
 
-  Insert section showing unpulled commits.
+  Insert section showing commits that haven't been pulled from the
+  upstream branch yet.
 
-- Function: magit-insert-unpushed-commits
+- Function: magit-insert-unpulled-from-pushremote
 
-  Insert section showing unpushed commits.
+  Insert section showing commits that haven't been pulled from the
+  push-remote branch yet.
+
+- Function: magit-insert-unpushed-to-upstream
+
+  Insert section showing commits that haven't been pushed to the
+  upstream yet.
+
+- Function: magit-insert-unpushed-to-pushremote
+
+  Insert section showing commits that haven't been pushed to the
+  push-remote yet.
 
 The following functions can also be added to the above hook:
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3085,10 +3085,20 @@ Also see [[info:gitman#git-rebase]].
 When no rebase is in progress, then the popup buffer features the
 following commands.
 
-- Key: r r, magit-rebase
+- Key: r p, magit-rebase-onto-pushremote
 
-  Start a non-interactive rebase sequence.  All commits not in
-  UPSTREAM are rebased.
+  Rebase the current branch onto ~branch.<name>.pushRemote~.  If that
+  variable is unset, then rebase onto ~remote.pushDefault~.
+
+- Key: r u, magit-rebase-onto-upstream
+
+  Rebase the current branch onto its upstream branch.
+
+- Key: r e, magit-rebase
+
+  Rebase the current branch onto a branch read in the minibuffer.  All
+  commits that are reachable from head but not from the selected
+  branch TARGET are being rebased."
 
 - Key: r o, magit-rebase-subset
 
@@ -3101,9 +3111,9 @@ This can be used to turn one of the above non-interactive rebase
 variants into an interactive rebase.
 
 For example if you want to clean up a feature branch and at the same
-time rebase it onto ~master~, then you could use ~r-ir~.  But we recommend
-that you instead do that in two steps.  First use ~rs~ to cleanup the
-feature branch, and then in a second step ~rl~ to rebase it onto ~master~.
+time rebase it onto ~master~, then you could use ~r-iu~.  But we recommend
+that you instead do that in two steps.  First use ~ri~ to cleanup the
+feature branch, and then in a second step ~ru~ to rebase it onto ~master~.
 That way if things turn out to be more complicated than you thought
 and/or you make a mistake and have to start over, then you only have
 to redo half the work.
@@ -3116,20 +3126,11 @@ is not enabled in the popup.
 
   Start an interactive rebase sequence.
 
-- Key: r l, magit-rebase-unpushed
-
-  Start an interactive rebase sequence of unpushed commits.  This is
-  like ~magit-rebase-interactive~, but if the upstream of the current
-  branch is configured, then all commits since the merge-base are
-  rebased.  If there is no upstream or no merge-base, then the user
-  has to select the first commit to be rebased like for
-  ~magit-rebase-interactive~.
-
 - Key: r f, magit-rebase-autosquash
 
   Combine squash and fixup commits with their intended targets.
 
-- Key: r e, magit-rebase-edit-commit
+- Key: r m, magit-rebase-edit-commit
 
   Edit a single older commit using rebase.
 
@@ -3635,23 +3636,25 @@ Also see [[info:gitman#git-fetch]].
   This prefix command shows the following suffix commands along with
   the appropriate infix arguments in a popup buffer.
 
-- Key: f f, magit-fetch-current
+- Key: f p, magit-fetch-from-pushremote
 
-  Fetch from the upstream repository of the current branch.  If ~HEAD~
-  is detached or if the upstream is not configured, then read the
-  remote.
+  Fetch from the push-remote of the current branch.
 
-- Key: f o, magit-fetch
+- Key: f u, magit-fetch-from-upstream
+
+  Fetch from the push-remote of the current branch.
+
+- Key: f e, magit-fetch
 
   Fetch from another repository.
 
 - Key: f a, magit-fetch-all
 
-  Fetch from all configured remotes.
+  Fetch from all remotes.
 
 - Key: f m, magit-submodule-fetch
 
-  Fetch all submodules.  With a prefix argument fetch all remotes or
+  Fetch all submodules.  With a prefix argument fetch all remotes of
   all submodules.
 
 ** Pulling
@@ -3660,16 +3663,20 @@ Also see [[info:gitman#git-pull]].
 
 - Key: F, magit-pull-popup
 
-  This prefix command shows the following suffix commands along with
-  the appropriate infix arguments in a popup buffer.
+  This prefix command shows the following suffix commands in a popup
+  buffer.
 
-- Key: F F, magit-pull-current
+- Key: F p, magit-pull-from-pushremote
 
-  Fetch and merge into current branch.
+  Pull from the push-remote of the current branch.
 
-- Key: F o, magit-pull
+- Key: F u, magit-pull-from-upstream
 
-  Fetch from another repository and merge a fetched branch.
+  Pull from the upstream of the current branch.
+
+- Key: F e, magit-pull
+
+  Pull from a branch read in the minibuffer.
 
 ** Pushing
 
@@ -3680,18 +3687,16 @@ Also see [[info:gitman#git-push]].
   This prefix command shows the following suffix commands along with
   the appropriate infix arguments in a popup buffer.
 
-- Key: P Q, magit-push-quickly
+- Key: P p, magit-push-current-to-pushremote
 
-  Push the current branch to ~branch.<name>.pushRemote~.  If that
-  variable is unset, then push to ~remote.pushDefault~.  If that
-  variable is unset too, then raise an error.
+  Push the current branch to ~branch.<name>.pushRemote~ or if that
+  is unset to ~remote.pushDefault~.
 
-- Key: P P, magit-push-current
+- Key: P u, magit-push-current-to-upstream
 
-  Push the current branch to its upstream branch.  If the upstream
-  isn't set, then read the remote branch.
+  Push the current branch to its upstream branch.
 
-- Key: P e, magit-push-elsewhere
+- Key: P e, magit-push-current
 
   Push the current branch to a branch read in the minibuffer.
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3694,8 +3694,8 @@ Also see [[info:gitman#git-push]].
 
 - Key: P o, magit-push
 
-  Push a branch to its upstream branch.  If the upstream isn't set,
-  then read the remote branch.
+  Push an arbitrary branch or commit somewhere.  Both the source and
+  the target are read in the minibuffer.
 
 - Key: P m, magit-push-matching
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3107,7 +3107,7 @@ info:gitman#git-config.  Also see [[info:gitman#git-branch]],
   else then ~HEAD~ becomes detached.  Checkout fails if the working tree
   or the staging area contain changes.
 
-- Key: b c, magit-branch
+- Key: b n, magit-branch
 
   Create a new branch.  The user is asked for a branch or arbitrary
   revision to use as the starting point of the new branch.  When a
@@ -3115,7 +3115,7 @@ info:gitman#git-config.  Also see [[info:gitman#git-branch]],
   the new branch.  The name of the new branch is also read in the
   minibuffer.
 
-- Key: b B, magit-branch-and-checkout
+- Key: b c, magit-branch-and-checkout
 
   This command creates a new branch like ~magit-branch~, but then also
   checks it out.

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3713,26 +3713,6 @@ Also see [[info:gitman#git-push]].
 
   Push a tag to another repository.
 
-- User Option: magit-push-always-verify
-
-  Whether certain commands require verification before pushing.
-
-  Starting with ~v2.1.0~ some of the push commands are supposed to
-  push to the configured upstream branch without requiring user
-  confirmation or offering to push somewhere else.
-
-  This has taken a few users by surprise, and they suggested that we
-  force users to opt-in to this behavior.  Unfortunately adding this
-  option means that now other users will complain about us needlessly
-  forcing them to set an option.  This is an attempt to make everyone
-  happy and like all such attempts it is prone to fail.  Before
-  complaining about having to set this option, please consider that
-  other users are less experienced than you and have different needs.
-
-  You should set the value of this option to nil, causing all push
-  commands to behave as intended.  But first read the description of
-  each command above.
-
 ** Creating and sending patches
 
 - Key: W, magit-patch-popup

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2929,12 +2929,175 @@ To show no diff while committing remove ~magit-commit-diff~ from
 
 ** Branching
 
-Also see [[info:gitman#git-branch]] and [[info:gitman#git-checkout]].
+The upstream branch of some local branch is the branch into which the
+commits on that local branch should eventually be merged, usually
+something like ~origin/master~.  For the ~master~ branch itself the
+upstream branch and the branch it is being pushed to, are usually the
+same remote branch.  But for a feature branch the upstream branch and
+the branch it is being pushed to should differ.
+
+Feature branches too should /eventually/ end up in a remote branch such
+as ~origin/master~ or ~origin/maint~.  Such a branch should therefore be
+used as the upstream.  But feature branches shouldn't be pushed
+directly to such branches.  Instead a feature branch ~my-feature~ is
+usually pushed to ~my-fork/my-feature~ or ~origin/my-feature~.  After the
+new feature has been reviewed, the maintainer merges the feature into
+~master~.  And finally ~master~ (not ~my-feature~ itself) is pushed to
+~origin/master~.
+
+But new features seldom are perfect on the first try, and so feature
+branches usually have to be improved and re-pushed many times.
+Pushing should therefore be easy to do, and for that reason some users
+have concluded that the remote branch to which a feature branch is
+being pushed should be set as the upstream.  Luckily Git has long ago
+gained support for a push-remote which can be configured separately
+from the upstream branch, using the variables ~branch.<name>.pushRemote~
+and ~remote.pushDefault~, so we no longer have to choose which of the
+two remotes should be used as "the remote".
+
+Each of the fetching, pulling, and pushing popups features three
+commands which act on the current branch and some other branch.  Of
+these, ~p~ is bound to command which acts on the push-remote, ~u~ is bound
+to the command which acts on the upstream, and ~e~ is bound to a command
+which acts on any other branch.  The status buffer shows unpushed and
+unpulled for both the push-remote and the upstream.  In other words;
+embrace the fact that two remotes can be configure for any local
+branch.
+
+It's also easy to configure these two remotes.  The values of all the
+variables that are related to fetching, pulling, and pushing (as well
+as some other branch-related variables) can be inspected and changed
+in the branching popup.
 
 - Key: b, magit-branch-popup
 
-  This prefix command shows the following suffix commands along with
-  the appropriate infix arguments in a popup buffer.
+  This prefix command shows the following suffix commands in a popup
+  buffer.  It also displays the values of the following variables and
+  allows changing their values.
+
+The following variables are used to configure a specific branch.  The
+values are being displayed for the current branch (if any).  To change
+the value for another branch use a prefix argument.
+
+- Variable: branch.NAME.merge
+
+  Together with ~branch.NAME.remote~ this variable defines the upstream
+  branch of the local branch named NAME.  The value of this variable
+  is the full reference of the upstream /branch/.
+
+- Variable: branch.NAME.remote
+
+  Together with ~branch.NAME.merge~ this variable defines the upstream
+  branch of the local branch named NAME.  The value of this variable
+  is the name of the upstream /remote/.
+
+- Variable: branch.NAME.rebase
+
+  This variable controls whether pulling into the branch named NAME is
+  done by rebasing or by merging the fetched branch.
+
+  - When ~true~ then pulling is done by rebasing.
+  - When ~false~ then pulling is done by merging.
+  - When undefined then the value of ~pull.rebase~ is used.  The default
+    of that variable is ~false~.
+
+- Variable: branch.NAME.pushRemote
+
+  This variable specifies the remote that the branch named NAME is
+  usually pushed to.  The value has to be the name of an existing
+  remote.
+
+  It is not possible to specify the name of /branch/ to push the local
+  branch to.  The name of the remote branch is always the same as the
+  name of the local branch.
+
+  If this variable is undefined but ~remote.pushDefault~ is defined,
+  then the value of the latter is used.  By default ~remote.pushDefault~
+  is undefined.
+
+- Variable: branch.NAME.description
+
+  This variable can be used to describe the branch named NAME.  That
+  description is used e.g. when turning the branch into a series of
+  patches.
+
+The following variables specify defaults which are used if the above
+branch-specific variables are not set.
+
+- Variable: pull.rebase
+
+  This variable specifies whether pulling is done by rebasing or by
+  merging.  It can be overwritten using ~branch.NAME.rebase~.
+
+  - When ~true~ then pulling is done by rebasing.
+  - When ~false~ (the default) then pulling is done by merging.
+
+  Since it is never a good idea to merge the upstream branch into a
+  feature or hotfix branch and most branches are such branches, you
+  should consider setting this to ~true~, and ~branch.master.rebase~ to
+  ~false~.
+
+- Variable: remote.pushDefault
+
+  This variable specifies what remote the local branches are usually
+  pushed to.  This can be overwritten per branch using
+  ~branch.NAME.pushRemote~.
+
+The following variables are used during the creation of a branch and
+control whether the various branch-specific variables are
+automatically set at this time.
+
+- Variable: remote.autoSetupMerge
+
+  This variable specifies under what circumstances creating a branch
+  NAME should result in the variables ~branch.NAME.merge~ and
+  ~branch.NAME.remote~ being set according to the starting point used to
+  create the branch.  If the starting point isn't a branch, then these
+  variables are never set.
+
+  - When ~always~ then the variables are set regardless of whether the
+    starting point is a local or a remote branch.
+  - When ~true~ (the default) then the variable are set when the staring
+    point is a remote branch, but not when it is a local branch.
+  - When ~false~ then the variables are never set.
+
+- Variable: remote.autoSetupRebase
+
+  This variable specifies whether creating a branch NAME should result
+  in the variable ~branch.NAME.rebase~ being set to ~true~.
+
+  - When ~always~ then the variable is set regardless of whether the
+    starting point is a local or a remote branch.
+  - When ~local~ then the variable are set when the starting point is a
+    local branch, but not when it is a remote branch.
+  - When ~remote~ then the variable are set when the starting point is a
+    remote branch, but not when it is a local branch.
+  - When ~never~ (the default) then the variable is never set.
+
+- Variable: remote.autoSetupPush
+
+  This variable specifies whether creating a branch NAME should result
+  in the variable ~branch.NAME.pushRemote~ being set to what value.
+
+  This variable should either be undefined, or it should be the name
+  of an existing branch, in which case ~branch.NAME.pushRemote~ is set
+  to the same value.  Any other value, i.e. a non-existend remote, is
+  ignored.
+
+  This variable is only used by Magit, Git knows nothing about it.
+
+Note that the respective commands always change the repository-local
+values.  If you want to change the global value which is used when the
+local value is undefined, then you have to do so on the command line,
+e.g.:
+
+#+BEGIN_SRC shell
+  git config --global remote.autoSetupMerge always
+#+END_SRC
+
+For more information about these variables you should also see
+info:gitman#git-config.  Also see [[info:gitman#git-branch]],
+[[info:gitman#git-checkout]], and [[*Pushing]].
 
 - Key: b b, magit-checkout
 
@@ -2989,33 +3152,17 @@ Also see [[info:gitman#git-branch]] and [[info:gitman#git-checkout]].
   branches, then offer to delete those.  Otherwise, prompt for a single
   branch to be deleted, defaulting to the branch at point.
 
-- Key: b u, magit-branch-set-upstream
-
-  Change the upstream branch of a branch.  Both branches are read in
-  the minibuffer, while providing reasonable defaults.
-
-- Key: b U, magit-branch-unset-upstream
-
-  Unset the upstream branch of a branch read in the minibuffer and
-  defaulting to the branch at point or the current branch.
-
 - Key: b r, magit-branch-rename
 
   Rename a branch.  The branch and the new name are read in the
   minibuffer.  With prefix argument the branch is renamed even if that
   name conflicts with an existing branch.
 
-- Key: b e, magit-branch-edit-description
-
-  Edit the description of a branch.  The branch is read in the
-  minibuffer defaulting to the branch at point or the current branch.
-  The description is edited in a regular buffer similar to how commit
-  messages are edited.
-
 - User Option: magit-branch-read-upstream-first
 
   When creating a branch, whether to read the upstream branch before
-  the name of the branch that is to be created.
+  the name of the branch that is to be created.  The default is ~nil~,
+  and I recommend you leave it at that.
 
 ** Merging
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3693,11 +3693,9 @@ Also see [[info:gitman#git-push]].
 
 - Key: P Q, magit-push-quickly
 
-  Push the current branch to some remote.  When the Git variable
-  ~magit.pushRemote~ is set, then push to that remote.  If that variable
-  is undefined or the remote does not exist, then push to "origin".
-  If that also doesn't exist then raise an error.  The local branch is
-  pushed to the remote branch with the same name.
+  Push the current branch to ~branch.<name>.pushRemote~.  If that
+  variable is unset, then push to ~remote.pushDefault~.  If that
+  variable is unset too, then raise an error.
 
 - Key: P m, magit-push-matching
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3699,13 +3699,6 @@ Also see [[info:gitman#git-push]].
   If that also doesn't exist then raise an error.  The local branch is
   pushed to the remote branch with the same name.
 
-- Key: P i, magit-push-implicitly
-
-  Push without explicitly specifying what to push.  This runs ~git push
-  -v~.  What is being pushed depends on various Git variables as
-  described in the info:gitman#git-push and info:gitman#git-config
-  manpages.
-
 - Key: P m, magit-push-matching
 
   Push all matching branches to another repository.  If multiple

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1863,14 +1863,6 @@ Also see [[info:gitman#git-diff]].
 
   Show changes between any two files on disk.
 
-- Key: M-x magit-diff-unpushed, magit-diff-unpushed
-
-  Show unpushed changes.
-
-- Key: M-x magit-diff-unpulled, magit-diff-unpulled
-
-  Show unpulled changes.
-
 All of the above suffix commands update the repository's diff buffer.
 The diff popup also features two commands which show differences in
 another buffer:

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3689,8 +3689,7 @@ Also see [[info:gitman#git-push]].
 
 - Key: P e, magit-push-elsewhere
 
-  Push a branch or commit to some remote branch.  Read the local and
-  remote branch.
+  Push the current branch to a branch read in the minibuffer.
 
 - Key: P o, magit-push
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -5226,8 +5226,7 @@ isn't set, then read the remote branch.
 @cindex magit-push-elsewhere
 @item @kbd{P e} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-elsewhere})
 
-Push a branch or commit to some remote branch.  Read the local and
-remote branch.
+Push the current branch to a branch read in the minibuffer.
 
 @kindex P o
 @cindex magit-push

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -1939,14 +1939,28 @@ If optional HEADING is non-nil use that as section heading
 instead of "Stashes:".
 @end defun
 
-@defun magit-insert-unpulled-commits
+@defun magit-insert-unpulled-from-upstream
 
-Insert section showing unpulled commits.
+Insert section showing commits that haven't been pulled from the
+upstream branch yet.
 @end defun
 
-@defun magit-insert-unpushed-commits
+@defun magit-insert-unpulled-from-pushremote
 
-Insert section showing unpushed commits.
+Insert section showing commits that haven't been pulled from the
+push-remote branch yet.
+@end defun
+
+@defun magit-insert-unpushed-to-upstream
+
+Insert section showing commits that haven't been pushed to the
+upstream yet.
+@end defun
+
+@defun magit-insert-unpushed-to-pushremote
+
+Insert section showing commits that haven't been pushed to the
+push-remote yet.
 @end defun
 
 The following functions can also be added to the above hook:

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -4273,12 +4273,26 @@ When no rebase is in progress, then the popup buffer features the
 following commands.
 
 @table @asis
-@kindex r r
-@cindex magit-rebase
-@item @kbd{r r} @tie{}@tie{}@tie{}@tie{}(@code{magit-rebase})
+@kindex r p
+@cindex magit-rebase-onto-pushremote
+@item @kbd{r p} @tie{}@tie{}@tie{}@tie{}(@code{magit-rebase-onto-pushremote})
 
-Start a non-interactive rebase sequence.  All commits not in
-UPSTREAM are rebased.
+Rebase the current branch onto @code{branch.<name>.pushRemote}.  If that
+variable is unset, then rebase onto @code{remote.pushDefault}.
+
+@kindex r u
+@cindex magit-rebase-onto-upstream
+@item @kbd{r u} @tie{}@tie{}@tie{}@tie{}(@code{magit-rebase-onto-upstream})
+
+Rebase the current branch onto its upstream branch.
+
+@kindex r e
+@cindex magit-rebase
+@item @kbd{r e} @tie{}@tie{}@tie{}@tie{}(@code{magit-rebase})
+
+Rebase the current branch onto a branch read in the minibuffer.  All
+commits that are reachable from head but not from the selected
+branch TARGET are being rebased."
 
 @kindex r o
 @cindex magit-rebase-subset
@@ -4294,9 +4308,9 @@ This can be used to turn one of the above non-interactive rebase
 variants into an interactive rebase.
 
 For example if you want to clean up a feature branch and at the same
-time rebase it onto @code{master}, then you could use @code{r-ir}.  But we recommend
-that you instead do that in two steps.  First use @code{rs} to cleanup the
-feature branch, and then in a second step @code{rl} to rebase it onto @code{master}.
+time rebase it onto @code{master}, then you could use @code{r-iu}.  But we recommend
+that you instead do that in two steps.  First use @code{ri} to cleanup the
+feature branch, and then in a second step @code{ru} to rebase it onto @code{master}.
 That way if things turn out to be more complicated than you thought
 and/or you make a mistake and have to start over, then you only have
 to redo half the work.
@@ -4312,26 +4326,15 @@ is not enabled in the popup.
 
 Start an interactive rebase sequence.
 
-@kindex r l
-@cindex magit-rebase-unpushed
-@item @kbd{r l} @tie{}@tie{}@tie{}@tie{}(@code{magit-rebase-unpushed})
-
-Start an interactive rebase sequence of unpushed commits.  This is
-like @code{magit-rebase-interactive}, but if the upstream of the current
-branch is configured, then all commits since the merge-base are
-rebased.  If there is no upstream or no merge-base, then the user
-has to select the first commit to be rebased like for
-@code{magit-rebase-interactive}.
-
 @kindex r f
 @cindex magit-rebase-autosquash
 @item @kbd{r f} @tie{}@tie{}@tie{}@tie{}(@code{magit-rebase-autosquash})
 
 Combine squash and fixup commits with their intended targets.
 
-@kindex r e
+@kindex r m
 @cindex magit-rebase-edit-commit
-@item @kbd{r e} @tie{}@tie{}@tie{}@tie{}(@code{magit-rebase-edit-commit})
+@item @kbd{r m} @tie{}@tie{}@tie{}@tie{}(@code{magit-rebase-edit-commit})
 
 Edit a single older commit using rebase.
 
@@ -5118,17 +5121,21 @@ the git-fetch(1) manpage
 This prefix command shows the following suffix commands along with
 the appropriate infix arguments in a popup buffer.
 
-@kindex f f
-@cindex magit-fetch-current
-@item @kbd{f f} @tie{}@tie{}@tie{}@tie{}(@code{magit-fetch-current})
+@kindex f p
+@cindex magit-fetch-from-pushremote
+@item @kbd{f p} @tie{}@tie{}@tie{}@tie{}(@code{magit-fetch-from-pushremote})
 
-Fetch from the upstream repository of the current branch.  If @code{HEAD}
-is detached or if the upstream is not configured, then read the
-remote.
+Fetch from the push-remote of the current branch.
 
-@kindex f o
+@kindex f u
+@cindex magit-fetch-from-upstream
+@item @kbd{f u} @tie{}@tie{}@tie{}@tie{}(@code{magit-fetch-from-upstream})
+
+Fetch from the push-remote of the current branch.
+
+@kindex f e
 @cindex magit-fetch
-@item @kbd{f o} @tie{}@tie{}@tie{}@tie{}(@code{magit-fetch})
+@item @kbd{f e} @tie{}@tie{}@tie{}@tie{}(@code{magit-fetch})
 
 Fetch from another repository.
 
@@ -5136,13 +5143,13 @@ Fetch from another repository.
 @cindex magit-fetch-all
 @item @kbd{f a} @tie{}@tie{}@tie{}@tie{}(@code{magit-fetch-all})
 
-Fetch from all configured remotes.
+Fetch from all remotes.
 
 @kindex f m
 @cindex magit-submodule-fetch
 @item @kbd{f m} @tie{}@tie{}@tie{}@tie{}(@code{magit-submodule-fetch})
 
-Fetch all submodules.  With a prefix argument fetch all remotes or
+Fetch all submodules.  With a prefix argument fetch all remotes of
 all submodules.
 @end table
 
@@ -5168,20 +5175,26 @@ the git-pull(1) manpage
 @cindex magit-pull-popup
 @item @kbd{F} @tie{}@tie{}@tie{}@tie{}(@code{magit-pull-popup})
 
-This prefix command shows the following suffix commands along with
-the appropriate infix arguments in a popup buffer.
+This prefix command shows the following suffix commands in a popup
+buffer.
 
-@kindex F F
-@cindex magit-pull-current
-@item @kbd{F F} @tie{}@tie{}@tie{}@tie{}(@code{magit-pull-current})
+@kindex F p
+@cindex magit-pull-from-pushremote
+@item @kbd{F p} @tie{}@tie{}@tie{}@tie{}(@code{magit-pull-from-pushremote})
 
-Fetch and merge into current branch.
+Pull from the push-remote of the current branch.
 
-@kindex F o
+@kindex F u
+@cindex magit-pull-from-upstream
+@item @kbd{F u} @tie{}@tie{}@tie{}@tie{}(@code{magit-pull-from-upstream})
+
+Pull from the upstream of the current branch.
+
+@kindex F e
 @cindex magit-pull
-@item @kbd{F o} @tie{}@tie{}@tie{}@tie{}(@code{magit-pull})
+@item @kbd{F e} @tie{}@tie{}@tie{}@tie{}(@code{magit-pull})
 
-Fetch from another repository and merge a fetched branch.
+Pull from a branch read in the minibuffer.
 @end table
 
 @node Pushing
@@ -5209,24 +5222,22 @@ the git-push(1) manpage
 This prefix command shows the following suffix commands along with
 the appropriate infix arguments in a popup buffer.
 
-@kindex P Q
-@cindex magit-push-quickly
-@item @kbd{P Q} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-quickly})
+@kindex P p
+@cindex magit-push-current-to-pushremote
+@item @kbd{P p} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-current-to-pushremote})
 
-Push the current branch to @code{branch.<name>.pushRemote}.  If that
-variable is unset, then push to @code{remote.pushDefault}.  If that
-variable is unset too, then raise an error.
+Push the current branch to @code{branch.<name>.pushRemote} or if that
+is unset to @code{remote.pushDefault}.
 
-@kindex P P
-@cindex magit-push-current
-@item @kbd{P P} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-current})
+@kindex P u
+@cindex magit-push-current-to-upstream
+@item @kbd{P u} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-current-to-upstream})
 
-Push the current branch to its upstream branch.  If the upstream
-isn't set, then read the remote branch.
+Push the current branch to its upstream branch.
 
 @kindex P e
-@cindex magit-push-elsewhere
-@item @kbd{P e} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-elsewhere})
+@cindex magit-push-current
+@item @kbd{P e} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-current})
 
 Push the current branch to a branch read in the minibuffer.
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -5257,29 +5257,7 @@ remote configured for the current branch as default.
 @item @kbd{P T} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-tag})
 
 Push a tag to another repository.
-
 @end table
-
-@defopt magit-push-always-verify
-
-Whether certain commands require verification before pushing.
-
-Starting with @code{v2.1.0} some of the push commands are supposed to
-push to the configured upstream branch without requiring user
-confirmation or offering to push somewhere else.
-
-This has taken a few users by surprise, and they suggested that we
-force users to opt-in to this behavior.  Unfortunately adding this
-option means that now other users will complain about us needlessly
-forcing them to set an option.  This is an attempt to make everyone
-happy and like all such attempts it is prone to fail.  Before
-complaining about having to set this option, please consider that
-other users are less experienced than you and have different needs.
-
-You should set the value of this option to nil, causing all push
-commands to behave as intended.  But first read the description of
-each command above.
-@end defopt
 
 @node Creating and sending patches
 @section Creating and sending patches

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -4016,7 +4016,227 @@ To show no diff while committing remove @code{magit-commit-diff} from
 @node Branching
 @section Branching
 
-Also see 
+The upstream branch of some local branch is the branch into which the
+commits on that local branch should eventually be merged, usually
+something like @code{origin/master}.  For the @code{master} branch itself the
+upstream branch and the branch it is being pushed to, are usually the
+same remote branch.  But for a feature branch the upstream branch and
+the branch it is being pushed to should differ.
+
+Feature branches too should @emph{eventually} end up in a remote branch such
+as @code{origin/master} or @code{origin/maint}.  Such a branch should therefore be
+used as the upstream.  But feature branches shouldn't be pushed
+directly to such branches.  Instead a feature branch @code{my-feature} is
+usually pushed to @code{my-fork/my-feature} or @code{origin/my-feature}.  After the
+new feature has been reviewed, the maintainer merges the feature into
+@code{master}.  And finally @code{master} (not @code{my-feature} itself) is pushed to
+@code{origin/master}.
+
+But new features seldom are perfect on the first try, and so feature
+branches usually have to be improved and re-pushed many times.
+Pushing should therefore be easy to do, and for that reason some users
+have concluded that the remote branch to which a feature branch is
+being pushed should be set as the upstream.  Luckily Git has long ago
+gained support for a push-remote which can be configured separately
+from the upstream branch, using the variables @code{branch.<name>.pushRemote}
+and @code{remote.pushDefault}, so we no longer have to choose which of the
+two remotes should be used as "the remote".
+
+Each of the fetching, pulling, and pushing popups features three
+commands which act on the current branch and some other branch.  Of
+these, @code{p} is bound to command which acts on the push-remote, @code{u} is bound
+to the command which acts on the upstream, and @code{e} is bound to a command
+which acts on any other branch.  The status buffer shows unpushed and
+unpulled for both the push-remote and the upstream.  In other words;
+embrace the fact that two remotes can be configure for any local
+branch.
+
+It's also easy to configure these two remotes.  The values of all the
+variables that are related to fetching, pulling, and pushing (as well
+as some other branch-related variables) can be inspected and changed
+in the branching popup.
+
+@table @asis
+@kindex b
+@cindex magit-branch-popup
+@item @kbd{b} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-popup})
+
+This prefix command shows the following suffix commands in a popup
+buffer.  It also displays the values of the following variables and
+allows changing their values.
+@end table
+
+The following variables are used to configure a specific branch.  The
+values are being displayed for the current branch (if any).  To change
+the value for another branch use a prefix argument.
+
+@defvar branch.NAME.merge
+
+Together with @code{branch.NAME.remote} this variable defines the upstream
+branch of the local branch named NAME.  The value of this variable
+is the full reference of the upstream @emph{branch}.
+@end defvar
+
+@defvar branch.NAME.remote
+
+Together with @code{branch.NAME.merge} this variable defines the upstream
+branch of the local branch named NAME.  The value of this variable
+is the name of the upstream @emph{remote}.
+@end defvar
+
+@defvar branch.NAME.rebase
+
+This variable controls whether pulling into the branch named NAME is
+done by rebasing or by merging the fetched branch.
+
+@itemize
+@item
+When @code{true} then pulling is done by rebasing.
+
+@item
+When @code{false} then pulling is done by merging.
+
+@item
+When undefined then the value of @code{pull.rebase} is used.  The default
+of that variable is @code{false}.
+@end itemize
+@end defvar
+
+@defvar branch.NAME.pushRemote
+
+This variable specifies the remote that the branch named NAME is
+usually pushed to.  The value has to be the name of an existing
+remote.
+
+It is not possible to specify the name of @emph{branch} to push the local
+branch to.  The name of the remote branch is always the same as the
+name of the local branch.
+
+If this variable is undefined but @code{remote.pushDefault} is defined,
+then the value of the latter is used.  By default @code{remote.pushDefault}
+is undefined.
+@end defvar
+
+@defvar branch.NAME.description
+
+This variable can be used to describe the branch named NAME.  That
+description is used e.g. when turning the branch into a series of
+patches.
+@end defvar
+
+The following variables specify defaults which are used if the above
+branch-specific variables are not set.
+
+@defvar pull.rebase
+
+This variable specifies whether pulling is done by rebasing or by
+merging.  It can be overwritten using @code{branch.NAME.rebase}.
+
+@itemize
+@item
+When @code{true} then pulling is done by rebasing.
+
+@item
+When @code{false} (the default) then pulling is done by merging.
+@end itemize
+Since it is never a good idea to merge the upstream branch into a
+feature or hotfix branch and most branches are such branches, you
+should consider setting this to @code{true}, and @code{branch.master.rebase} to
+@code{false}.
+@end defvar
+
+@defvar remote.pushDefault
+
+This variable specifies what remote the local branches are usually
+pushed to.  This can be overwritten per branch using
+@code{branch.NAME.pushRemote}.
+@end defvar
+
+The following variables are used during the creation of a branch and
+control whether the various branch-specific variables are
+automatically set at this time.
+
+@defvar remote.autoSetupMerge
+
+This variable specifies under what circumstances creating a branch
+NAME should result in the variables @code{branch.NAME.merge} and
+@code{branch.NAME.remote} being set according to the starting point used to
+create the branch.  If the starting point isn't a branch, then these
+variables are never set.
+
+@itemize
+@item
+When @code{always} then the variables are set regardless of whether the
+starting point is a local or a remote branch.
+
+@item
+When @code{true} (the default) then the variable are set when the staring
+point is a remote branch, but not when it is a local branch.
+
+@item
+When @code{false} then the variables are never set.
+@end itemize
+@end defvar
+
+@defvar remote.autoSetupRebase
+
+This variable specifies whether creating a branch NAME should result
+in the variable @code{branch.NAME.rebase} being set to @code{true}.
+
+@itemize
+@item
+When @code{always} then the variable is set regardless of whether the
+starting point is a local or a remote branch.
+
+@item
+When @code{local} then the variable are set when the starting point is a
+local branch, but not when it is a remote branch.
+
+@item
+When @code{remote} then the variable are set when the starting point is a
+remote branch, but not when it is a local branch.
+
+@item
+When @code{never} (the default) then the variable is never set.
+@end itemize
+@end defvar
+
+@defvar remote.autoSetupPush
+
+This variable specifies whether creating a branch NAME should result
+in the variable @code{branch.NAME.pushRemote} being set to what value.
+
+This variable should either be undefined, or it should be the name
+of an existing branch, in which case @code{branch.NAME.pushRemote} is set
+to the same value.  Any other value, i.e. a non-existend remote, is
+ignored.
+
+This variable is only used by Magit, Git knows nothing about it.
+@end defvar
+
+Note that the respective commands always change the repository-local
+values.  If you want to change the global value which is used when the
+local value is undefined, then you have to do so on the command line,
+e.g.:
+
+@example
+git config --global remote.autoSetupMerge always
+@end example
+
+For more information about these variables you should also see
+
+@ifinfo
+@ref{git-config,,,gitman,}
+@end ifinfo
+@ifhtml
+@html
+the <a href="http://git-scm.com/docs/git-config">git-config(1)</a> manpage
+@end html
+@end ifhtml
+@iftex
+the git-config(1) manpage
+@end iftex
+.  Also see 
 @ifinfo
 @ref{git-branch,,,gitman,}
 @end ifinfo
@@ -4028,7 +4248,8 @@ the <a href="http://git-scm.com/docs/git-branch">git-branch(1)</a> manpage
 @iftex
 the git-branch(1) manpage
 @end iftex
- and 
+,
+
 @ifinfo
 @ref{git-checkout,,,gitman,}
 @end ifinfo
@@ -4040,16 +4261,9 @@ the <a href="http://git-scm.com/docs/git-checkout">git-checkout(1)</a> manpage
 @iftex
 the git-checkout(1) manpage
 @end iftex
-.
+, and @ref{Pushing,Pushing}.
 
 @table @asis
-@kindex b
-@cindex magit-branch-popup
-@item @kbd{b} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-popup})
-
-This prefix command shows the following suffix commands along with
-the appropriate infix arguments in a popup buffer.
-
 @kindex b b
 @cindex magit-checkout
 @item @kbd{b b} @tie{}@tie{}@tie{}@tie{}(@code{magit-checkout})
@@ -4115,20 +4329,6 @@ Delete one or multiple branches.  If the region marks multiple
 branches, then offer to delete those.  Otherwise, prompt for a single
 branch to be deleted, defaulting to the branch at point.
 
-@kindex b u
-@cindex magit-branch-set-upstream
-@item @kbd{b u} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-set-upstream})
-
-Change the upstream branch of a branch.  Both branches are read in
-the minibuffer, while providing reasonable defaults.
-
-@kindex b U
-@cindex magit-branch-unset-upstream
-@item @kbd{b U} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-unset-upstream})
-
-Unset the upstream branch of a branch read in the minibuffer and
-defaulting to the branch at point or the current branch.
-
 @kindex b r
 @cindex magit-branch-rename
 @item @kbd{b r} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-rename})
@@ -4137,21 +4337,13 @@ Rename a branch.  The branch and the new name are read in the
 minibuffer.  With prefix argument the branch is renamed even if that
 name conflicts with an existing branch.
 
-@kindex b e
-@cindex magit-branch-edit-description
-@item @kbd{b e} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-edit-description})
-
-Edit the description of a branch.  The branch is read in the
-minibuffer defaulting to the branch at point or the current branch.
-The description is edited in a regular buffer similar to how commit
-messages are edited.
-
 @end table
 
 @defopt magit-branch-read-upstream-first
 
 When creating a branch, whether to read the upstream branch before
-the name of the branch that is to be created.
+the name of the branch that is to be created.  The default is @code{nil},
+and I recommend you leave it at that.
 @end defopt
 
 @node Merging

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -4274,9 +4274,9 @@ branch then that becomes the current branch.  If it is something
 else then @code{HEAD} becomes detached.  Checkout fails if the working tree
 or the staging area contain changes.
 
-@kindex b c
+@kindex b n
 @cindex magit-branch
-@item @kbd{b c} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch})
+@item @kbd{b n} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch})
 
 Create a new branch.  The user is asked for a branch or arbitrary
 revision to use as the starting point of the new branch.  When a
@@ -4284,9 +4284,9 @@ branch name is provided, then that becomes the upstream branch of
 the new branch.  The name of the new branch is also read in the
 minibuffer.
 
-@kindex b B
+@kindex b c
 @cindex magit-branch-and-checkout
-@item @kbd{b B} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-and-checkout})
+@item @kbd{b c} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-and-checkout})
 
 This command creates a new branch like @code{magit-branch}, but then also
 checks it out.

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -2540,18 +2540,6 @@ Show changes between the working tree and the index.
 @item @kbd{d p} @tie{}@tie{}@tie{}@tie{}(@code{magit-diff-paths})
 
 Show changes between any two files on disk.
-
-@kindex M-x magit-diff-unpushed
-@cindex magit-diff-unpushed
-@item @kbd{M-x magit-diff-unpushed} @tie{}@tie{}@tie{}@tie{}(@code{magit-diff-unpushed})
-
-Show unpushed changes.
-
-@kindex M-x magit-diff-unpulled
-@cindex magit-diff-unpulled
-@item @kbd{M-x magit-diff-unpulled} @tie{}@tie{}@tie{}@tie{}(@code{magit-diff-unpulled})
-
-Show unpulled changes.
 @end table
 
 All of the above suffix commands update the repository's diff buffer.

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -5233,8 +5233,8 @@ remote branch.
 @cindex magit-push
 @item @kbd{P o} @tie{}@tie{}@tie{}@tie{}(@code{magit-push})
 
-Push a branch to its upstream branch.  If the upstream isn't set,
-then read the remote branch.
+Push an arbitrary branch or commit somewhere.  Both the source and
+the target are read in the minibuffer.
 
 @kindex P m
 @cindex magit-push-matching

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -5207,19 +5207,20 @@ the git-push(1) manpage
 This prefix command shows the following suffix commands along with
 the appropriate infix arguments in a popup buffer.
 
+@kindex P Q
+@cindex magit-push-quickly
+@item @kbd{P Q} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-quickly})
+
+Push the current branch to @code{branch.<name>.pushRemote}.  If that
+variable is unset, then push to @code{remote.pushDefault}.  If that
+variable is unset too, then raise an error.
+
 @kindex P P
 @cindex magit-push-current
 @item @kbd{P P} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-current})
 
 Push the current branch to its upstream branch.  If the upstream
 isn't set, then read the remote branch.
-
-@kindex P o
-@cindex magit-push
-@item @kbd{P o} @tie{}@tie{}@tie{}@tie{}(@code{magit-push})
-
-Push a branch to its upstream branch.  If the upstream isn't set,
-then read the remote branch.
 
 @kindex P e
 @cindex magit-push-elsewhere
@@ -5228,13 +5229,12 @@ then read the remote branch.
 Push a branch or commit to some remote branch.  Read the local and
 remote branch.
 
-@kindex P Q
-@cindex magit-push-quickly
-@item @kbd{P Q} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-quickly})
+@kindex P o
+@cindex magit-push
+@item @kbd{P o} @tie{}@tie{}@tie{}@tie{}(@code{magit-push})
 
-Push the current branch to @code{branch.<name>.pushRemote}.  If that
-variable is unset, then push to @code{remote.pushDefault}.  If that
-variable is unset too, then raise an error.
+Push a branch to its upstream branch.  If the upstream isn't set,
+then read the remote branch.
 
 @kindex P m
 @cindex magit-push-matching

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -5238,39 +5238,6 @@ is undefined or the remote does not exist, then push to "origin".
 If that also doesn't exist then raise an error.  The local branch is
 pushed to the remote branch with the same name.
 
-@kindex P i
-@cindex magit-push-implicitly
-@item @kbd{P i} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-implicitly})
-
-Push without explicitly specifying what to push.  This runs @code{git push
-  -v}.  What is being pushed depends on various Git variables as
-described in the 
-@ifinfo
-@ref{git-push,,,gitman,}
-@end ifinfo
-@ifhtml
-@html
-the <a href="http://git-scm.com/docs/git-push">git-push(1)</a> manpage
-@end html
-@end ifhtml
-@iftex
-the git-push(1) manpage
-@end iftex
- and 
-@ifinfo
-@ref{git-config,,,gitman,}
-@end ifinfo
-@ifhtml
-@html
-the <a href="http://git-scm.com/docs/git-config">git-config(1)</a> manpage
-@end html
-@end ifhtml
-@iftex
-the git-config(1) manpage
-@end iftex
-
-manpages.
-
 @kindex P m
 @cindex magit-push-matching
 @item @kbd{P m} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-matching})

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -5232,11 +5232,9 @@ remote branch.
 @cindex magit-push-quickly
 @item @kbd{P Q} @tie{}@tie{}@tie{}@tie{}(@code{magit-push-quickly})
 
-Push the current branch to some remote.  When the Git variable
-@code{magit.pushRemote} is set, then push to that remote.  If that variable
-is undefined or the remote does not exist, then push to "origin".
-If that also doesn't exist then raise an error.  The local branch is
-pushed to the remote branch with the same name.
+Push the current branch to @code{branch.<name>.pushRemote}.  If that
+variable is unset, then push to @code{remote.pushDefault}.  If that
+variable is unset too, then raise an error.
 
 @kindex P m
 @cindex magit-push-matching

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -620,12 +620,8 @@ If no DWIM context is found, nil is returned."
     (magit-section-case
       ([* unstaged] 'unstaged)
       ([* staged] 'staged)
-      (unpushed (format "%s...%s"
-                        (magit-get-tracked-branch)
-                        (magit-get-current-branch)))
-      (unpulled (format "%s...%s"
-                        (magit-get-current-branch)
-                        (magit-get-tracked-branch)))
+      (unpushed (magit-section-value it))
+      (unpulled (magit-section-value it))
       (branch (let ((current (magit-get-current-branch))
                     (atpoint (magit-section-value it)))
                 (if (equal atpoint current)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1680,7 +1680,7 @@ or a ref which is not a branch, then it inserts nothing."
     map)
   "Keymap for the `unstaged' section.")
 
-(magit-define-section-jumper unstaged "Unstaged changes")
+(magit-define-section-jumper magit-jump-to-unstaged "Unstaged changes" unstaged)
 
 (defun magit-insert-unstaged-changes ()
   "Insert section showing unstaged changes."
@@ -1700,7 +1700,7 @@ or a ref which is not a branch, then it inserts nothing."
     map)
   "Keymap for the `staged' section.")
 
-(magit-define-section-jumper staged "Staged changes")
+(magit-define-section-jumper magit-jump-to-staged "Staged changes" staged)
 
 (defun magit-insert-staged-changes ()
   "Insert section showing staged changes."

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -717,22 +717,6 @@ a commit read from the minibuffer."
   (magit-diff-setup nil nil args files))
 
 ;;;###autoload
-(defun magit-diff-unpushed (&optional args files)
-  "Show unpushed changes."
-  (interactive (magit-diff-arguments))
-  (-if-let (tracked (magit-get-tracked-ref))
-      (magit-diff-setup (concat tracked "...") nil args files)
-    (user-error "No upstream set")))
-
-;;;###autoload
-(defun magit-diff-unpulled (&optional args files)
-  "Show unpulled changes."
-  (interactive (magit-diff-arguments))
-  (-if-let (tracked (magit-get-tracked-ref))
-      (magit-diff-setup (concat "..." tracked) nil args files)
-    (user-error "No upstream set")))
-
-;;;###autoload
 (defun magit-diff-while-committing (&optional args files)
   "While committing, show the changes that are about to be committed.
 While amending, invoking the command again toggles between

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1110,6 +1110,14 @@ Return a list of two integers: (A>B B>A)."
                              secondary-default
                              (magit-get-current-branch))))
 
+(defun magit-read-local-branch-or-commit (prompt)
+  (let ((branches (magit-list-local-branch-names))
+        (commit (magit-commit-at-point)))
+    (or (magit-completing-read "Push" (if commit (cons commit branches) branches)
+                               nil nil nil 'magit-revision-history
+                               (or (magit-local-branch-at-point) commit))
+                     (user-error "Nothing selected"))))
+
 (defun magit-read-local-branch-or-ref (prompt &optional secondary-default)
   (magit-completing-read prompt (nconc (magit-list-local-branch-names)
                                        (magit-list-refs "refs/"))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -745,12 +745,15 @@ which is different from the current branch and still exists."
             merge
           (concat remote "/" merge))))))
 
+(cl-defun magit-get-push-remote
+    (&optional (branch (magit-get-current-branch)))
+  (or (and branch (magit-get "branch" branch "pushRemote"))
+      (magit-get "remote.pushDefault")))
+
 (cl-defun magit-get-push-branch
     (&optional (branch (magit-get-current-branch)))
-  (when branch
-    (-when-let (remote (or (magit-get "branch" branch "pushRemote")
-                           (magit-get "remote.pushDefault")))
-      (concat remote "/" branch))))
+  (-when-let (remote (and branch (magit-get-push-remote branch)))
+    (concat remote "/" branch)))
 
 (defun magit-get-remote (&optional branch)
   (when (or branch (setq branch (magit-get-current-branch)))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -896,6 +896,10 @@ where COMMITS is the number of commits in TAG but not in REV."
   (and (or (member string (magit-list-branches))
            (member string (magit-list-branch-names))) t))
 
+(defun magit-local-branch-p (branch)
+  (and (or (member branch (magit-list-local-branches))
+           (member branch (magit-list-local-branch-names))) t))
+
 (defun magit-remote-p (string)
   (car (member string (magit-list-remotes))))
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1106,7 +1106,7 @@ Return a list of two integers: (A>B B>A)."
 (defun magit-read-local-branch (prompt &optional secondary-default)
   (magit-completing-read prompt (magit-list-local-branch-names)
                          nil t nil 'magit-revision-history
-                         (or (magit-branch-at-point)
+                         (or (magit-local-branch-at-point)
                              secondary-default
                              (magit-get-current-branch))))
 
@@ -1114,7 +1114,7 @@ Return a list of two integers: (A>B B>A)."
   (magit-completing-read prompt (nconc (magit-list-local-branch-names)
                                        (magit-list-refs "refs/"))
                          nil t nil 'magit-revision-history
-                         (or (magit-branch-at-point)
+                         (or (magit-local-branch-at-point)
                              secondary-default
                              (magit-get-current-branch))))
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -742,8 +742,13 @@ which is different from the current branch and still exists."
       (when (and remote merge (string-prefix-p "refs/heads/" merge))
         (setq merge (substring merge 11))
         (if (string-equal remote ".")
-            merge
-          (concat remote "/" merge))))))
+            (propertize merge 'face 'magit-branch-local)
+          (propertize (concat remote "/" merge) 'face 'magit-branch-remote))))))
+
+(cl-defun magit-get-tracked-remote
+    (&optional (branch (magit-get-current-branch)))
+  (when branch
+    (magit-get "branch" branch "remote")))
 
 (cl-defun magit-get-push-remote
     (&optional (branch (magit-get-current-branch)))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1090,7 +1090,7 @@ Return a list of two integers: (A>B B>A)."
     (prompt &optional remote default local-branch require-match)
   (when (consp default)
     (setq default (concat (car default) "/" (cdr default))))
-  (let ((branch (magit-completing-read
+  (let ((choice (magit-completing-read
                  prompt
                  (nconc (and local-branch
                              (if remote
@@ -1099,9 +1099,10 @@ Return a list of two integers: (A>B B>A)."
                                       (magit-list-remotes))))
                         (magit-list-remote-branch-names remote t))
                  nil require-match nil 'magit-revision-history default)))
-    (string-match "^\\([^/]+\\)/\\(.+\\)" branch)
-    (cons (match-string 1 branch)
-          (match-string 2 branch))))
+    (if (string-match "\\`\\([^/]+\\)/\\(.+\\)" choice)
+        (cons (match-string 1 choice)
+              (match-string 2 choice))
+      (user-error "`%s' doesn't have the form REMOTE/BRANCH" choice))))
 
 (defun magit-read-local-branch (prompt &optional secondary-default)
   (magit-completing-read prompt (magit-list-local-branch-names)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1264,11 +1264,10 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
 
 (defun magit-insert-unpulled-commits ()
   "Insert section showing unpulled commits."
-  (-when-let (tracked (magit-get-tracked-ref))
+  (when (magit-git-success "rev-parse" "@{upstream}")
     (magit-insert-section (unpulled)
       (magit-insert-heading "Unpulled commits:")
-      (magit-insert-log (concat "HEAD.." tracked)
-                        magit-log-section-arguments))))
+      (magit-insert-log "..@{upstream}" magit-log-section-arguments))))
 
 (defvar magit-unpushed-section-map
   (let ((map (make-sparse-keymap)))
@@ -1280,11 +1279,10 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
 
 (defun magit-insert-unpushed-commits ()
   "Insert section showing unpushed commits."
-  (-when-let (tracked (magit-get-tracked-ref))
+  (when (magit-git-success "rev-parse" "@{upstream}")
     (magit-insert-section (unpushed)
       (magit-insert-heading "Unpushed commits:")
-      (magit-insert-log (concat tracked "..HEAD")
-                        magit-log-section-arguments))))
+      (magit-insert-log "@{upstream}.." magit-log-section-arguments))))
 
 ;;;; Auxiliary Log Sections
 
@@ -1306,11 +1304,10 @@ If an upstream is configured for the current branch and it is
 ahead of the current branch, then show the missing commits,
 otherwise show the last `magit-log-section-commit-count'
 commits."
-  (let ((tracked (magit-get-tracked-ref)))
-    (if (and tracked (not (equal (magit-rev-parse "HEAD")
-                                 (magit-rev-parse tracked))))
-        (magit-insert-unpulled-commits)
-      (magit-insert-recent-commits t))))
+  (if (equal (magit-rev-parse "HEAD")
+             (magit-rev-parse "@{upstream}"))
+      (magit-insert-recent-commits t)
+    (magit-insert-unpulled-commits)))
 
 (defun magit-insert-unpulled-cherries ()
   "Insert section showing unpulled commits.
@@ -1318,11 +1315,12 @@ Like `magit-insert-unpulled-commits' but prefix each commit
 which has not been applied yet (i.e. a commit with a patch-id
 not shared with any local commit) with \"+\", and all others
 with \"-\"."
-  (-when-let (tracked (magit-get-tracked-ref))
+  (when (magit-git-success "rev-parse" "@{upstream}")
     (magit-insert-section (unpulled)
       (magit-insert-heading "Unpulled commits:")
       (magit-git-wash (apply-partially 'magit-log-wash-log 'cherry)
-        "cherry" "-v" (magit-abbrev-arg) (magit-get-current-branch) tracked))))
+        "cherry" "-v" (magit-abbrev-arg)
+        (magit-get-current-branch) "@{upstream}"))))
 
 (defun magit-insert-unpushed-cherries ()
   "Insert section showing unpushed commits.
@@ -1330,11 +1328,11 @@ Like `magit-insert-unpushed-commits' but prefix each commit
 which has not been applied to upstream yet (i.e. a commit with
 a patch-id not shared with any upstream commit) with \"+\", and
 all others with \"-\"."
-  (-when-let (tracked (magit-get-tracked-ref))
+  (when (magit-git-success "rev-parse" "@{upstream}")
     (magit-insert-section (unpushed)
       (magit-insert-heading "Unpushed commits:")
       (magit-git-wash (apply-partially 'magit-log-wash-log 'cherry)
-        "cherry" "-v" (magit-abbrev-arg) tracked))))
+        "cherry" "-v" (magit-abbrev-arg) "@{upstream}"))))
 
 ;;;; Submodule Sections
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1260,7 +1260,8 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
     map)
   "Keymap for the `unpulled' section.")
 
-(magit-define-section-jumper unpulled "Unpulled commits")
+(magit-define-section-jumper magit-jump-to-unpulled
+  "Unpulled commits" unpulled)
 
 (defun magit-insert-unpulled-commits ()
   "Insert section showing unpulled commits."
@@ -1275,7 +1276,8 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
     map)
   "Keymap for the `unpushed' section.")
 
-(magit-define-section-jumper unpushed "Unpushed commits")
+(magit-define-section-jumper magit-jump-to-unpushed
+  "Unpushed commits" unpushed)
 
 (defun magit-insert-unpushed-commits ()
   "Insert section showing unpushed commits."

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1256,7 +1256,7 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
 
 (defvar magit-unpulled-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing] 'magit-diff-unpulled)
+    (define-key map [remap magit-visit-thing] 'magit-diff-dwim)
     map)
   "Keymap for `unpulled' sections.")
 
@@ -1289,7 +1289,7 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
 
 (defvar magit-unpushed-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing] 'magit-diff-unpushed)
+    (define-key map [remap magit-visit-thing] 'magit-diff-dwim)
     map)
   "Keymap for `unpushed' sections.")
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1265,7 +1265,7 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
 (defun magit-insert-unpulled-commits ()
   "Insert section showing unpulled commits."
   (when (magit-git-success "rev-parse" "@{upstream}")
-    (magit-insert-section (unpulled)
+    (magit-insert-section (unpulled "..@{upstream}")
       (magit-insert-heading "Unpulled commits:")
       (magit-insert-log "..@{upstream}" magit-log-section-arguments))))
 
@@ -1280,7 +1280,7 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
 (defun magit-insert-unpushed-commits ()
   "Insert section showing unpushed commits."
   (when (magit-git-success "rev-parse" "@{upstream}")
-    (magit-insert-section (unpushed)
+    (magit-insert-section (unpushed "@{upstream}..")
       (magit-insert-heading "Unpushed commits:")
       (magit-insert-log "@{upstream}.." magit-log-section-arguments))))
 
@@ -1289,14 +1289,14 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
 (defun magit-insert-recent-commits (&optional collapse)
   "Insert section showing recent commits.
 Show the last `magit-log-section-commit-count' commits."
-  (magit-insert-section (recent nil collapse)
-    (magit-insert-heading "Recent commits:")
-    (magit-insert-log
-     (let ((beg (format "HEAD~%s" magit-log-section-commit-count)))
-       (and (magit-rev-verify beg)
-            (concat beg "..HEAD")))
-     (cons (format "-%d" magit-log-section-commit-count)
-           magit-log-section-arguments))))
+  (let* ((start (format "HEAD~%s" magit-log-section-commit-count))
+         (range (and (magit-rev-verify start)
+                     (concat start "..HEAD"))))
+    (magit-insert-section (recent range collapse)
+      (magit-insert-heading "Recent commits:")
+      (magit-insert-log range
+                        (cons (format "-%d" magit-log-section-commit-count)
+                              magit-log-section-arguments)))))
 
 (defun magit-insert-unpulled-or-recent-commits ()
   "Insert section showing unpulled or recent commits.
@@ -1316,7 +1316,7 @@ which has not been applied yet (i.e. a commit with a patch-id
 not shared with any local commit) with \"+\", and all others
 with \"-\"."
   (when (magit-git-success "rev-parse" "@{upstream}")
-    (magit-insert-section (unpulled)
+    (magit-insert-section (unpulled "..@{upstream}")
       (magit-insert-heading "Unpulled commits:")
       (magit-git-wash (apply-partially 'magit-log-wash-log 'cherry)
         "cherry" "-v" (magit-abbrev-arg)
@@ -1329,7 +1329,7 @@ which has not been applied to upstream yet (i.e. a commit with
 a patch-id not shared with any upstream commit) with \"+\", and
 all others with \"-\"."
   (when (magit-git-success "rev-parse" "@{upstream}")
-    (magit-insert-section (unpushed)
+    (magit-insert-section (unpushed "@{upstream}..")
       (magit-insert-heading "Unpushed commits:")
       (magit-git-wash (apply-partially 'magit-log-wash-log 'cherry)
         "cherry" "-v" (magit-abbrev-arg) "@{upstream}"))))

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -888,8 +888,10 @@ and are defined in `magit-popup-mode-map' (which see)."
        (magit-popup-manpage man (magit-popup-lookup int :options)))
       (`magit-popup-help
        (magit-popup-manpage man nil))
-      (`self-insert-command
-       (setq def (magit-popup-lookup int :actions))
+      ((or `self-insert-command
+           `magit-invoke-popup-action)
+       (setq def (or (magit-popup-lookup int :actions)
+                     (magit-popup-lookup int :variables)))
        (if def
            (magit-popup-describe-function (magit-popup-event-fun def))
          (ding)

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -806,7 +806,7 @@ TYPE is one of `:action', `:sequence-action', `:switch', or
         (user-error "%c isn't bound to any action" event)))))
 
 (defun magit-popup-set-variable
-    (variable choices &optional default other global)
+    (variable choices &optional default other)
   (--if-let (--if-let (magit-git-string "config" "--local" variable)
                 (cadr (member it choices))
               (car choices))
@@ -814,8 +814,7 @@ TYPE is one of `:action', `:sequence-action', `:switch', or
     (magit-call-git "config" "--unset" variable))
   (magit-refresh)
   (message "%s %s" variable
-           (magit-popup-format-variable-1
-            variable choices default other global)))
+           (magit-popup-format-variable-1 variable choices default other)))
 
 (defun magit-popup-quit ()
   "Quit the current popup command without invoking an action."
@@ -1128,18 +1127,15 @@ of events shared by all popups and before point is adjusted.")
         'type type 'event (magit-popup-event-key ev)))
 
 (defun magit-popup-format-variable
-    (variable choices &optional default other global width)
+    (variable choices &optional default other width)
   (concat variable
           (if width (make-string (- width (length variable)) ?\s) " ")
-          (magit-popup-format-variable-1
-           variable choices default other global)))
+          (magit-popup-format-variable-1 variable choices default other)))
 
 (defun magit-popup-format-variable-1
-    (variable choices &optional default other global)
-  (let ((local (magit-git-string "config" "--local"  variable)))
-    (when global
-      (setq global (magit-git-string "config" "--global"
-                                     (if (stringp global) global variable))))
+    (variable choices &optional default other)
+  (let ((local  (magit-git-string "config" "--local"  variable))
+        (global (magit-git-string "config" "--global" variable)))
     (when other
       (--if-let (magit-git-string "config" other)
           (setq other (concat other ":" it))

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -384,7 +384,9 @@ repository are reverted if `magit-revert-buffers' is non-nil.
 
 See `magit-start-process' for more information."
   (message "Running %s %s" magit-git-executable
-           (mapconcat 'identity (-flatten args) " "))
+           (let ((m (mapconcat #'identity (-flatten args) " ")))
+             (remove-list-of-text-properties 0 (length m) '(face) m)
+             m))
   (magit-start-git nil args))
 
 (defun magit-run-git-async-no-revert (&rest args)

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -164,20 +164,17 @@ then read the remote."
 ;;;###autoload
 (defun magit-pull-current (source args)
   "Fetch and merge into current branch."
-  (interactive (magit-pull-read-args t))
+  (interactive (list (or (magit-get-tracked-branch)
+                         (magit-read-remote-branch "Pull" nil nil nil t))
+                     (magit-pull-arguments)))
   (magit-git-pull source args))
 
 ;;;###autoload
 (defun magit-pull (source args)
   "Fetch from another repository and merge a fetched branch."
-  (interactive (magit-pull-read-args))
+  (interactive (list (magit-read-remote-branch "Pull" nil nil nil t)
+                     (magit-pull-arguments)))
   (magit-git-pull source args))
-
-(defun magit-pull-read-args (&optional use-upstream)
-  (list (let ((source (magit-get-tracked-branch)))
-          (or (and use-upstream source)
-              (magit-read-remote-branch "Pull" nil source nil t)))
-        (magit-pull-arguments)))
 
 ;;; Push
 

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -216,10 +216,7 @@ If that variable is unset too, then raise an error."
 ;;;###autoload
 (defun magit-push-current (branch remote &optional remote-branch args)
   "Push the current branch to its upstream branch.
-If the upstream isn't set, then read the remote branch.
-
-If `magit-push-always-verify' is not nil, however, always read
-the remote branch."
+If the upstream isn't set, then read the remote branch."
   (interactive (magit-push-read-args t t))
   (magit-push branch remote remote-branch args))
 
@@ -233,10 +230,7 @@ Read the local and remote branch."
 ;;;###autoload
 (defun magit-push (branch remote &optional remote-branch args)
   "Push a branch to its upstream branch.
-If the upstream isn't set, then read the remote branch.
-
-If `magit-push-always-verify' is not nil, however, always read
-the remote branch."
+If the upstream isn't set, then read the remote branch."
   (interactive (magit-push-read-args t))
   (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert
@@ -244,60 +238,6 @@ the remote branch."
    (if remote-branch
        (format "%s:refs/heads/%s" branch remote-branch)
      branch)))
-
-(defcustom magit-push-always-verify 'nag
-  "Whether certain commands require verification before pushing.
-
-Starting with v2.1.0 some of the push commands are supposed to
-push to the configured upstream branch without requiring user
-confirmation or offering to push somewhere else.
-
-This has taken a few users by surprise, and they suggested that
-we force users to opt-in to this behavior.  Unfortunately adding
-this option means that now other users will complain about us
-needlessly forcing them to set an option.  But what can you do?
-\(I am not making this up.  This has happened in the past and it
-is very frustrating.)
-
-You should set the value of this option to nil, causing all push
-commands to behave as intended:
-
-`PP' Push the current branch to its upstream branch, no questions
-     asked.  If no upstream branch is configured or if that is
-     another local branch, then prompt for the remote and branch
-     to push to.
-
-`Po' Push another local branch (not the current branch) to its
-     upstream branch.  If no upstream branch is configured or if
-     that is another local branch, then prompt for the remote and
-     branch to push to.
-
-`Pe' Push any local branch to any remote branch.  This command
-     isn't affected by this option.  It always asks which branch
-     should be pushed (defaulting to the current branch) and then
-     where that should be pushed (defaulting to the upstream
-     branch of the previously selected branch).
-
-There are other push commands besides these.  You should read
-their doc-strings instead of blindly trying them out and then
-being surprised if it turns out that they do something different
-from what you expected.  For example inside the push popup type
-`?i' to learn what \"implicitly\" means here.  Or to learn about
-all push commands at once, consult the manual.
-
-While I have your attention, I would also like to warn you that
-pushing will be further improved in the v2.4.0 release, and that
-you might be surprised by some of these changes, unless you read
-the documentation.
-
-Setting this option to t makes little sense.  If you consider
-doing that, then you should probably just use `Pe' instead of
-`PP' or `Po'."
-  :package-version '(magit . "2.2.0")
-  :group 'magit-commands
-  :type '(choice (const :tag "require verification and mention this option" nag)
-                 (const :tag "require verification" t)
-                 (const :tag "don't require verification" nil)))
 
 (defun magit-push-read-args (&optional use-upstream use-current default-current)
   (let* ((current (magit-get-current-branch))
@@ -313,14 +253,9 @@ doing that, then you should probably just use `Pe' instead of
                     (user-error "Nothing selected")))
          (remote (and (magit-branch-p local)
                       (magit-get-remote-branch local))))
-    (unless (and use-upstream remote (not magit-push-always-verify))
-      (setq remote (magit-read-remote-branch
-                    (concat
-                     (format "Push %s to" local)
-                     (and use-upstream remote
-                          (eq magit-push-always-verify 'nag)
-                          " [also see option magit-push-always-verify]"))
-                    nil remote local 'confirm)))
+    (unless (and use-upstream remote)
+      (setq remote (magit-read-remote-branch (format "Push %s to" local)
+                                             nil remote local 'confirm)))
     (list local (car remote) (cdr remote) (magit-push-arguments))))
 
 ;;;###autoload

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -340,7 +340,8 @@ manpages."
   "Push all matching branches to another repository.
 If multiple remotes exit, then read one from the user.
 If just one exists, use that without requiring confirmation."
-  (interactive (list (magit-read-remote "Push matching branches to" nil t)))
+  (interactive (list (magit-read-remote "Push matching branches to" nil t)
+                     (magit-push-arguments)))
   (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert "push" "-v" args remote ":"))
 
@@ -360,7 +361,8 @@ branch as default."
   "Push a tag to another repository."
   (interactive
    (let  ((tag (magit-read-tag "Push tag")))
-     (list tag (magit-read-remote (format "Push %s to remote" tag) nil t))))
+     (list tag (magit-read-remote (format "Push %s to remote" tag) nil t)
+           (magit-push-arguments))))
   (run-hooks 'magit-credential-hook)
   (magit-run-git-async-no-revert "push" remote tag))
 

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -164,7 +164,9 @@ Then show the status buffer for the new repository."
   "Popup console for pull commands."
   'magit-commands
   :man-page "git-pull"
-  :switches '((?r "Rebase" "--rebase"))
+  :variables '((?r "branch.%s.rebase"
+                   magit-cycle-branch*rebase
+                   magit-pull-format-branch*rebase))
   :actions '((lambda ()
                (--if-let (magit-get-current-branch)
                    (concat
@@ -177,6 +179,12 @@ Then show the status buffer for the new repository."
              (?e "elsewhere"              magit-pull))
   :default-action 'magit-pull
   :max-action-columns 1)
+
+(defun magit-pull-format-branch*rebase ()
+  (magit-popup-format-variable (format "branch.%s.rebase"
+                                       (or (magit-get-current-branch) "<name>"))
+                               '("true" "false")
+                               "false" "pull.rebase"))
 
 (defun magit-git-pull (source args)
   (run-hooks 'magit-credential-hook)

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -191,10 +191,9 @@ then read the remote."
               (?Q "Quickly"    magit-push-quickly)
               (?t "Tags"       magit-push-tags)
               (?o "Other"      magit-push)
-              (?i "Implicitly" magit-push-implicitly)
+              (?m "Matching"   magit-push-matching)
               (?T "Tag"        magit-push-tag)
-              (?e "Elsewhere"  magit-push-elsewhere)
-              (?m "Matching"   magit-push-matching))
+              (?e "Elsewhere"  magit-push-elsewhere))
   :default-action 'magit-push-current
   :max-action-columns 3)
 
@@ -324,16 +323,6 @@ branch with the same name."
           (magit-run-git-async-no-revert "push" "-v" args remote branch)
         (user-error "Cannot determine remote to push to"))
     (user-error "No branch is checked out")))
-
-;;;###autoload
-(defun magit-push-implicitly (&optional args)
-  "Push without explicitly specifing what to push.
-This runs `git push -v'.  What is being pushed depends on various
-Git variables as described in the `git-push(1)' and `git-config(1)'
-manpages."
-  (interactive (list (magit-push-arguments)))
-  (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "push" "-v" args))
 
 ;;;###autoload
 (defun magit-push-matching (remote &optional args)

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -237,11 +237,17 @@ Read the local and remote branch."
   (magit-git-push branch target args))
 
 ;;;###autoload
-(defun magit-push (branch target args)
-  "Push a branch to its upstream branch.
-If the upstream isn't set, then read the remote branch."
-  (interactive (magit-push-read-args t))
-  (magit-git-push branch target args))
+(defun magit-push (source target args)
+  "Push an arbitrary branch or commit somewhere.
+Both the source and the target are read in the minibuffer."
+  (interactive
+   (let ((source (magit-read-local-branch-or-commit "Push")))
+     (list source
+           (magit-read-remote-branch (format "Push %s to" source) nil
+                                     (magit-get-tracked-branch source)
+                                     source 'confirm)
+           (magit-push-arguments))))
+  (magit-git-push source target args))
 
 (defun magit-push-read-args (&optional use-upstream use-current default-current)
   (let* ((current (magit-get-current-branch))

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -231,10 +231,17 @@ If the upstream isn't set, then read the remote branch."
 
 ;;;###autoload
 (defun magit-push-elsewhere (branch target args)
-  "Push a branch or commit to some remote branch.
-Read the local and remote branch."
-  (interactive (magit-push-read-args nil nil t))
-  (magit-git-push branch target args))
+  "Push the current branch to a branch read in the minibuffer."
+  (interactive
+   (-if-let (branch (magit-get-current-branch))
+       (list branch
+             (magit-read-remote-branch (format "Push %s to" branch)
+                                       nil nil branch 'confirm)
+             (magit-push-arguments))
+     (list nil nil nil)))
+  (if (and branch target)
+      (magit-git-push branch target args)
+    (call-interactively 'magit-push)))
 
 ;;;###autoload
 (defun magit-push (source target args)

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -268,23 +268,23 @@ It the SECTION has a different type, then do nothing."
   (when (eq (magit-section-type section) 'hunk)
     (magit-section-set-window-start section)))
 
-(defmacro magit-define-section-jumper (sym title &optional value)
-  "Define an interactive function to go to section SYM.
-TITLE is the displayed title of the section."
-  (let ((fun (intern (format "magit-jump-to-%s" sym))))
-    `(progn
-       (defun ,fun (&optional expand) ,(format "\
-Jump to section '%s'.
-With a prefix argument also expand it." title)
-         (interactive "P")
-         (--if-let (magit-get-section
-                    (cons '(,sym . ,value) (magit-section-ident magit-root-section)))
-             (progn (goto-char (magit-section-start it))
-                    (when expand
-                      (with-local-quit (magit-section-show it))
-                      (recenter 0)))
-           (message ,(format "Section '%s' wasn't found" title))))
-       (put ',fun 'definition-name ',sym))))
+(defmacro magit-define-section-jumper (name heading type &optional value)
+  "Define an interactive function to go some section.
+Together TYPE and VALUE identify the section.
+HEADING is the displayed heading of the section."
+  (declare (indent defun))
+  `(defun ,name (&optional expand) ,(format "\
+Jump to the section \"%s\".
+With a prefix argument also expand it." heading)
+     (interactive "P")
+     (--if-let (magit-get-section
+                (cons (cons ',type ,value)
+                      (magit-section-ident magit-root-section)))
+         (progn (goto-char (magit-section-start it))
+                (when expand
+                  (with-local-quit (magit-section-show it))
+                  (recenter 0)))
+       (message ,(format "Section \"%s\" wasn't found" heading)))))
 
 ;;;; Visibility
 

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -312,8 +312,11 @@ This discards all changes made since the sequence started."
   :sequence-predicate 'magit-rebase-in-progress-p
   :max-action-columns 2)
 
+(defun magit-git-rebase (target args)
+  (magit-run-git-sequencer "rebase" target args))
+
 ;;;###autoload
-(defun magit-rebase (upstream &optional args)
+(defun magit-rebase (upstream args)
   "Start a non-interactive rebase sequence.
 All commits not in UPSTREAM are rebased."
   (interactive (list (magit-read-other-branch-or-commit
@@ -322,11 +325,11 @@ All commits not in UPSTREAM are rebased."
                       (magit-get-tracked-branch))
                      (magit-rebase-arguments)))
   (message "Rebasing...")
-  (magit-run-git-sequencer "rebase" upstream args)
+  (magit-git-rebase upstream args)
   (message "Rebasing...done"))
 
 ;;;###autoload
-(defun magit-rebase-subset (newbase start &optional args)
+(defun magit-rebase-subset (newbase start args)
   "Start a non-interactive rebase sequence.
 Rebase commits from START to `HEAD' onto NEWBASE.
 START has to be selected from a list of recent commits."
@@ -376,7 +379,7 @@ START has to be selected from a list of recent commits."
       message)))
 
 ;;;###autoload
-(defun magit-rebase-interactive (commit &optional args)
+(defun magit-rebase-interactive (commit args)
   "Start an interactive rebase sequence."
   (interactive (list (magit-commit-at-point)
                      (magit-rebase-arguments)))
@@ -384,14 +387,14 @@ START has to be selected from a list of recent commits."
     "Type %p on a commit to rebase it and all commits above it,"))
 
 ;;;###autoload
-(defun magit-rebase-unpushed (&optional args)
+(defun magit-rebase-unpushed (args)
   "Start an interactive rebase sequence of all unpushed commits."
   (interactive (list (magit-rebase-arguments)))
   (magit-rebase-interactive-1 :merge-base args
     "Type %p on a commit to rebase it and all commits above it,"))
 
 ;;;###autoload
-(defun magit-rebase-autosquash (&optional args)
+(defun magit-rebase-autosquash (args)
   "Combine squash and fixup commits with their intended targets."
   (interactive (list (magit-rebase-arguments)))
   (magit-rebase-interactive-1 :merge-base (cons "--autosquash" args)
@@ -399,7 +402,7 @@ START has to be selected from a list of recent commits."
     "true"))
 
 ;;;###autoload
-(defun magit-rebase-edit-commit (commit &optional args)
+(defun magit-rebase-edit-commit (commit args)
   "Edit a single older commit using rebase."
   (interactive (list (magit-commit-at-point)
                      (magit-rebase-arguments)))
@@ -408,7 +411,7 @@ START has to be selected from a list of recent commits."
     "perl -i -p -e '++$x if not $x and s/^pick/edit/'"))
 
 ;;;###autoload
-(defun magit-rebase-reword-commit (commit &optional args)
+(defun magit-rebase-reword-commit (commit args)
   "Reword a single older commit using rebase."
   (interactive (list (magit-commit-at-point)
                      (magit-rebase-arguments)))

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -291,20 +291,26 @@ This discards all changes made since the sequence started."
   "Key menu for rebasing."
   'magit-commands
   :man-page "git-rebase"
-  :switches '((?k "Keep empty commits" "--keep-empty")
-              (?p "Preserve merges" "--preserve-merges")
+  :switches '((?k "Keep empty commits"    "--keep-empty")
+              (?p "Preserve merges"       "--preserve-merges")
               (?c "Lie about author date" "--committer-date-is-author-date")
-              (?a "Autosquash" "--autosquash")
-              (?A "Autostash" "--autostash")
-              (?i "Interactive" "--interactive"))
-  :actions  '((?r "Rebase"             magit-rebase)
-              (?f "Autosquash"         magit-rebase-autosquash)
-              (?o "Rebase subset"      magit-rebase-subset)
-              nil
-              (?i "Rebase interactive" magit-rebase-interactive)
-              (?e "Edit commit"        magit-rebase-edit-commit)
-              (?l "Rebase unpushed"    magit-rebase-unpushed)
-              (?w "Reword commit"      magit-rebase-reword-commit))
+              (?a "Autosquash"            "--autosquash")
+              (?A "Autostash"             "--autostash")
+              (?i "Interactive"           "--interactive"))
+  :actions  '((lambda ()
+                (concat (propertize "Rebase " 'face 'magit-popup-heading)
+                        (propertize (or (magit-get-current-branch) "HEAD")
+                                    'face 'magit-branch-local)
+                        (propertize " onto" 'face 'magit-popup-heading)))
+              (?p magit-get-push-branch    magit-rebase-onto-pushremote)
+              (?u magit-get-tracked-branch magit-rebase-onto-upstream)
+              (?e "elsewhere"              magit-rebase)
+              "Rebase"
+              (?i "interactively"      magit-rebase-interactive)
+              (?m "to edit a commit"   magit-rebase-edit-commit)
+              (?s "subset"             magit-rebase-subset)
+              (?w "to reword a commit" magit-rebase-reword-commit) nil
+              (?f "to autosquash"      magit-rebase-autosquash))
   :sequence-actions '((?r "Continue" magit-rebase-continue)
                       (?s "Skip"     magit-rebase-skip)
                       (?e "Edit"     magit-rebase-edit)
@@ -316,21 +322,44 @@ This discards all changes made since the sequence started."
   (magit-run-git-sequencer "rebase" target args))
 
 ;;;###autoload
-(defun magit-rebase (upstream args)
-  "Start a non-interactive rebase sequence.
-All commits not in UPSTREAM are rebased."
+(defun magit-rebase-onto-pushremote (args)
+  "Rebase the current branch onto `branch.<name>.pushRemote'.
+If that variable is unset, then rebase onto `remote.pushDefault'."
+  (interactive (list (magit-rebase-arguments)))
+  (--if-let (magit-get-current-branch)
+      (-if-let (remote (magit-get-push-remote it))
+          (if (member remote (magit-list-remotes))
+              (magit-git-rebase (concat remote "/" it) args)
+            (user-error "Remote `%s' doesn't exist" remote))
+        (user-error "No push-remote is configured for %s" it))
+    (user-error "No branch is checked out")))
+
+;;;###autoload
+(defun magit-rebase-onto-upstream (args)
+  "Rebase the current branch onto its upstream branch."
+  (interactive (list (magit-rebase-arguments)))
+  (--if-let (magit-get-current-branch)
+      (-if-let (target (magit-get-tracked-branch it))
+          (magit-git-rebase target args)
+        (user-error "No upstream is configured for %s" it))
+    (user-error "No branch is checked out")))
+
+;;;###autoload
+(defun magit-rebase (target args)
+  "Rebase the current branch onto a branch read in the minibuffer.
+All commits that are reachable from head but not from the
+selected branch TARGET are being rebased."
   (interactive (list (magit-read-other-branch-or-commit
                       "Rebase onto"
-                      (magit-get-current-branch)
-                      (magit-get-tracked-branch))
+                      (magit-get-current-branch))
                      (magit-rebase-arguments)))
   (message "Rebasing...")
-  (magit-git-rebase upstream args)
+  (magit-git-rebase target args)
   (message "Rebasing...done"))
 
 ;;;###autoload
 (defun magit-rebase-subset (newbase start args)
-  "Start a non-interactive rebase sequence.
+  "Rebase a subset of the current branches history onto a new base.
 Rebase commits from START to `HEAD' onto NEWBASE.
 START has to be selected from a list of recent commits."
   (interactive (list (magit-read-other-branch-or-commit
@@ -387,18 +416,11 @@ START has to be selected from a list of recent commits."
     "Type %p on a commit to rebase it and all commits above it,"))
 
 ;;;###autoload
-(defun magit-rebase-unpushed (args)
-  "Start an interactive rebase sequence of all unpushed commits."
-  (interactive (list (magit-rebase-arguments)))
-  (magit-rebase-interactive-1 :merge-base args
-    "Type %p on a commit to rebase it and all commits above it,"))
-
-;;;###autoload
 (defun magit-rebase-autosquash (args)
   "Combine squash and fixup commits with their intended targets."
   (interactive (list (magit-rebase-arguments)))
   (magit-rebase-interactive-1 :merge-base (cons "--autosquash" args)
-    "Type %p on a commit to squash into it and the commits above it,"
+    "Type %p on a commit to squash into it and then rebase as necessary,"
     "true"))
 
 ;;;###autoload

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -292,7 +292,8 @@ When the region is active offer to drop all contained stashes."
     map)
   "Keymap for `stash' sections.")
 
-(magit-define-section-jumper stashes "Stashes" "refs/stash")
+(magit-define-section-jumper magit-jump-to-stashes
+  "Stashes" stashes "refs/stash")
 
 (cl-defun magit-insert-stashes (&optional (ref   "refs/stash")
                                           (heading "Stashes:"))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -521,7 +521,7 @@ the status buffer causes this section to disappear again."
       (insert (mapconcat #'identity magit-diff-section-file-args " "))
       (insert ?\n))))
 
-(magit-define-section-jumper untracked "Untracked files")
+(magit-define-section-jumper magit-jump-to-untracked "Untracked files" untracked)
 
 (defvar magit-untracked-section-map
   (let ((map (make-sparse-keymap)))
@@ -567,7 +567,7 @@ Do so depending on the value of `status.showUntrackedFiles'."
 
 ;;;;; Auxiliary Status Sections
 
-(magit-define-section-jumper tracked "Tracked files")
+(magit-define-section-jumper magit-jump-to-tracked "Tracked files" tracked)
 
 (defun magit-insert-tracked-files ()
   "Insert a tree of tracked files."

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1375,6 +1375,19 @@ defaulting to the branch at point."
 (put 'magit-branch-delete 'interactive-only t)
 
 ;;;###autoload
+(defun magit-branch-rename (old new &optional force)
+  "Rename branch OLD to NEW.
+With prefix, forces the rename even if NEW already exists.
+\n(git branch -m|-M OLD NEW)."
+  (interactive
+   (let ((branch (magit-read-local-branch "Rename branch")))
+     (list branch
+           (magit-read-string-ns (format "Rename branch '%s' to" branch))
+           current-prefix-arg)))
+  (unless (string= old new)
+    (magit-run-git-no-revert "branch" (if force "-M" "-m") old new)))
+
+;;;###autoload
 (defun magit-branch-set-upstream (branch upstream)
   "Change the UPSTREAM branch of BRANCH."
   (interactive
@@ -1391,19 +1404,6 @@ defaulting to the branch at point."
   "Unset the upstream branch of BRANCH."
   (interactive (list (magit-read-local-branch "Unset upstream of branch")))
   (magit-run-git-no-revert "branch" "--unset-upstream" branch))
-
-;;;###autoload
-(defun magit-branch-rename (old new &optional force)
-  "Rename branch OLD to NEW.
-With prefix, forces the rename even if NEW already exists.
-\n(git branch -m|-M OLD NEW)."
-  (interactive
-   (let ((branch (magit-read-local-branch "Rename branch")))
-     (list branch
-           (magit-read-string-ns (format "Rename branch '%s' to" branch))
-           current-prefix-arg)))
-  (unless (string= old new)
-    (magit-run-git-no-revert "branch" (if force "-M" "-m") old new)))
 
 ;;;###autoload
 (defun magit-branch-edit-description (branch)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -734,6 +734,20 @@ Refs are compared with a branch read form the user."
   (magit-insert-section (branchbuf)
     (run-hooks 'magit-refs-sections-hook)))
 
+(defun magit-insert-branch-description ()
+  "Insert header containing the description of the current branch.
+Insert a header line with the name and description of the
+current branch.  The description is taken from the Git variable
+`branch.<NAME>.description'; if that is undefined then no header
+line is inserted at all."
+  (let ((branch (magit-get-current-branch)))
+    (--when-let (magit-git-lines
+                 "config" (format "branch.%s.description" branch))
+      (magit-insert-section (branchdesc branch t)
+        (magit-insert-heading branch ": " (car it))
+        (insert (mapconcat 'identity (cdr it) "\n"))
+        (insert "\n\n")))))
+
 (defconst magit-refs-branch-line-re
   (concat "^"
           "\\(?:[ \\*]\\) "
@@ -1388,6 +1402,12 @@ With prefix, forces the rename even if NEW already exists.
     (magit-run-git-no-revert "branch" (if force "-M" "-m") old new)))
 
 ;;;###autoload
+(defun magit-branch-edit-description (branch)
+  "Edit the description of BRANCH."
+  (interactive (list (magit-read-local-branch "Edit branch description")))
+  (magit-run-git-with-editor "branch" "--edit-description"))
+
+;;;###autoload
 (defun magit-branch-set-upstream (branch upstream)
   "Change the UPSTREAM branch of BRANCH."
   (interactive
@@ -1404,26 +1424,6 @@ With prefix, forces the rename even if NEW already exists.
   "Unset the upstream branch of BRANCH."
   (interactive (list (magit-read-local-branch "Unset upstream of branch")))
   (magit-run-git-no-revert "branch" "--unset-upstream" branch))
-
-;;;###autoload
-(defun magit-branch-edit-description (branch)
-  "Edit the description of BRANCH."
-  (interactive (list (magit-read-local-branch "Edit branch description")))
-  (magit-run-git-with-editor "branch" "--edit-description"))
-
-(defun magit-insert-branch-description ()
-  "Insert header containing the description of the current branch.
-Insert a header line with the name and description of the
-current branch.  The description is taken from the Git variable
-`branch.<NAME>.description'; if that is undefined then no header
-line is inserted at all."
-  (let ((branch (magit-get-current-branch)))
-    (--when-let (magit-git-lines
-                 "config" (format "branch.%s.description" branch))
-      (magit-insert-section (branchdesc branch t)
-        (magit-insert-heading branch ": " (car it))
-        (insert (mapconcat 'identity (cdr it) "\n"))
-        (insert "\n\n")))))
 
 ;;;; Merge
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1220,9 +1220,9 @@ Non-interactively DIRECTORY is (re-)initialized unconditionally."
                (?P "branch.autoSetupPush"
                    magit-cycle-branch*autoSetupPush
                    magit-format-branch*autoSetupPush))
-  :actions '((?B "Create and checkout" magit-branch-and-checkout)
+  :actions '((?c "Create and checkout" magit-branch-and-checkout)
              (?b "Checkout"            magit-checkout)
-             (?c "Create"              magit-branch)
+             (?n "Create"              magit-branch)
              (?m "Rename"              magit-branch-rename)
              (?s "Create spin-off"     magit-branch-spinoff)
              (?x "Reset"               magit-branch-reset) nil

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1451,12 +1451,26 @@ With prefix, forces the rename even if NEW already exists.
 ;;;###autoload
 (defun magit-edit-branch*description (branch)
   "Edit the description of the current branch.
-With a prefix argument edit the description of another branch."
+With a prefix argument edit the description of another branch.
+
+The description for the branch named NAME is stored in the Git
+variable `branch.<name>.description'."
   (interactive
    (list (or (and (not current-prefix-arg)
                   (magit-get-current-branch))
              (magit-read-local-branch "Edit branch description"))))
   (magit-run-git-with-editor "branch" "--edit-description"))
+
+(defun magit-edit-branch*description-check-buffers ()
+  (and buffer-file-name
+       (string-match-p "/BRANCH_DESCRIPTION\\'" buffer-file-name)
+       (add-hook 'with-editor-post-finish-hook
+                 (lambda ()
+                   (when (derived-mode-p 'magit-popup-mode)
+                     (magit-refresh-popup-buffer)))
+                 nil t)))
+
+(add-hook 'find-file-hook 'magit-edit-branch*description-check-buffers)
 
 (defun magit-format-branch*description ()
   (let* ((branch (or (magit-get-current-branch) "<name>"))

--- a/t/magit-tests.el
+++ b/t/magit-tests.el
@@ -213,11 +213,11 @@
 
 ;;; Status
 
-(defun magit-test-get-section (type info)
+(defun magit-test-get-section (list file)
   (magit-status-internal default-directory)
-  (--first (equal (magit-section-value it) info)
+  (--first (equal (magit-section-value it) file)
            (magit-section-children
-            (magit-get-section `((,type) (status))))))
+            (magit-get-section `(,list (status))))))
 
 (ert-deftest magit-status:file-sections ()
   (magit-with-test-repository
@@ -226,20 +226,20 @@
       (modify "file")
       (modify "file with space")
       (modify "file with äöüéλ")
-      (should (magit-test-get-section 'untracked "file"))
-      (should (magit-test-get-section 'untracked "file with space"))
-      (should (magit-test-get-section 'untracked "file with äöüéλ"))
+      (should (magit-test-get-section '(untracked) "file"))
+      (should (magit-test-get-section '(untracked) "file with space"))
+      (should (magit-test-get-section '(untracked) "file with äöüéλ"))
       (magit-stage-modified t)
-      (should (magit-test-get-section 'staged "file"))
-      (should (magit-test-get-section 'staged "file with space"))
-      (should (magit-test-get-section 'staged "file with äöüéλ"))
+      (should (magit-test-get-section '(staged) "file"))
+      (should (magit-test-get-section '(staged) "file with space"))
+      (should (magit-test-get-section '(staged) "file with äöüéλ"))
       (magit-git "add" ".")
       (modify "file")
       (modify "file with space")
       (modify "file with äöüéλ")
-      (should (magit-test-get-section 'unstaged "file"))
-      (should (magit-test-get-section 'unstaged "file with space"))
-      (should (magit-test-get-section 'unstaged "file with äöüéλ")))))
+      (should (magit-test-get-section '(unstaged) "file"))
+      (should (magit-test-get-section '(unstaged) "file with space"))
+      (should (magit-test-get-section '(unstaged) "file with äöüéλ")))))
 
 (ert-deftest magit-status:log-sections ()
   (magit-with-test-repository
@@ -250,10 +250,12 @@
     (magit-git "branch" "--set-upstream-to=origin/master")
     (magit-git "reset" "--hard" "HEAD~")
     (magit-git "commit" "-m" "unpushed" "--allow-empty")
-    (should (magit-test-get-section 'unpulled
-                                    (magit-rev-parse "--short" "origin/master")))
-    (should (magit-test-get-section 'unpushed
-                                    (magit-rev-parse "--short" "master")))))
+    (should (magit-test-get-section
+             '(unpulled . "..@{upstream}")
+             (magit-rev-parse "--short" "origin/master")))
+    (should (magit-test-get-section
+             '(unpushed . "@{upstream}..")
+             (magit-rev-parse "--short" "master")))))
 
 ;;; magit-tests.el ends soon
 (provide 'magit-tests)


### PR DESCRIPTION
Fully support the push-remote in addition to the upstream. They are both used to specify another branch related to the current branch, but serve different purposes. The push-remote is where the local branch is usually pushed to, while the upstream is where we want the changes to *eventually* end up.

The push-remote is configured using the variable `branch.<name>.pushRemote` or `remote.pushDefault`. The upstream is configured using `branch.<name>.remote` and `branch.<name>.merge`.

To some extend that was already supported previously - `Q` from the push popup pushed to the push remote, but for some odd reason it used `magit.pushRemote` instead of the two variables mentioned above. But the changes here go way beyond just using the correct variable.

The fetching, pulling, and pushing popups now all feature three actions to push to the current branch to the push-remote, the upstream, and somewhere else. The branching popup shows all relevant variables and allows changing them easily. In the status buffer unpushed and unpulled changes are shown for both the upstream and the push-remote.

----

Please give it a spin and let me know what you think. Start by reading the documentation in the `Branching` info node. You then might want to set `--dry-run` in the push popup (`p - d C-c C-c`).

----

#### Issues

* [ ] I haven't gotten much feedback yet.
* [x] The echo area message contains propertized text.
* [ ] "Same key bindings" (`FF`, `ff`, `PP`) are lost, which is a feature (it makes accidents less likely), but also might upset muscle memory. Some other bindings (for create and/or checkout commands) are changed "needlessly" (because this is a good time to do it).
* [ ] Documentation has to be improved.