### PR TITLE
Fix typos in documentation

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1522,7 +1522,7 @@ By default the following functions are members of the above hook:
 - Function: magit-insert-error-header
 
   Insert a header line showing the message about the Git error that
-  just occured.
+  just occurred.
 
   This function is only aware of the last error that occur when Git
   was run for side-effects.  If, for example, an error occurs while
@@ -3081,7 +3081,7 @@ automatically set at this time.
 
   This variable should either be undefined, or it should be the name
   of an existing branch, in which case ~branch.NAME.pushRemote~ is set
-  to the same value.  Any other value, i.e. a non-existend remote, is
+  to the same value.  Any other value, i.e. a non-existent remote, is
   ignored.
 
   This variable is only used by Magit, Git knows nothing about it.
@@ -5337,7 +5337,7 @@ In v2.1 the default behavior of the branch and push commands changed,
 which has taken a few users by surprise and left more unsatisfied.
 The next release, v2.4, will try to address these concerns.
 
-** I cannot install the pre-requisits for Magit v2
+** I cannot install the pre-requisites for Magit v2
 
 An Elpa archive featuring obsolete Magit v1.4.2 and its dependencies
 is available from http://magit.vc/elpa/v1.  But note that v1.4.2 is

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -238,7 +238,7 @@ FAQ
 * I changed several thousand files at once and now Magit is unusable::
 * I am having problems committing::
 * I don't like how branching and pushing works::
-* I cannot install the pre-requisits for Magit v2::
+* I cannot install the pre-requisites for Magit v2::
 * I am using an Emacs release older than v24.4: I am using an Emacs release older than v244. 
 * I am using a Git release older than v1.9.4: I am using a Git release older than v194. 
 * I am using MS Windows and cannot push with Magit::
@@ -2053,7 +2053,7 @@ By default the following functions are members of the above hook:
 @defun magit-insert-error-header
 
 Insert a header line showing the message about the Git error that
-just occured.
+just occurred.
 
 This function is only aware of the last error that occur when Git
 was run for side-effects.  If, for example, an error occurs while
@@ -4208,7 +4208,7 @@ in the variable @code{branch.NAME.pushRemote} being set to what value.
 
 This variable should either be undefined, or it should be the name
 of an existing branch, in which case @code{branch.NAME.pushRemote} is set
-to the same value.  Any other value, i.e. a non-existend remote, is
+to the same value.  Any other value, i.e. a non-existent remote, is
 ignored.
 
 This variable is only used by Magit, Git knows nothing about it.
@@ -7275,7 +7275,7 @@ made it into the manual yet, see @uref{https://github.com/magit/magit/wiki/FAQ}.
 * I changed several thousand files at once and now Magit is unusable::
 * I am having problems committing::
 * I don't like how branching and pushing works::
-* I cannot install the pre-requisits for Magit v2::
+* I cannot install the pre-requisites for Magit v2::
 * I am using an Emacs release older than v24.4: I am using an Emacs release older than v244. 
 * I am using a Git release older than v1.9.4: I am using a Git release older than v194. 
 * I am using MS Windows and cannot push with Magit::
@@ -7318,8 +7318,8 @@ In v2.1 the default behavior of the branch and push commands changed,
 which has taken a few users by surprise and left more unsatisfied.
 The next release, v2.4, will try to address these concerns.
 
-@node I cannot install the pre-requisits for Magit v2
-@section I cannot install the pre-requisits for Magit v2
+@node I cannot install the pre-requisites for Magit v2
+@section I cannot install the pre-requisites for Magit v2
 
 An Elpa archive featuring obsolete Magit v1.4.2 and its dependencies
 is available from @uref{http://magit.vc/elpa/v1}.  But note that v1.4.2 is

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -725,7 +725,7 @@ a commit read from the minibuffer."
   "While committing, show the changes that are about to be committed.
 While amending, invoking the command again toggles between
 showing just the new changes or all the changes that will
-be commited."
+be committed."
   (interactive (magit-diff-arguments))
   (let ((toplevel (magit-toplevel))
         (diff-buf (magit-mode-get-buffer 'magit-diff-mode)))

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -307,7 +307,7 @@ It should be clear by now that we consider it a mistake to set
 this to display the region when the Magit selection is also
 visualized, but since it has been requested a few times and
 because it doesn't cost much to offer this option we do so.
-However that might change.  If the existance of this option
+However that might change.  If the existence of this option
 starts complicating other things, then it will be removed."
   :package-version '(magit . "2.3.0")
   :group 'magit-modes

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -424,7 +424,7 @@ when the command is invoked directly, then it returns the default
 value of the variable `SHORTNAME-arguments'.
 
 Optional argument GROUP specifies the Custom group in which the
-option is placed.  If ommitted then the option is placed in some
+option is placed.  If omitted then the option is placed in some
 group the same way it is done when directly using `defcustom'.
 
 Optional argument MODE is deprecated, instead use the keyword
@@ -483,7 +483,7 @@ usually specified in that order):
 `:switches'
   The popup arguments which can be toggled on and off.  VALUE
   is a list whose members have the form (KEY DESC SWITCH), see
-  `magit-define-popup-switch' for defails.
+  `magit-define-popup-switch' for details.
 
 `:options'
   The popup arguments which take a value, as in \"--opt=OPTVAL\".

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -43,7 +43,7 @@
   :group 'magit)
 
 (defcustom magit-section-show-child-count t
-  "Whether to append the number of childen to section headings."
+  "Whether to append the number of children to section headings."
   :package-version '(magit . "2.1.0")
   :group 'magit-section
   :type 'boolean)
@@ -594,7 +594,7 @@ section at point.  If no clause succeeds or if there is no
 section at point return nil.
 
 See `magit-section-match' for the forms CONDITION can take.
-Additionall a CONDITION of t is allowed in the final clause, and
+Additionally a CONDITION of t is allowed in the final clause, and
 matches if no other CONDITION match, even if there is no section
 at point."
   (declare (indent 0)
@@ -733,7 +733,7 @@ inside any of these strings, then insert all of them unchanged.
 Otherwise use the `magit-section-heading' face for all inserted
 text.
 
-The `content' property of the secton struct is the end of the
+The `content' property of the section struct is the end of the
 heading (which lasts from `start' to `content') and the beginning
 of the the body (which lasts from `content' to `end').  If the
 value of `content' is nil, then the section has no heading and

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -158,7 +158,7 @@ Global settings:
                       (const safe-with-wip))))
 
 (defcustom magit-ellipsis ?…
-  "Character used to abreviate text."
+  "Character used to abbreviate text."
   :package-version '(magit . "2.1.0")
   :group 'magit-modes
   :type 'character)
@@ -360,7 +360,7 @@ This is similar to `read-string', but
 ;;; Text Utilities
 
 (defmacro magit-bind-match-strings (varlist string &rest body)
-  "Bind varibles to submatches accoring to VARLIST then evaluate BODY.
+  "Bind variables to submatches according to VARLIST then evaluate BODY.
 Bind the symbols in VARLIST to submatches of the current match
 data, starting with 1 and incrementing by 1 for each symbol.  If
 the last match was against a string then that has to be provided

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1680,7 +1680,7 @@ creating a branch (named NAME) should result in the variable
 
 It should either be undefined, or it should be the name of an
 existing branch, in which case `branch.<name>.pushRemote' is set
-to the same value.  Any other value, i.e. a non-existend remote,
+to the same value.  Any other value, i.e. a non-existent remote,
 is ignored.
 
 This variable is only used by Magit, Git knows nothing about it."
@@ -1847,7 +1847,7 @@ If no merge is in progress, do nothing."
 (defun magit-reset-index (commit)
   "Reset the index to COMMIT.
 Keep the head and working tree as-is, so if COMMIT refers to the
-head this effectivley unstages all changes.
+head this effectively unstages all changes.
 \n(git reset COMMIT)"
   (interactive (list (magit-read-branch-or-commit "Reset index to")))
   (magit-reset-internal nil commit "."))
@@ -2291,7 +2291,7 @@ With a prefix argument fetch all remotes."
   "Keymap for `magit-file-mode'.")
 
 (magit-define-popup magit-file-popup
-  "Popup consule for Magit commands in file-visiting buffers."
+  "Popup console for Magit commands in file-visiting buffers."
   :actions '((?s "Stage"   magit-stage-file)
              (?l "Log"     magit-log-buffer-file)
              (?c "Commit"  magit-commit-popup)

--- a/lisp/with-editor.el
+++ b/lisp/with-editor.el
@@ -341,7 +341,7 @@ not a good idea to change such entries.")
     (error "With-Editor mode cannot be turned off"))
   (add-hook 'kill-buffer-query-functions
             'with-editor-kill-buffer-noop nil t)
-  ;; `server-excecute' displays a message which is not
+  ;; `server-execute' displays a message which is not
   ;; correct when using this mode.
   (when with-editor-show-usage
     (with-editor-usage-message)))


### PR DESCRIPTION
Catched by ispell and ispell-comments-and-strings.