### PR TITLE
Update git-popup dependency

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -16,7 +16,7 @@
 ;;	Rémi Vanicat      <vanicat@debian.org>
 ;;	Yann Hodique      <yann.hodique@gmail.com>
 
-;; Package-Requires: ((emacs "24.4") (async "20150909.2257") (dash "20151021.113") (with-editor "20151111") (git-commit "20151111") (magit-popup "20151111"))
+;; Package-Requires: ((emacs "24.4") (async "20150909.2257") (dash "20151021.113") (with-editor "20151111") (git-commit "20151111") (magit-popup "20151221"))
 ;; Keywords: git tools vc
 ;; Homepage: https://github.com/magit/magit
 


### PR DESCRIPTION
I updated magit today and it seems git popup dependency wasn't updated to the latest version. 
Manually updating worked so here it's a PR to update the dependency