### PR TITLE
Add :require property to `auth-source-search' call

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -681,7 +681,8 @@ tracked in the current repository are reverted if
   "Use `auth-source-search' to get a password.
 If found, return the password.  Otherwise, return nil."
   (require 'auth-source)
-  (let ((secret (plist-get (car (auth-source-search :max 1 :host key))
+  (let ((secret (plist-get (car (auth-source-search :max 1 :host key
+                                                    :require '(:host)))
                            :secret)))
     (if (functionp secret)
         (funcall secret)


### PR DESCRIPTION
If :host is not required, the first item not having the :host property
or matching it is selected. This is not a problem for netrc files where
all entries have a :host (or :machine) property. Other backends like
secrets do not.