### PR TITLE
revert buffers using a globalized variant of auto-revert-mode

### DIFF
--- a/Documentation/RelNotes/2.4.0.txt
+++ b/Documentation/RelNotes/2.4.0.txt
@@ -19,6 +19,13 @@ UNRELEASED.
 Changes since v2.3.0
 --------------------
 
+* The new mode `magit-auto-revert-mode', a magit-specific globalized
+  variant of `auto-revert-mode', replace the old implementation, which
+  was configured using the option `magit-revert-buffers'.  The new
+  mode is enabled for all users by default, except for those who have
+  set `magit-revert-buffers' to nil while the old implementation was
+  still in use.  #2474
+
 * All of Git's push-related variables are now honored.  #2414
 
 * In addition to the upstream branch, the push-remote (configured
@@ -86,17 +93,6 @@ Changes since v2.3.0
 
 * The command `with-editor-finish' now runs the new hook
   `with-editor-post-finish-hook'.
-
-* By default all files inside a repository are now reverted when the
-  file on disk changes, not just tracked files, as was the case
-  before.  This change was necessary because determining the tracked
-  files can be very slow depending on the number of tracked files and
-  buffers.  Setting `magit-revert-buffers-only-for-tracked-files' to
-  `t' restores the old behavior.  #2458
-
-* It is now possible to revert file-visiting buffers both silently and
-  asynchronously at the same time (by setting `magit-revert-buffers' to
-  a negative number).
 
 * The command `magit-diff-visit-file' now runs the new hook
   `magit-diff-visit-file-hook'.

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -702,94 +702,127 @@ refresh explicitly.
 *** Automatic Reverting of File-Visiting Buffers
 
 By default Magit automatically reverts buffers that are visiting files
-that are being tracked in the current Git repository, after running a
-Git command changed the visited file on disk.  This is useful because
-it makes it possible to continue editing a buffer after e.g.
-performing a merge, without having to type ~M-x revert-buffer RET RET~,
-in each of the affected buffers.
+that are being tracked in a Git repository, after they have changed on
+disk.  When using Magit one often changes files on disk by running
+git, i.e. "outside Emacs", making this a rather important feature.
 
-- User Option: magit-revert-buffers
+For example, if you discard a change in the status buffer, then that
+is done by running ~git apply --reverse ...~, and Emacs considers the
+file to have "change on disk".  If Magit did not automaticallyrevert
+the buffer, then you would have to type ~M-x revert-buffer RET RET~ in
+the visiting buffer before you could continue making changes.
 
-  This option controls if and how file-visiting buffers in the current
-  repository are reverted.
+- User Option: magit-auto-revert-mode
 
-  Unmodified buffers visiting files belonging to the current
-  repository may be reverted after refreshing the current Magit buffer
-  and after running certain other commands.
+  When this mode is enabled, then buffers that visit tracked files,
+  are automatically reverted after the visited files changed on disk.
 
-  - ~nil~
+- User Option: global-auto-revert-mode
 
-    Don't revert any buffers.
+  When this mode is enabled, then any file-visiting buffer is
+  automatically reverted after the visited file changed on disk.
 
-  - ~ask~
+  If you like buffers that visit tracked files to be automatically
+  reverted, then you might also like any buffer to be reverted, not
+  just those visiting tracked files.  If that is the case, then enable
+  this mode /instead of/ ~magit-auto-revert-mode~.
 
-    List the buffers which might potentially have to be reverted and
-    ask the user whether she wants to revert them.  If so, then do it
-    synchronously.
+- User Option: magit-auto-revert-immediately
 
-  - ~t~
+  This option controls whether Magit reverts buffers immediately.
 
-    Revert the buffers synchronously, mentioning each one as it is
-    being reverted and then also show a summary in the echo area.
+  If this is non-nil and either ~global-auto-revert-mode~ or
+  ~magit-auto-revert-mode~ is enabled, then Magit immediately reverts
+  buffers by explicitly calling ~auto-revert-buffers~ after running git
+  for side-effects.
 
-  - ~usage~
+  If ~auto-revert-use-notify~ is non-nil (and file notifications are
+  actually supported), then ~magit-auto-revert-immediately~ should be
+  set to nil, because the reverts happen immediately anyway.
 
-    Like ~t~ but include usage information in the summary.  This is the
-    default so that users come here and pick what is right for them.
+  If ~magit-auto-revert-immediately~ and ~auto-revert-use-notify~ are both
+  nil, then reverts happen after ~auto-revert-interval~ seconds of user
+  inactivity.  That is not desirable.
 
-  - ~silent~
+- User Option: auto-revert-use-notify
 
-    Revert the buffers synchronously and be quiet about it.
+  This option controls whether file notification functions should be
+  used.  Note that this variable unfortunately defaults to ~t~ even on
+  systems on which file notifications cannot be used.
 
-    This (or a negative number) is the recommended setting, because
-    for the other values the revert messages might prevent you from
-    seeing other, more important, messages in the echo area.
+- User Option: magit-auto-revert-tracked-only
 
-  - NUMBER
+  This option controls whether ~magit-auto-revert-mode~ only reverts
+  tracked files or all files that are located inside Git repositories,
+  including untracked files and files located inside Git's control
+  directory.
 
-    An integer or float.  Revert the buffers asynchronously.  If
-    NUMBER is positive, then mention each buffer as it is being
-    reverted.  If it is negative, then be quiet about it.  If user
-    input arrives, then stop reverting.  After (the absolute value of)
-    NUMBER seconds resume reverting.
+- Command: auto-revert-mode
 
-- User Option: magit-revert-buffers-only-for-tracked-files
+  The global mode ~magit-auto-revert-mode~ works by turning on this
+  local mode in the appropriate buffers.  You can also turn it on or
+  off manually, which might be necessary if Magit does not notice that
+  a previously untracked file now is being tracked or vice-versa.
 
-  This option controls whether only buffers that visit tracked files
+- User Option: auto-revert-stop-on-user-input
 
-  If non-nil, then only tracked files may be reverted.  If nil, then
-  all files in the current repository may potentially be reverted.
-  Reverting untracked files should be safe and limiting to only
-  tracked files has the potential of causing very noticable delays.
+  This option controls whether the arrival of user input suspends the
+  automatic reverts for ~auto-revert-interval~ seconds.
 
-- User Option: magit-after-revert-hook
+- User Option: auto-revert-interval
 
-  This hook is run in each file-visiting buffer belonging to the
-  current repository that was actually reverted during a refresh.
+  This option controls for how many seconds Emacs waits before
+  resuming suspended reverts.
 
-  Note that adding something here is very expensive.  If you
-  experience performance issues, you might want to check this hook, as
-  well as ~magit-not-reverted-hook~ and, if possible, remove some of the
-  functions added by third-party packages.
+- User Option: auto-revert-verbose
 
-- User Option: magit-not-reverted-hook
+  This option controls whether Emacs reports when a buffer has been
+  reverted.
 
-  This hook is run in each file-visiting buffer belonging to the
-  current repository that was _not_ reverted during a refresh.  The file
-  was not reverted because it did not change, and so Magit does not
-  have to do anything.  This hook is intended for third-party
-  extensions that need to run some functions even on such files.
+The options with the ~auto-revert-~ prefix are located in the Custom
+group named ~auto-revert~.  The other, magit-specific, options are
+located in the ~magit~ group.
 
-- Function: magit-refresh-vc-mode-line
+**** Risk of Reverting Automatically
 
-  This function updates the information displayed by ~vc-mode~ in the
-  mode-line.  This is a simpler, more efficient, and less buggy
-  substitute for ~vc-mode-line~.
+For the vast majority users automatically reverting file-visiting
+buffers after they have changed on disk is harmless.
 
-  This function is intended to be added to ~magit-after-revert-hook~ and
-  ~magit-not-reverted-hook~.  It isn't part of the default value of these
-  hooks because, even though it is faster than, VC's variant it is still
-  to slow if many file-visiting buffers are open.
+If a buffer is modified (i.e. it contains changes that haven't been
+saved yet), then Emacs would refuse to automatically revert it.  If
+you safe a previously modified buffer, then that results in what is
+seen by Git as an uncommitted change.  Git would then refuse to carry
+out any commands that would cause these changes to be lost.  In other
+words, if there is anything that could be lost, then either Git or
+Emacs would refuse to discard the changes.
+
+However if you do use file-visiting buffers as a sort of ad hoc
+"staging area", then the automatic reverts could potentially cause
+data loss.  So far I have only heard from one user who uses such a
+workflow.
+
+An example: You visit some file in a buffer, edit it, and save the
+changes.  Then, outside of Emacs (or at least not using Magit or by
+saving the buffer) you change the file on disk again.  At this point
+the buffer is the only place where the intermediate version still
+exists.  You have saved the changes to disk, but that has since been
+overwritten.  Meanwhile Emacs considers the buffer to be unmodified
+(because you have not made any changes to it since you last saved it
+to the visited file) and therefore would not object to it being
+automatically reverted.  At this point an Auto-Revert mode would kick
+in.  It would check whether the buffer is modified and since that is
+not the case it would revert it.  The intermediate version would be
+lost.  (Actually you could still get it back using the ~undo~ command.)
+
+If your work flow depends on Emacs preserving the intermediate version
+in the buffer, then you have to disable all Auto-Revert modes.  But
+please consider that such a work flow would be dangerous even without
+using an Auto-Revert mode, and should therefore be avoided.  If Emacs
+crashed or if you quit Emacs by mistake, then you would also lose the
+buffer content.  There would be no autosave file still containing the
+intermediate version (because that was deleted when you saved the
+buffer) and you would not be asked whether you want to safe the buffer
+(because it isn't modified).
 
 ** Sections
 
@@ -4557,13 +4590,13 @@ This section discusses various variables that you might want to
 change (or *not* change) for safety reasons.
 
 Git keeps *committed* changes around long enough for users to recover
-changes they have accidentally deleted.  It does not do the same for
-*uncommitted* changes in the working tree and not even the index (the
-staging area).  Because Magit makes it so easy to modify uncommitted
-changes, it also makes it easy to shoot yourself in the foot in the
-process.  For that reason Magit provides three global modes that save
-*tracked* files to work-in-progress references after or before certain
-actions.  See [[*Wip modes]].
+changes they have accidentally been deleted.  It does not do the same
+for *uncommitted* changes in the working tree and not even the index
+(the staging area).  Because Magit makes it so easy to modify
+uncommitted changes, it also makes it easy to shoot yourself in the
+foot in the process.  For that reason Magit provides three global
+modes that save *tracked* files to work-in-progress references after or
+before certain actions.  See [[*Wip modes]].
 
 These modes are not enabled by default because of performance
 concerns.  Instead a lot of potentially destructive commands require
@@ -4579,33 +4612,10 @@ controls whether the system trash is used, which is the case by default.
 Nevertheless, ~trash~ isn't a member of ~magit-no-confirm~ - you
 might want to change that.
 
-Buffers visiting files tracked in the current repository are being
-reverted after certain actions.  See [[*Automatic Reverting of
-File-Visiting Buffers]].  This isn't as risky as it might seem.  If a
-buffer is modified (i.e. it contains changes that haven't been saved
-yet), then Emacs/Magit would refuse to revert it.  If the buffer has
-been saved resulting in what is seen by Git as an uncommitted change,
-then Git in turn would refuse to carry out the action that would cause
-these changes to be lost.  Since Git doesn't do anything, the file
-doesn't change on disk, and Emacs/Magit has nothing to revert.
-
-However if you do modify some files, visit the respective files in
-Emacs, somehow discard the changes (not using Magit and probably even
-outside Emacs), and then expect the respective file-visiting buffers
-to retain the uncommitted changes, then the automatic reverting would
-actually be harmful.  In other words if you use file-visiting buffers
-as a sort of "staging area", then you should set ~magit-revert-buffers~
-to ~nil~.
-
-So far I have only heard from one user who uses such a workflow.  But
-because there might be some other users doing such things, and I don't
-want to be responsible for data loss, these reverts by default happen
-quite verbosely, allowing these few users to undo the reverts using
-the ~undo~ command and then disabling the automatic reverts for the
-future.  Most users should however keep automatic reverts turned on
-and instead configure it to be less verbose by setting
-~magit-revert-buffers~ to ~t~ or even ~silent~.  This option is mentioned
-again in the next section.
+By default buffers visiting files are automatically reverted when the
+visited file changes on disk.  This isn't as risky as it might seem,
+but to make an informed decision you should see [[*Risk of Reverting
+Automatically]].
 
 *** Performance
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -1013,112 +1013,142 @@ intervention.  If it is @code{t} then the user has to confirm each save.
 @subsection Automatic Reverting of File-Visiting Buffers
 
 By default Magit automatically reverts buffers that are visiting files
-that are being tracked in the current Git repository, after running a
-Git command changed the visited file on disk.  This is useful because
-it makes it possible to continue editing a buffer after e.g.
-performing a merge, without having to type @code{M-x revert-buffer RET RET},
-in each of the affected buffers.
+that are being tracked in a Git repository, after they have changed on
+disk.  When using Magit one often changes files on disk by running
+git, i.e. "outside Emacs", making this a rather important feature.
 
-@defopt magit-revert-buffers
+For example, if you discard a change in the status buffer, then that
+is done by running @code{git apply --reverse ...}, and Emacs considers the
+file to have "change on disk".  If Magit did not automaticallyrevert
+the buffer, then you would have to type @code{M-x revert-buffer RET RET} in
+the visiting buffer before you could continue making changes.
 
-This option controls if and how file-visiting buffers in the current
-repository are reverted.
+@defopt magit-auto-revert-mode
 
-Unmodified buffers visiting files belonging to the current
-repository may be reverted after refreshing the current Magit buffer
-and after running certain other commands.
-
-@itemize
-@item
-@code{nil}
-
-Don't revert any buffers.
-
-
-@item
-@code{ask}
-
-List the buffers which might potentially have to be reverted and
-ask the user whether she wants to revert them.  If so, then do it
-synchronously.
-
-
-@item
-@code{t}
-
-Revert the buffers synchronously, mentioning each one as it is
-being reverted and then also show a summary in the echo area.
-
-
-@item
-@code{usage}
-
-Like @code{t} but include usage information in the summary.  This is the
-default so that users come here and pick what is right for them.
-
-
-@item
-@code{silent}
-
-Revert the buffers synchronously and be quiet about it.
-
-This (or a negative number) is the recommended setting, because
-for the other values the revert messages might prevent you from
-seeing other, more important, messages in the echo area.
-
-
-@item
-NUMBER
-
-An integer or float.  Revert the buffers asynchronously.  If
-NUMBER is positive, then mention each buffer as it is being
-reverted.  If it is negative, then be quiet about it.  If user
-input arrives, then stop reverting.  After (the absolute value of)
-NUMBER seconds resume reverting.
-@end itemize
+When this mode is enabled, then buffers that visit tracked files,
+are automatically reverted after the visited files changed on disk.
 @end defopt
 
-@defopt magit-revert-buffers-only-for-tracked-files
+@defopt global-auto-revert-mode
 
-This option controls whether only buffers that visit tracked files
+When this mode is enabled, then any file-visiting buffer is
+automatically reverted after the visited file changed on disk.
 
-If non-nil, then only tracked files may be reverted.  If nil, then
-all files in the current repository may potentially be reverted.
-Reverting untracked files should be safe and limiting to only
-tracked files has the potential of causing very noticable delays.
+If you like buffers that visit tracked files to be automatically
+reverted, then you might also like any buffer to be reverted, not
+just those visiting tracked files.  If that is the case, then enable
+this mode @emph{instead of} @code{magit-auto-revert-mode}.
 @end defopt
 
-@defopt magit-after-revert-hook
+@defopt magit-auto-revert-immediately
 
-This hook is run in each file-visiting buffer belonging to the
-current repository that was actually reverted during a refresh.
+This option controls whether Magit reverts buffers immediately.
 
-Note that adding something here is very expensive.  If you
-experience performance issues, you might want to check this hook, as
-well as @code{magit-not-reverted-hook} and, if possible, remove some of the
-functions added by third-party packages.
+If this is non-nil and either @code{global-auto-revert-mode} or
+@code{magit-auto-revert-mode} is enabled, then Magit immediately reverts
+buffers by explicitly calling @code{auto-revert-buffers} after running git
+for side-effects.
+
+If @code{auto-revert-use-notify} is non-nil (and file notifications are
+actually supported), then @code{magit-auto-revert-immediately} should be
+set to nil, because the reverts happen immediately anyway.
+
+If @code{magit-auto-revert-immediately} and @code{auto-revert-use-notify} are both
+nil, then reverts happen after @code{auto-revert-interval} seconds of user
+inactivity.  That is not desirable.
 @end defopt
 
-@defopt magit-not-reverted-hook
+@defopt auto-revert-use-notify
 
-This hook is run in each file-visiting buffer belonging to the
-current repository that was reverted during a refresh.  The file
-was not reverted because it did not change, and so Magit does not
-have to do anything.  This hook is intended for third-party
-extensions that need to run some functions even on such files.
+This option controls whether file notification functions should be
+used.  Note that this variable unfortunately defaults to @code{t} even on
+systems on which file notifications cannot be used.
 @end defopt
 
-@defun magit-refresh-vc-mode-line
+@defopt magit-auto-revert-tracked-only
 
-This function updates the information displayed by @code{vc-mode} in the
-mode-line.  This is a simpler, more efficient, and less buggy
-substitute for @code{vc-mode-line}.
+This option controls whether @code{magit-auto-revert-mode} only reverts
+tracked files or all files that are located inside Git repositories,
+including untracked files and files located inside Git's control
+directory.
+@end defopt
 
-This function is intended to be added to @code{magit-after-revert-hook} and
-@code{magit-not-reverted-hook}.  It isn't part of the default value of these
-hooks because, even though it is faster than, VC's variant it is still
-to slow if many file-visiting buffers are open.
-@end defun
+@cindex auto-revert-mode
+@deffn Command auto-revert-mode
+
+The global mode @code{magit-auto-revert-mode} works by turning on this
+local mode in the appropriate buffers.  You can also turn it on or
+off manually, which might be necessary if Magit does not notice that
+a previously untracked file now is being tracked or vice-versa.
+@end deffn
+
+@defopt auto-revert-stop-on-user-input
+
+This option controls whether the arrival of user input suspends the
+automatic reverts for @code{auto-revert-interval} seconds.
+@end defopt
+
+@defopt auto-revert-interval
+
+This option controls for how many seconds Emacs waits before
+resuming suspended reverts.
+@end defopt
+
+@defopt auto-revert-verbose
+
+This option controls whether Emacs reports when a buffer has been
+reverted.
+@end defopt
+
+The options with the @code{auto-revert-} prefix are located in the Custom
+group named @code{auto-revert}.  The other, magit-specific, options are
+located in the @code{magit} group.
+
+@menu
+* Risk of Reverting Automatically::
+@end menu
+
+@node Risk of Reverting Automatically
+@unnumberedsubsubsec Risk of Reverting Automatically
+
+For the vast majority users automatically reverting file-visiting
+buffers after they have changed on disk is harmless.
+
+If a buffer is modified (i.e. it contains changes that haven't been
+saved yet), then Emacs would refuse to automatically revert it.  If
+you safe a previously modified buffer, then that results in what is
+seen by Git as an uncommitted change.  Git would then refuse to carry
+out any commands that would cause these changes to be lost.  In other
+words, if there is anything that could be lost, then either Git or
+Emacs would refuse to discard the changes.
+
+However if you do use file-visiting buffers as a sort of ad hoc
+"staging area", then the automatic reverts could potentially cause
+data loss.  So far I have only heard from one user who uses such a
+workflow.
+
+An example: You visit some file in a buffer, edit it, and save the
+changes.  Then, outside of Emacs (or at least not using Magit or by
+saving the buffer) you change the file on disk again.  At this point
+the buffer is the only place where the intermediate version still
+exists.  You have saved the changes to disk, but that has since been
+overwritten.  Meanwhile Emacs considers the buffer to be unmodified
+(because you have not made any changes to it since you last saved it
+to the visited file) and therefore would not object to it being
+automatically reverted.  At this point an Auto-Revert mode would kick
+in.  It would check whether the buffer is modified and since that is
+not the case it would revert it.  The intermediate version would be
+lost.  (Actually you could still get it back using the @code{undo} command.)
+
+If your work flow depends on Emacs preserving the intermediate version
+in the buffer, then you have to disable all Auto-Revert modes.  But
+please consider that such a work flow would be dangerous even without
+using an Auto-Revert mode, and should therefore be avoided.  If Emacs
+crashed or if you quit Emacs by mistake, then you would also lose the
+buffer content.  There would be no autosave file still containing the
+intermediate version (because that was deleted when you saved the
+buffer) and you would not be asked whether you want to safe the buffer
+(because it isn't modified).
 
 @node Sections
 @section Sections
@@ -6398,13 +6428,13 @@ This section discusses various variables that you might want to
 change (or @strong{not} change) for safety reasons.
 
 Git keeps @strong{committed} changes around long enough for users to recover
-changes they have accidentally deleted.  It does not do the same for
-@strong{uncommitted} changes in the working tree and not even the index (the
-staging area).  Because Magit makes it so easy to modify uncommitted
-changes, it also makes it easy to shoot yourself in the foot in the
-process.  For that reason Magit provides three global modes that save
-@strong{tracked} files to work-in-progress references after or before certain
-actions.  See @ref{Wip modes,Wip modes}.
+changes they have accidentally been deleted.  It does not do the same
+for @strong{uncommitted} changes in the working tree and not even the index
+(the staging area).  Because Magit makes it so easy to modify
+uncommitted changes, it also makes it easy to shoot yourself in the
+foot in the process.  For that reason Magit provides three global
+modes that save @strong{tracked} files to work-in-progress references after or
+before certain actions.  See @ref{Wip modes,Wip modes}.
 
 These modes are not enabled by default because of performance
 concerns.  Instead a lot of potentially destructive commands require
@@ -6419,32 +6449,9 @@ controls whether the system trash is used, which is the case by default.
 Nevertheless, @code{trash} isn't a member of @code{magit-no-confirm} - you
 might want to change that.
 
-Buffers visiting files tracked in the current repository are being
-reverted after certain actions.  See @ref{Automatic Reverting of File-Visiting Buffers,Automatic Reverting of File-Visiting Buffers}.  This isn't as risky as it might seem.  If a
-buffer is modified (i.e. it contains changes that haven't been saved
-yet), then Emacs/Magit would refuse to revert it.  If the buffer has
-been saved resulting in what is seen by Git as an uncommitted change,
-then Git in turn would refuse to carry out the action that would cause
-these changes to be lost.  Since Git doesn't do anything, the file
-doesn't change on disk, and Emacs/Magit has nothing to revert.
-
-However if you do modify some files, visit the respective files in
-Emacs, somehow discard the changes (not using Magit and probably even
-outside Emacs), and then expect the respective file-visiting buffers
-to retain the uncommitted changes, then the automatic reverting would
-actually be harmful.  In other words if you use file-visiting buffers
-as a sort of "staging area", then you should set @code{magit-revert-buffers}
-to @code{nil}.
-
-So far I have only heard from one user who uses such a workflow.  But
-because there might be some other users doing such things, and I don't
-want to be responsible for data loss, these reverts by default happen
-quite verbosely, allowing these few users to undo the reverts using
-the @code{undo} command and then disabling the automatic reverts for the
-future.  Most users should however keep automatic reverts turned on
-and instead configure it to be less verbose by setting
-@code{magit-revert-buffers} to @code{t} or even @code{silent}.  This option is mentioned
-again in the next section.
+By default buffers visiting files are automatically reverted when the
+visited file changes on disk.  This isn't as risky as it might seem,
+but to make an informed decision you should see @ref{Risk of Reverting Automatically,Risk of Reverting Automatically}.
 
 @node Performance
 @subsection Performance

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test-interactive:
 	(ert t))"
 
 magit: clean-lisp
-	@$(EMACSBIN) -Q $(LOAD_PATH) --eval "(progn\
+	@$(EMACSBIN) -Q $(LOAD_PATH) --debug-init --eval "(progn\
 	(require 'magit)\
 	(global-set-key \"\\C-xg\" 'magit-status)\
 	(tool-bar-mode 0)\

--- a/default.mk
+++ b/default.mk
@@ -30,6 +30,7 @@ ELS += magit-popup.el
 ELS += magit-utils.el
 ELS += magit-section.el
 ELS += magit-git.el
+ELS += magit-autorevert.el
 ELS += magit-mode.el
 ELS += magit-process.el
 ELS += magit-core.el

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -14,6 +14,7 @@ magit-mode.elc:		magit-section.elc magit-git.elc
 magit-popup.elc:
 magit-process.elc:	with-editor.elc magit-utils.elc magit-section.elc \
 			magit-git.elc magit-mode.elc
+magit-autorevert.elc:	magit-git.elc magit-process.elc
 magit-core.elc:		magit-utils.elc magit-section.elc magit-git.elc \
 			magit-mode.elc magit-popup.elc magit-process.elc
 magit-diff.elc:		git-commit.elc magit-core.elc

--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -176,7 +176,7 @@ The major mode configured here is turned on by the minor mode
   "Hook run at the end of `git-commit-setup'."
   :group 'git-commit
   :type 'hook
-  :options '(magit-revert-buffers
+  :options '(
              git-commit-save-message
              git-commit-setup-changelog-support
              git-commit-turn-on-auto-fill

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -164,18 +164,17 @@ With a prefix argument and if necessary, attempt a 3-way merge."
   "Add the change at point to the staging area."
   (interactive)
   (--when-let (magit-apply--get-selection)
-    (let ((inhibit-magit-revert t))
-      (pcase (list (magit-diff-type) (magit-diff-scope))
-        (`(untracked     ,_) (magit-stage-untracked))
-        (`(unstaged  region) (magit-apply-region it "--cached"))
-        (`(unstaged    hunk) (magit-apply-hunk   it "--cached"))
-        (`(unstaged   hunks) (magit-apply-hunks  it "--cached"))
-        (`(unstaged    file) (magit-stage-1 "-u" (list (magit-section-value it))))
-        (`(unstaged   files) (magit-stage-1 "-u" (magit-region-values)))
-        (`(unstaged    list) (magit-stage-1 "-u"))
-        (`(staged        ,_) (user-error "Already staged"))
-        (`(committed     ,_) (user-error "Cannot stage committed changes"))
-        (`(undefined     ,_) (user-error "Cannot stage this change"))))))
+    (pcase (list (magit-diff-type) (magit-diff-scope))
+      (`(untracked     ,_) (magit-stage-untracked))
+      (`(unstaged  region) (magit-apply-region it "--cached"))
+      (`(unstaged    hunk) (magit-apply-hunk   it "--cached"))
+      (`(unstaged   hunks) (magit-apply-hunks  it "--cached"))
+      (`(unstaged    file) (magit-stage-1 "-u" (list (magit-section-value it))))
+      (`(unstaged   files) (magit-stage-1 "-u" (magit-region-values)))
+      (`(unstaged    list) (magit-stage-1 "-u"))
+      (`(staged        ,_) (user-error "Already staged"))
+      (`(committed     ,_) (user-error "Cannot stage committed changes"))
+      (`(undefined     ,_) (user-error "Cannot stage this change")))))
 
 ;;;###autoload
 (defun magit-stage-file (file)
@@ -213,7 +212,9 @@ ignored) files.
 
 (defun magit-stage-1 (arg &optional files)
   (magit-wip-commit-before-change files " before stage")
-  (magit-run-git-no-revert "add" arg (if files (cons "--" files) "."))
+  (magit-run-git "add" arg (if files (cons "--" files) "."))
+  (when magit-auto-revert-mode
+    (mapc #'magit-turn-on-auto-revert-mode-if-desired files))
   (magit-wip-commit-after-apply files " after stage"))
 
 (defun magit-stage-untracked ()
@@ -229,14 +230,15 @@ ignored) files.
         (push file plain)))
     (magit-wip-commit-before-change files " before stage")
     (when plain
-      (magit-run-git-no-revert "add" "--" plain))
+      (magit-run-git "add" "--" plain)
+      (when magit-auto-revert-mode
+        (mapc #'magit-turn-on-auto-revert-mode-if-desired plain)))
     (dolist (repo repos)
-      (let ((inhibit-magit-revert t))
-        (save-excursion
-          (goto-char (magit-section-start
-                      (magit-get-section
-                       `((file . ,repo) (untracked) (status)))))
-          (call-interactively 'magit-submodule-add))))
+      (save-excursion
+        (goto-char (magit-section-start
+                    (magit-get-section
+                     `((file . ,repo) (untracked) (status)))))
+        (call-interactively 'magit-submodule-add)))
     (magit-wip-commit-after-apply files " after stage")))
 
 ;;;; Unstage
@@ -245,20 +247,19 @@ ignored) files.
   "Remove the change at point from the staging area."
   (interactive)
   (--when-let (magit-apply--get-selection)
-    (let ((inhibit-magit-revert t))
-      (pcase (list (magit-diff-type) (magit-diff-scope))
-        (`(untracked     ,_) (user-error "Cannot unstage untracked changes"))
-        (`(unstaged      ,_) (user-error "Already unstaged"))
-        (`(staged    region) (magit-apply-region it "--reverse" "--cached"))
-        (`(staged      hunk) (magit-apply-hunk   it "--reverse" "--cached"))
-        (`(staged     hunks) (magit-apply-hunks  it "--reverse" "--cached"))
-        (`(staged      file) (magit-unstage-1 (list (magit-section-value it))))
-        (`(staged     files) (magit-unstage-1 (magit-region-values)))
-        (`(staged      list) (magit-unstage-all))
-        (`(committed     ,_) (if (bound-and-true-p magit-unstage-use-anti-stage)
-                                 (magit-anti-stage)
-                               (user-error "Cannot unstage committed changes")))
-        (`(undefined     ,_) (user-error "Cannot unstage this change"))))))
+    (pcase (list (magit-diff-type) (magit-diff-scope))
+      (`(untracked     ,_) (user-error "Cannot unstage untracked changes"))
+      (`(unstaged      ,_) (user-error "Already unstaged"))
+      (`(staged    region) (magit-apply-region it "--reverse" "--cached"))
+      (`(staged      hunk) (magit-apply-hunk   it "--reverse" "--cached"))
+      (`(staged     hunks) (magit-apply-hunks  it "--reverse" "--cached"))
+      (`(staged      file) (magit-unstage-1 (list (magit-section-value it))))
+      (`(staged     files) (magit-unstage-1 (magit-region-values)))
+      (`(staged      list) (magit-unstage-all))
+      (`(committed     ,_) (if (bound-and-true-p magit-unstage-use-anti-stage)
+                               (magit-anti-stage)
+                             (user-error "Cannot unstage committed changes")))
+      (`(undefined     ,_) (user-error "Cannot unstage this change")))))
 
 ;;;###autoload
 (defun magit-unstage-file (file)

--- a/lisp/magit-autorevert.el
+++ b/lisp/magit-autorevert.el
@@ -1,0 +1,146 @@
+;;; magit-autorevert.el --- revert buffers when files in Git repositories change  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2010-2016  The Magit Project Contributors
+;;
+;; You should have received a copy of the AUTHORS.md file which
+;; lists all contributors.  If not, see http://magit.vc/authors.
+
+;; Author: Jonas Bernoulli <jonas@bernoul.li>
+;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
+
+;; Magit is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; Magit is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+;; License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Magit.  If not, see http://www.gnu.org/licenses.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'dash)
+
+(require 'magit-git)
+
+(require 'autorevert)
+
+(defcustom magit-auto-revert-tracked-only t
+  "Whether `magit-auto-revert-mode' only reverts tracked files."
+  :package-version '(magit . "2.4.0")
+  :group 'magit
+  :type 'boolean
+  :set (lambda (var val)
+         (set var val)
+         (when (bound-and-true-p magit-auto-revert-mode)
+           (magit-auto-revert-mode -1)
+           (magit-auto-revert-mode))))
+
+(defcustom magit-auto-revert-immediately (not file-notify--library)
+  "Whether Magit reverts buffers immediately.
+
+If this is non-nil and either `global-auto-revert-mode' or
+`magit-auto-revert-mode' is enabled, then Magit immediately
+reverts buffers by explicitly calling `auto-revert-buffers'
+after running git for side-effects.
+
+If `auto-revert-use-notify' is non-nil (and file notifications
+are actually supported), then `magit-auto-revert-immediately'
+should be nil, because the reverts happen immediately anyway.
+
+If `magit-auto-revert-immediately' and `auto-revert-use-notify'
+are both nil, then reverts happen after `auto-revert-interval'
+seconds of user inactivity.  That is not desirable."
+  :package-version '(magit . "2.4.0")
+  :group 'magit
+  :type 'boolean)
+
+(defun magit-turn-on-auto-revert-mode-if-desired (&optional file)
+  (if file
+      (--when-let (find-buffer-visiting file)
+        (with-current-buffer it
+          (magit-turn-on-auto-revert-mode-if-desired)))
+    (when (and buffer-file-name
+               (magit-toplevel)
+               (or (not magit-auto-revert-tracked-only)
+                   (magit-file-tracked-p buffer-file-name)))
+      (auto-revert-mode))))
+
+(defvar magit-revert-buffers t)
+(make-obsolete-variable 'magit-revert-buffers 'magit-auto-revert-mode
+                        "Magit 2.4.0")
+
+;;;###autoload
+(define-globalized-minor-mode magit-auto-revert-mode auto-revert-mode
+  magit-turn-on-auto-revert-mode-if-desired
+  :package-version '(magit . "2.4.0")
+  :group 'magit
+  ;; When `global-auto-revert-mode' is enabled, then this mode is
+  ;; redundant.  When `magit-revert-buffers' is nil, then the user has
+  ;; opted out of the automatic reverts while the old implementation
+  ;; was still in use.  In all other cases enable the mode because if
+  ;; buffers are not automatically reverted that would make many very
+  ;; common tasks much more cumbersome.
+  :init-value (and (not global-auto-revert-mode) magit-revert-buffers))
+
+;; `:init-value t' only sets the value of the mode variable
+;; but does not cause the mode function to be called.
+(cl-eval-when (load eval)
+  (when magit-auto-revert-mode
+    (magit-auto-revert-mode)))
+
+;; If the user has set the obsolete `magit-revert-buffers' to nil
+;; after loading magit, then we should still respect that setting.
+(defun magit-auto-revert-mode--maybe-turn-off-after-init ()
+  (unless magit-revert-buffers
+    (magit-auto-revert-mode -1)))
+(unless after-init-time
+  (add-hook 'after-init-hook
+            #'magit-auto-revert-mode--maybe-turn-off-after-init t))
+
+(put 'magit-auto-revert-mode 'function-documentation
+     "Toggle Magit Auto Revert mode.
+With a prefix argument ARG, enable Magit Auto Revert mode if ARG
+is positive, and disable it otherwise.  If called from Lisp,
+enable the mode if ARG is omitted or nil.
+
+Magit Auto Revert mode is a global minor mode that reverts
+buffers associated with a file that is located inside a Git
+repository when the file changes on disk.  Use `auto-revert-mode'
+to revert a particular buffer.  Or use `global-auto-revert-mode'
+to revert all file-visiting buffers, not just those that visit
+a file located inside a Git repository.
+
+This global mode works by turning on the buffer-local mode
+`auto-revert-mode' at the time a buffer is first created.  The
+local mode is turned on if the visited file is being tracked in
+a Git repository at the time when the buffer is created.
+
+If `magit-auto-revert-tracked-only' is non-nil (the default),
+then only tracked files are reverted.  But if you stage a
+previously untracked file using `magit-stage', then this mode
+notices that.
+
+Unlike `global-auto-revert-mode', this mode never reverts any
+buffers that are not visiting files.
+
+This function calls the hook `magit-auto-revert-mode-hook'.")
+
+(defun magit-auto-revert-buffers ()
+  (when (and magit-auto-revert-immediately
+             (or magit-auto-revert-mode global-auto-revert-mode))
+    (auto-revert-buffers)))
+
+(custom-add-to-group 'magit 'auto-revert-check-vc-info 'custom-variable)
+
+;;; magit-autorevert.el ends soon
+(provide 'magit-autorevert)
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+;;; magit-autorevert.el ends here

--- a/lisp/magit-core.el
+++ b/lisp/magit-core.el
@@ -36,6 +36,7 @@
 (require 'magit-mode)
 (require 'magit-popup)
 (require 'magit-process)
+(require 'magit-autorevert)
 
 (defgroup magit nil
   "Controlling Git from Emacs."

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -34,13 +34,13 @@
 
 (require 'magit-section)
 (require 'magit-git)
+;; (require 'magit-autorevert)
 
 ;; For `magit-xref-insert-buttons' from `magit'
 (defvar magit-diff-show-xref-buttons)
 (defvar magit-revision-show-xref-buttons)
-;; For `magit-revert-buffers'
-(declare-function magit-blame-mode 'magit-blame)
-(defvar magit-blame-mode)
+;; For `magit-refresh' and `magit-refresh-all'
+(declare-function magit-auto-revert-buffers 'magit-autorevert)
 
 (require 'format-spec)
 (require 'help-mode)
@@ -175,98 +175,6 @@ displayed.  Otherwise fall back to regular region highlighting."
   :package-version '(magit . "2.1.0")
   :group 'magit-modes
   :type 'hook)
-
-(defvar magit-revert-buffers-timer nil)
-
-(defun magit-revert-buffers-set-timer ()
-  (when (timerp magit-revert-buffers-timer)
-    (cancel-timer magit-revert-buffers-timer))
-  (setq magit-revert-buffers-timer
-        (and (boundp 'magit-revert-buffers)
-             (numberp magit-revert-buffers)
-             (run-with-timer 0 (abs magit-revert-buffers)
-                             'magit-revert-buffers-async))))
-
-(defcustom magit-revert-buffers 'usage
-  "How file-visiting buffers in the current repository are reverted.
-
-After running certain commands, after refreshing the current
-Magit buffer, unmodified buffers visiting files belonging to
-the current repository may optionally be reverted.
-
-`nil'     Don't revert any buffers.
-
-`ask'     List the buffers which might potentially have to be
-          reverted and ask the user whether she wants to revert
-          them.  If so, then do it synchronously.
-
-`t'       Revert the buffers synchronously, mentioning each one
-          as it is being reverted and then also show a summary.
-
-`usage'   Like `t' but include usage information in the summary.
-          This is the default so that users come here and pick
-          what is right for them.
-
-`silent'  Revert the buffers synchronously and be quiet about it.
-          This (or a negative number) is the recommended setting,
-          because for the other values the revert messages might
-          prevent you from seeing other, more important, messages
-          in the echo area.
-
-NUMBER    An integer or float.  Revert the buffers asynchronously.
-          If NUMBER is positive, then mention each buffer as it is
-          being reverted.  If it is negative, then be quiet about
-          it.  If user input arrives, then stop reverting.  After
-          (the absolute value of) NUMBER seconds resume reverting.
-
-Also see option `magit-revert-buffers-only-for-tracked-files'."
-  :package-version '(magit . "2.1.0")
-  :group 'magit
-  :type '(choice
-          (const :tag "Don't revert" nil)
-          (const :tag "Ask whether to revert" ask)
-          (const :tag "Revert synchronously" t)
-          (const :tag "Revert synchronously but in silence" silent)
-          (const :tag "Revert synchronously with usage information" usage)
-          (integer :tag "Revert asynchronously (interval in seconds)"))
-  :set (lambda (var val)
-         (set-default var val)
-         (magit-revert-buffers-set-timer)))
-
-(defcustom magit-revert-buffers-only-for-tracked-files t
-  "Whether to revert only buffers that visit tracked files.
-
-If non-nil, then only tracked files may be reverted.  If nil,
-then all files in the current repository may potentially be
-reverted.  Reverting untracked files should be safe and limiting
-to only tracked files has the potential of causing very noticable
-delays.
-
-Also see option `magit-revert-buffers'."
-  :package-version '(magit . "2.4.0")
-  :group 'magit
-  :type 'boolean)
-
-(defcustom magit-after-revert-hook nil
-  "Normal hook for `magit-revert-buffer' to run after reverting.
-
-This hook is only run for buffers that were actually reverted.
-For other buffers `magit-not-reverted-hook' is run instead."
-  :package-version '(magit . "2.4.0")
-  :group 'magit-modes
-  :type 'hook
-  :options '(magit-refresh-vc-mode-line))
-
-(defcustom magit-not-reverted-hook nil
-  "Normal hook for `magit-revert-buffer' to run instead of reverting.
-
-This hook is only run for buffers which might have been reverted
-but were not actually reverted, because that was not necessary.
-For other buffers `magit-after-revert-hook' is run instead."
-  :package-version '(magit . "2.4.0")
-  :group 'magit-modes
-  :type 'hook
-  :options '(magit-refresh-vc-mode-line))
 
 (defcustom magit-save-repository-buffers t
   "Whether to save file-visiting buffers when appropriate.
@@ -730,7 +638,7 @@ window."
       (when (window-live-p window)
         (delete-window window)))))
 
-;;; Refresh Machinery
+;;; Refresh Magit Buffers
 
 (defvar inhibit-magit-refresh nil)
 
@@ -740,11 +648,7 @@ window."
   "Refresh some buffers belonging to the current repository.
 
 Refresh the current buffer if its major mode derives from
-`magit-mode', and refresh the corresponding status buffer.
-
-If option `magit-revert-buffers' call for it, then also revert
-all unmodified buffers that visit files being tracked in the
-current repository."
+`magit-mode', and refresh the corresponding status buffer."
   (interactive)
   (unless inhibit-magit-refresh
     (run-hooks 'magit-pre-refresh-hook)
@@ -754,7 +658,7 @@ current repository."
       (--when-let (magit-mode-get-buffer 'magit-status-mode)
         (with-current-buffer it
           (magit-refresh-buffer))))
-    (magit-revert-buffers)))
+    (magit-auto-revert-buffers)))
 
 (defun magit-refresh-all ()
   "Refresh all buffers belonging to the current repository.
@@ -766,7 +670,7 @@ tracked in the current repository."
   (interactive)
   (dolist (buffer (magit-mode-get-buffers))
     (with-current-buffer buffer (magit-refresh-buffer)))
-  (magit-revert-buffers t))
+  (magit-auto-revert-buffers))
 
 (defvar-local magit-refresh-start-time nil)
 
@@ -829,133 +733,7 @@ tracked in the current repository."
                                                 beg (line-end-position))))
                                 (t t)))))))))
 
-(defvar inhibit-magit-revert nil)
-(defvar magit-revert-buffers-backlog nil)
-
-(defun magit-revert-buffers (&optional force)
-  "Revert unmodified file-visiting buffers of the current repository.
-
-If either `magit-revert-buffers' is non-nil and `inhibit-magit-revert'
-is nil, or if optional FORCE is non-nil; then revert all unmodified
-buffers that visit files being tracked in the current repository.
-
-When called interactively then the revert is forced."
-  (interactive (list t))
-  (-when-let* ((- (or force
-                      (and magit-revert-buffers
-                           (not inhibit-magit-revert))))
-               (topdir (magit-toplevel))
-               (buffers (magit-revert-list-modified-buffers topdir))
-               (- (or force
-                      (not (eq magit-revert-buffers 'ask))
-                      (magit-confirm 'revert-buffer
-                        "Revert %s from visited file"
-                        "Revert %i buffers from visited files"
-                        (mapcar #'buffer-name buffers)))))
-    (if (numberp magit-revert-buffers)
-        (magit-revert-buffers-async buffers)
-      (magit-revert-buffers-sync buffers force))))
-
-(add-hook 'git-commit-setup-hook #'magit-revert-buffers)
-
-(defun magit-revert-buffers-sync (buffers force)
-  (if (eq magit-revert-buffers 'silent)
-      (mapc #'magit-revert-buffer buffers)
-    (let ((cnt (length buffers)))
-      (message "Reverting (up to) %s file-visiting buffer(s)..." cnt)
-      (setq cnt (length (-non-nil (mapcar #'magit-revert-buffer buffers))))
-      (if (> cnt 0)
-          (let ((s (if (> cnt 1) "s" "")))
-            (pcase magit-revert-buffers
-              (`t
-               (message "Reverting %s file-visiting buffer%s...done" cnt s))
-              (`usage
-               (message "Reverting %s file-visiting buffer%s...done%s%s%s" cnt s
-                        (substitute-command-keys
-                         "\n  This can be undone using `\\[undo]' in the ")
-                        "affected buffers\n  Customize behavior using `M-x "
-                        "customize-option RET magit-revert-buffers RET'"))
-              ((or `nil `ask)
-               (message "Reverting %s file-visiting buffer%s...done%s"
-                        cnt s (if force " (forced)" "")))))
-        (message "(No buffers need to be reverted)")))))
-
-(defun magit-revert-buffers-async (&optional buffers)
-  (setq buffers (nconc buffers (--filter (not (memq it buffers))
-                                         magit-revert-buffers-backlog)))
-  (while (and buffers (not (input-pending-p)))
-    (let ((buf (pop buffers)))
-      (when (buffer-live-p buf)
-        (with-current-buffer buf
-          (magit-revert-buffer buf)))))
-  (setq magit-revert-buffers-backlog buffers))
-
-(defun magit-revert-buffer (&optional buffer)
-  "Revert the current buffer.
-If optional BUFFER is non-nil, then revert that instead.
-The buffer is expected to visit a file.  Return t if the
-buffer had to be reverted, nil otherwise."
-  (with-current-buffer (or buffer (current-buffer))
-    (if (and (file-readable-p buffer-file-name)
-             (not (verify-visited-file-modtime (current-buffer))))
-        (if magit-blame-mode
-            (progn (message "Reverting %s inhibited due to magit-blame-mode"
-                            buffer-file-name)
-                   (run-hooks 'magit-not-reverted-hook)
-                   nil)
-          (if (or (eq magit-revert-buffers 'silent)
-                  (and (numberp magit-revert-buffers)
-                       (< magit-revert-buffers 0)))
-              (revert-buffer 'ignore-auto t t)
-            (message "Reverting buffer `%s'..." (buffer-name))
-            (revert-buffer 'ignore-auto t t)
-            (message "Reverting buffer `%s'...done" (buffer-name)))
-          (run-hooks 'magit-after-revert-hook)
-          t)
-      (run-hooks 'magit-not-reverted-hook)
-      nil)))
-
-(defun magit-revert-list-modified-buffers (topdir)
-  (if magit-revert-buffers-only-for-tracked-files
-      (let ((tracked (magit-revision-files "HEAD")))
-        (if (> (length tracked)
-               (length (buffer-list)))
-            (--filter (magit-revert-buffer-p it topdir tracked)
-                      (buffer-list))
-          (--keep (find-buffer-visiting (expand-file-name it topdir)) tracked)))
-    (--filter (magit-revert-buffer-p it topdir)
-              (buffer-list))))
-
-(defun magit-revert-buffer-p (buffer topdir &optional tracked)
-  (let ((file (buffer-file-name buffer)))
-    (and file
-         (equal (file-remote-p file)
-                (file-remote-p topdir))
-         (file-in-directory-p file topdir)
-         (or (not tracked)
-             (member (file-relative-name file topdir) tracked)))))
-
-(defun magit-refresh-vc-mode-line ()
-  "Update the information displayed by `vc-mode' in the mode-line.
-Like `vc-mode-line' but simpler, more efficient, and less buggy."
-  (setq vc-mode
-        (if vc-display-status
-            (magit-with-toplevel
-              (let* ((rev (or (magit-get-current-branch)
-                              (magit-rev-parse "--short" "HEAD")))
-                     (msg (cl-letf (((symbol-function #'vc-working-revision)
-                                     (lambda (&rest _) rev)))
-                            (vc-default-mode-line-string
-                             'Git buffer-file-name))))
-                (propertize
-                 (concat " " msg)
-                 'mouse-face 'mode-line-highlight
-                 'help-echo (concat (get-text-property 0 'help-echo msg)
-                                    "\nCurrent revision: " rev
-                                    "\nmouse-1: Version Control menu")
-                 'local-map vc-mode-line-map)))
-          " Git"))
-  (force-mode-line-update))
+;;; Save File-Visiting Buffers
 
 (defvar disable-magit-save-buffers nil)
 

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -159,7 +159,7 @@ the variable isn't already set."
 
 (defun magit-git-fetch (remote args)
   (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "fetch" remote args))
+  (magit-run-git-async "fetch" remote args))
 
 ;;;###autoload
 (defun magit-fetch-from-pushremote (args)
@@ -193,7 +193,7 @@ the variable isn't already set."
   "Fetch from all remotes."
   (interactive (list (magit-fetch-arguments)))
   (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "remote" "update" args))
+  (magit-run-git-async "remote" "update" args))
 
 ;;;###autoload
 (defun magit-fetch-all-prune ()
@@ -202,14 +202,14 @@ Prune remote tracking branches for branches that have been
 removed on the respective remote."
   (interactive)
   (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "remote" "update" "--prune"))
+  (magit-run-git-async "remote" "update" "--prune"))
 
 ;;;###autoload
 (defun magit-fetch-all-no-prune ()
   "Fetch from all remotes."
   (interactive)
   (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "remote" "update"))
+  (magit-run-git-async "remote" "update"))
 
 ;;; Pull
 
@@ -381,9 +381,8 @@ removed after restarting Emacs."
   (run-hooks 'magit-credential-hook)
   (-let [(remote . target)
          (magit-split-branch-name target)]
-    (magit-run-git-async-no-revert "push" "-v" args remote
-                                   (format "%s:refs/heads/%s"
-                                           branch target))))
+    (magit-run-git-async "push" "-v" args remote
+                         (format "%s:refs/heads/%s" branch target))))
 
 ;;;###autoload
 (defun magit-push-current-to-pushremote (args &optional push-remote)
@@ -491,7 +490,7 @@ If just one exists, use that without requiring confirmation."
   (interactive (list (magit-read-remote "Push matching branches to" nil t)
                      (magit-push-arguments)))
   (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "push" "-v" args remote ":"))
+  (magit-run-git-async "push" "-v" args remote ":"))
 
 ;;;###autoload
 (defun magit-push-tags (remote &optional args)
@@ -502,7 +501,7 @@ branch as default."
   (interactive (list (magit-read-remote "Push tags to remote" nil t)
                      (magit-push-arguments)))
   (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "push" remote "--tags" args))
+  (magit-run-git-async "push" remote "--tags" args))
 
 ;;;###autoload
 (defun magit-push-tag (tag remote &optional args)
@@ -512,7 +511,7 @@ branch as default."
      (list tag (magit-read-remote (format "Push %s to remote" tag) nil t)
            (magit-push-arguments))))
   (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "push" remote tag args))
+  (magit-run-git-async "push" remote tag args))
 
 ;;;###autoload
 (defun magit-push-implicitly (args)
@@ -537,7 +536,7 @@ what this command will do, the value it returns is displayed in
 the popup buffer."
   (interactive (list (magit-push-arguments)))
   (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "push" "-v" args))
+  (magit-run-git-async "push" "-v" args))
 
 (defun magit-push-implicitly--desc ()
   (let ((default (magit-get "push.default")))
@@ -587,7 +586,7 @@ To add this command to the push popup add this to your init file:
   (interactive (list (magit-read-remote "Push to remote")
                      (magit-push-arguments)))
   (run-hooks 'magit-credential-hook)
-  (magit-run-git-async-no-revert "push" "-v" args remote))
+  (magit-run-git-async "push" "-v" args remote))
 
 (defun magit-push-to-remote--desc ()
   (format "using %s\n" (propertize "git push <remote>" 'face 'bold)))
@@ -631,7 +630,7 @@ HEAD but not from the specified commit)."
                  range
                (format "%s~..%s" range range))))
          (magit-patch-arguments)))
-  (magit-run-git-no-revert "format-patch" range args))
+  (magit-run-git "format-patch" range args))
 
 ;;;###autoload
 (defun magit-request-pull (url start end)
@@ -650,8 +649,7 @@ is asked to pull.  START has to be reachable from that commit."
     (compose-mail)
     (setq default-directory dir))
   (message-goto-body)
-  (let ((inhibit-magit-revert t))
-    (magit-git-insert "request-pull" start url end))
+  (magit-git-insert "request-pull" start url end)
   (set-buffer-modified-p nil))
 
 ;;; magit-remote.el ends soon

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1496,7 +1496,7 @@ With prefix, forces the rename even if NEW already exists.
            (magit-read-string-ns (format "Rename branch '%s' to" branch))
            current-prefix-arg)))
   (unless (string= old new)
-    (magit-run-git-no-revert "branch" (if force "-M" "-m") old new)))
+    (magit-run-git "branch" (if force "-M" "-m") old new)))
 
 ;;;;; Branch Variables
 
@@ -1564,8 +1564,7 @@ already set.  When nil, then always unset."
                         (concat "refs/heads/" merge)))
     (magit-call-git "branch" "--unset-upstream" branch))
   (when (called-interactively-p 'any)
-    (let ((inhibit-magit-revert t))
-      (magit-refresh))))
+    (magit-refresh)))
 
 (defun magit-format-branch*merge/remote ()
   (let* ((branch (or (magit-get-current-branch) "<name>"))
@@ -2054,7 +2053,7 @@ defaulting to the tag at point.
   (interactive (list (--if-let (magit-region-values 'tag)
                          (magit-confirm t nil "Delete %i tags" it)
                        (magit-read-tag "Delete tag" t))))
-  (magit-run-git-no-revert "tag" "-d" tags))
+  (magit-run-git "tag" "-d" tags))
 
 (defun magit-tag-prune (tags remote-tags remote)
   "Offer to delete tags missing locally from REMOTE, and vice versa."
@@ -2078,8 +2077,7 @@ defaulting to the tag at point.
   (when tags
     (magit-call-git "tag" "-d" tags))
   (when remote-tags
-    (magit-run-git-async-no-revert
-     "push" remote (--map (concat ":" it) remote-tags))))
+    (magit-run-git-async "push" remote (--map (concat ":" it) remote-tags))))
 
 ;;;; Notes
 
@@ -2179,12 +2177,12 @@ of Git's `note' command, default to operate on that ref."
                                     it)))
          current-prefix-arg))
   (if ref
-      (magit-run-git-no-revert "config" (and global "--global") "core.notesRef"
-                               (if (string-prefix-p "refs/" ref)
-                                   ref
-                                 (concat "refs/notes/" ref)))
-    (magit-run-git-no-revert "config" (and global "--global")
-                             "--unset" "core.notesRef")))
+      (magit-run-git "config" (and global "--global") "core.notesRef"
+                     (if (string-prefix-p "refs/" ref)
+                         ref
+                       (concat "refs/notes/" ref)))
+    (magit-run-git "config" (and global "--global")
+                   "--unset" "core.notesRef")))
 
 (defun magit-notes-set-display-refs (refs &optional global)
   "Set notes refs to be display in addition to \"core.notesRef\".
@@ -2208,8 +2206,7 @@ the current repository."
   (magit-git-success "config" "--unset-all" global "notes.displayRef")
   (dolist (ref refs)
     (magit-call-git "config" "--add" global "notes.displayRef" ref))
-  (let ((inhibit-magit-revert t))
-    (magit-refresh)))
+  (magit-refresh))
 
 (defun magit-notes-read-args (prompt)
  (list (magit-read-branch-or-commit prompt)


### PR DESCRIPTION
```
Replace the old magit-specific auto-revert implementation with the
mode `magit-auto-revert-mode', a globalized variant of the built-in
`auto-revert-mode'.  By default Magit still explicitly triggers the
reverts after running git for side-effects.  Automatic reverts are
still enabled by default, and Magit is less verbose about it.  The
behavior can be tuned using `magit-auto-revert-' and `auto-revert-'
options.

The main benefit of this change is that this implementation caches
whether a file is tracked or not.  The old implementation determined
this on every revert cycle, which did not perform well when there
were many open buffers and/or many tracked files.
```