### PR TITLE
Generalize visibility cache

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -759,9 +759,6 @@ be committed."
                     nil (list (expand-file-name a)
                               (expand-file-name b))))
 
-(defvar-local magit-diff-hidden-files nil)
-(put 'magit-diff-hidden-files 'permanent-local t)
-
 ;;;###autoload
 (defun magit-show-commit (rev &optional args files module)
   "Show the revision at point.
@@ -792,11 +789,7 @@ for a revision."
           (unless (equal rev prev)
             (dolist (child (cdr (magit-section-children magit-root-section)))
               (when (eq (magit-section-type child) 'file)
-                (let ((file (magit-section-value child)))
-                  (if (magit-section-hidden child)
-                      (add-to-list 'magit-diff-hidden-files file)
-                    (setq magit-diff-hidden-files
-                          (delete file magit-diff-hidden-files))))))))))
+                (magit-section-cache-visibility child)))))))
     (magit-mode-setup #'magit-revision-mode rev nil args files)))
 
 (defun magit-diff-refresh (args files)
@@ -1655,13 +1648,6 @@ or a ref which is not a branch, then it inserts nothing."
          (list offset align-to
                (if magit-revision-use-gravatar-kludge slice2 slice1)
                (if magit-revision-use-gravatar-kludge slice1 slice2)))))))
-
-(defun magit-revision-set-visibility (section)
-  "Preserve section visibility when displaying another commit."
-  (and (derived-mode-p 'magit-revision-mode)
-       (eq (magit-section-type section) 'file)
-       (member (magit-section-value section) magit-diff-hidden-files)
-       'hide))
 
 ;;; Diff Sections
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1269,7 +1269,8 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
       (magit-insert-heading
         (format (propertize "Unpulled from %s:" 'face 'magit-section-heading)
                 (magit-get-upstream-branch)))
-      (magit-insert-log "..@{upstream}" magit-log-section-arguments))))
+      (magit-insert-log "..@{upstream}" magit-log-section-arguments)
+      (magit-section-cache-visibility))))
 
 (magit-define-section-jumper magit-jump-to-unpulled-from-pushremote
   "Unpulled from <push-remote>" unpulled
@@ -1284,7 +1285,8 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
         (magit-insert-heading
           (format (propertize "Unpulled from %s:" 'face 'magit-section-heading)
                   (propertize it 'face 'magit-branch-remote)))
-        (magit-insert-log (concat ".." it) magit-log-section-arguments)))))
+        (magit-insert-log (concat ".." it) magit-log-section-arguments)
+        (magit-section-cache-visibility)))))
 
 (defvar magit-unpushed-section-map
   (let ((map (make-sparse-keymap)))
@@ -1302,7 +1304,8 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
       (magit-insert-heading
         (format (propertize "Unpushed to %s:" 'face 'magit-section-heading)
                 (magit-get-upstream-branch)))
-      (magit-insert-log "@{upstream}.." magit-log-section-arguments))))
+      (magit-insert-log "@{upstream}.." magit-log-section-arguments)
+      (magit-section-cache-visibility))))
 
 (magit-define-section-jumper magit-jump-to-unpushed-to-pushremote
   "Unpushed to <push-remote>" unpushed
@@ -1317,7 +1320,8 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
         (magit-insert-heading
           (format (propertize "Unpushed to %s:" 'face 'magit-section-heading)
                   (propertize it 'face 'magit-branch-remote)))
-        (magit-insert-log (concat it "..") magit-log-section-arguments)))))
+        (magit-insert-log (concat it "..") magit-log-section-arguments)
+        (magit-section-cache-visibility)))))
 
 ;;;; Auxiliary Log Sections
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -959,8 +959,19 @@ invisible."
                 magit-section-visibility-cache)))
 
 (defun magit-section-visibility-ident (section)
-  (cons (magit-section-type  section)
-        (magit-section-value section)))
+  (let ((type  (magit-section-type  section))
+        (value (magit-section-value section)))
+    (cons type
+          (cond ((not (memq type '(unpulled unpushed))) value)
+                ((string-match-p "@{upstream}" value) value)
+                ;; Unfortunately Git chokes on "@{push}" when the
+                ;; value of `push.default' does not allow a 1:1
+                ;; mapping.  But collapsed logs of unpushed and
+                ;; unpulled commits in the status buffer should
+                ;; remain invisible after changing branches.
+                ;; So we have to pretend the value is constant.
+                ((string-match-p "\\`\\.\\." value) "..@{push}")
+                (t "@{push}..")))))
 
 ;;; Utilities
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -91,16 +91,18 @@ diff-related sections being the only exception."
   :options '(magit-diff-unhighlight))
 
 (defcustom magit-section-set-visibility-hook
-  '(magit-diff-expansion-threshold magit-revision-set-visibility)
+  '(magit-diff-expansion-threshold
+    magit-section-set-visibility-from-cache)
   "Hook used to set the initial visibility of a section.
 Stop at the first function that returns non-nil.  The value
 should be `show' or `hide'.  If no function returns non-nil
 determine the visibility as usual, i.e. use the hardcoded
 section specific default (see `magit-insert-section')."
-  :package-version '(magit . "2.1.0")
+  :package-version '(magit . "2.4.0")
   :group 'magit-section
   :type 'hook
-  :options '(magit-diff-expansion-threshold magit-revision-set-visibility))
+  :options '(magit-diff-expansion-threshold
+             magit-section-set-visibility-from-cache))
 
 (defface magit-section-highlight
   '((((class color) (background light)) :background "grey95")
@@ -311,6 +313,7 @@ With a prefix argument also expand it." heading)
     (magit-section-update-highlight))
   (-when-let (beg (magit-section-content section))
     (remove-overlays beg (magit-section-end section) 'invisible t))
+  (magit-section-update-visibility-cache section)
   (dolist (child (magit-section-children section))
     (if (magit-section-hidden child)
         (magit-section-hide child)
@@ -931,6 +934,33 @@ invisible."
       (--when-let (magit-section-parent section)
         (or (magit-get-section (magit-section-ident it))
             (magit-section-goto-successor-1 it)))))
+
+;;; Visibility
+
+(defvar-local magit-section-visibility-cache nil)
+(put 'magit-section-visibility-cache 'permanent-local t)
+
+(defun magit-section-set-visibility-from-cache (section)
+  (and (member (magit-section-visibility-ident section)
+               magit-section-visibility-cache)
+       'hide))
+
+(cl-defun magit-section-cache-visibility
+    (&optional (section magit-insert-section--current))
+  (let ((ident (magit-section-visibility-ident section)))
+    (if (magit-section-hidden section)
+        (cl-pushnew ident magit-section-visibility-cache :test #'equal)
+      (setq magit-section-visibility-cache
+            (delete ident magit-section-visibility-cache)))))
+
+(defun magit-section-update-visibility-cache (section)
+  (setq magit-section-visibility-cache
+        (delete (magit-section-visibility-ident section)
+                magit-section-visibility-cache)))
+
+(defun magit-section-visibility-ident (section)
+  (cons (magit-section-type  section)
+        (magit-section-value section)))
 
 ;;; Utilities
 


### PR DESCRIPTION
and use it for `unpulled` and `unpushed` sections in the status buffer. That prevents these sections from being re-expanded when switching branches and when re-attaching `HEAD` (useful at the end of rebases).