### PR TITLE
Automatically add cloned repos to projectile

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -4590,7 +4590,7 @@ are a start.
 
 *** Convenience
 To automatically add projects to projectile after a ~magit-clone~,
-set ~magit-add-project-to-projectile-after-clone~ to ~t~.
+set ~magit-add-project-to-projectile-after-clone~.
 * Plumbing
 
 The following sections describe how to use several of Magit's core

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -4588,6 +4588,9 @@ necessary open a new issue.  Note that "something is slow, I am using
 v2.2" is not helpful, you have to be a bit more specific.  Benchmarks
 are a start.
 
+*** Convenience
+To automatically add projects to projectile after a ~magit-clone~,
+set ~magit-add-project-to-projectile-after-clone~ to ~t~.
 * Plumbing
 
 The following sections describe how to use several of Magit's core

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -31,7 +31,12 @@
 
 (require 'magit)
 
-(defvar magit-add-project-to-projectile-after-clone)
+(defcustom magit-add-project-to-projectile-after-clone nil
+  "when non-nil, automatically adds magit-cloned repos
+to projectile's known project list"
+  :group 'magit-clone
+  :options '(nil t)
+  :type 'boolean)
 
 ;;; Clone
 

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -52,7 +52,7 @@ Then show the status buffer for the new repository."
                            (magit-convert-git-filename directory))
            0)
     ;; Automatically add project to projectile
-    (when (eq (magit-add-project-to-projectile-after-clone) t)
+    (when magit-add-project-to-projectile-after-clone
       (if (eq (fboundp 'projectile-add-known-project) t)
           (projectile-add-known-project directory)
         (message "projectile-add-known-project is not defined")))

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -31,6 +31,8 @@
 
 (require 'magit)
 
+(defvar magit-add-project-to-projectile-after-clone)
+
 ;;; Clone
 
 ;;;###autoload
@@ -49,6 +51,11 @@ Then show the status buffer for the new repository."
                            ;; Stop cygwin git making a "c:" directory.
                            (magit-convert-git-filename directory))
            0)
+    ;; Automatically add project to projectile
+    (when (eq (magit-add-project-to-projectile-after-clone) t)
+      (if (eq (fboundp 'projectile-add-known-project) t)
+          (projectile-add-known-project directory)
+        (message "projectile-add-known-project is not defined")))
     (message "Cloning %s...done" repository)
     (magit-status-internal directory)))
 


### PR DESCRIPTION
When cloning a repo, it would be nice if it showed up automatically in my projectile-known-projects list.

This PR adds that feature.  To turn it on, set `magit-add-project-to-projectile-after-clone` to `t`.  I also added a bit of documentation for that setting but was not sure where it should go, let me know if there is a better spot.  I wasn't sure whether `defvar` or `defcustom` was more appropriate, let me know if you want me to change that as well.