### PR TITLE
magit-pull-or-fetch-popup: new popup

### DIFF
--- a/Documentation/RelNotes/2.4.0.txt
+++ b/Documentation/RelNotes/2.4.0.txt
@@ -46,6 +46,10 @@ Changes since v2.3.0
   Likewise many commands were renamed and their behavior was adjusted.
   Some new commands, related to the push-remote, were added.  #2414
 
+* The popup command `magit-pull-and-fetch-popup' was added as a
+  possible replacement for the separate `magit-push-popup' and
+  `magit-fetch-popup'.  #2452
+
 * The status buffer now features up to four logs listing unpulled and
   unpushed commits.  Two for the upstream and two for the push-remote.
   #2414

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3859,6 +3859,10 @@ Also see [[info:gitman#git-fetch]].
   Fetch all submodules.  With a prefix argument fetch all remotes of
   all submodules.
 
+Instead of using one popup for fetching and another for pulling, you
+could also use ~magit-pull-and-fetch-popup~.  See its doc-string for
+more information.
+
 ** Pulling
 
 Also see [[info:gitman#git-pull]].
@@ -3879,6 +3883,10 @@ Also see [[info:gitman#git-pull]].
 - Key: F e, magit-pull
 
   Pull from a branch read in the minibuffer.
+
+Instead of using one popup for fetching and another for pulling, you
+could also use ~magit-pull-and-fetch-popup~.  See its doc-string for
+more information.
 
 ** Pushing
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -5407,6 +5407,10 @@ Fetch all submodules.  With a prefix argument fetch all remotes of
 all submodules.
 @end table
 
+Instead of using one popup for fetching and another for pulling, you
+could also use @code{magit-pull-and-fetch-popup}.  See its doc-string for
+more information.
+
 @node Pulling
 @section Pulling
 
@@ -5450,6 +5454,10 @@ Pull from the upstream of the current branch.
 
 Pull from a branch read in the minibuffer.
 @end table
+
+Instead of using one popup for fetching and another for pulling, you
+could also use @code{magit-pull-and-fetch-popup}.  See its doc-string for
+more information.
 
 @node Pushing
 @section Pushing


### PR DESCRIPTION
```
Combine `magit-pull-popup' and `magit-fetch-popup' into one common
popup.  By default the old popups are still bound in `magit-mode-map'.

Add this to your init file to use the new popup:

  (with-eval-after-load 'magit-remote
    (define-key magit-mode-map "f" 'magit-pull-and-fetch-popup)
    (define-key magit-mode-map "F" nil))

One advantage of the new popup is that it is once more possible to
press the same key twice to fetch.  However that binding now is "f f",
not "F F", and it fetches all remotes not just the current remote.

The new popup also lacks the commands for fetching from only a single
remote.  You can add them to the new popup by adding something like this
to your init file:

  (with-eval-after-load 'magit-remote
    (magit-define-popup-action 'magit-pull-and-fetch-popup ?U
      'magit-get-upstream-branch
      'magit-fetch-from-upstream-remote ?F)
    (magit-define-popup-action 'magit-pull-and-fetch-popup ?P
      'magit-get-push-branch
      'magit-fetch-from-push-remote ?F))
```