### PR TITLE
Include all info files in the elpa package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ magit-popup-$(VERSION).tar: info
 
 ELPA_ROOT_FILES = COPYING
 ELPA_LISP_FILES = $(addprefix lisp/,$(ELMS) magit-version.el)
-ELPA_DOCS_FILES = $(addprefix Documentation/,AUTHORS.md dir magit.info)
+ELPA_DOCS_FILES = $(addprefix Documentation/,AUTHORS.md dir magit.info*)
 
 define magit_pkg
 (define-package "magit" "$(VERSION)"


### PR DESCRIPTION
In debian, we now use `make elpa` to generate elpa package we use to create the debian package.

The magit elpa package generated by `make elpa` does only contain `magit.info` but not `magit.info-1` and `magit.info-2`. This patch fix this problem.