### PR TITLE
Try to limit reverts to buffers for current repository

### DIFF
--- a/Documentation/RelNotes/2.4.2.txt
+++ b/Documentation/RelNotes/2.4.2.txt
@@ -4,6 +4,21 @@ Magit v2.4.2 Release Notes (draft)
 Updates since v2.4.1
 --------------------
 
+* Added new option `auto-revert-buffer-list-filter' and redefined
+  `auto-revert-buffers' from `autorevert.el' to use it.  Added new
+  predicates `magit-auto-revert-buffer-p' and the more restrictive
+  `magit-auto-revert-repository-buffer-p', which are both intended
+  to be used as potential value of the option.
+
+  For now the option defaults to `nil', but that might change in a
+  future release.  When Magit explicitly calls `auto-revert-buffers'
+  (as opposed to when that is called due to a file notification event
+  or by a timer), and `auto-revert-buffer-list-filter' is `nil', then
+  it is let-bound to `magit-auto-revert-repository-buffer-p'.
+
+  Users who use Tramp and experience delays, should consider setting
+  the option to `magit-auto-revert-repository-buffer-p'.
+
 * The heading of the section which lists commits that exist in the
   current branch but not in its upstream was changed from "Unpushed
   to <upstream>" to "Unmerged into <upstream>", because one usually

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -781,6 +781,27 @@ the visiting buffer before you could continue making changes.
   This option controls for how many seconds Emacs waits before
   resuming suspended reverts.
 
+- User Option: auto-revert-buffer-list-filter
+
+  This option specifies an additional filter used by
+  ~auto-revert-buffers~ to determine whether a buffer should be reverted
+  or not.
+
+  This option is provided by ~magit~, which also redefines
+  ~auto-revert-buffers~ to respect it.  Magit users who do not turn on
+  the local mode ~auto-revert-mode~ themselves, are best served by
+  setting the value to ~magit-auto-revert-repository-buffers-p~.
+
+  However the default is nil, to not disturb users who do use the
+  local mode directly.  If you experience delays when running Magit
+  commands, then you should consider using one of the predicates
+  provided by Magit - especially if you also use Tramp.
+
+  Users who do turn on ~auto-revert-mode~ in buffers in which Magit
+  doesn't do that for them, should likely not use any filter.  Users
+  who turn on ~global-auto-revert-mode~, do not have to worry about this
+  option, because it is disregarded if the global mode is enabled.
+
 - User Option: auto-revert-verbose
 
   This option controls whether Emacs reports when a buffer has been
@@ -4675,6 +4696,22 @@ anything to ~magit-refresh-buffer-hook~, ~magit-status-refresh-hook~,
 check whether those additions impacts performance significantly.
 Setting ~magit-refresh-verbose~ and then inspecting the output in the
 ~*Messages*~ buffer, should help doing so.
+
+Magit also reverts buffers which visit files located inside the
+current repository, when the visited file changes on disk.  That is
+implemented on top of ~auto-revert-mode~ from the built-in library
+~autorevert~.  To figure out whether that impacts performance, check
+whether performance is significantly worse, when many buffers exist
+and/or when some buffers visit files using Tramp.  If so, then this
+should help.
+
+#+BEGIN_SRC emacs-lisp
+  (setq auto-revert-buffer-list-filter
+        'magit-auto-revert-repository-buffers-p)
+#+END_SRC
+
+For alternative approaches see [[*Automatic Reverting of File-Visiting
+Buffers]].
 
 If you have enabled any features that are disabled by default, then
 you should check whether they impact performance significantly.  It's

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -1105,6 +1105,28 @@ This option controls for how many seconds Emacs waits before
 resuming suspended reverts.
 @end defopt
 
+@defopt auto-revert-buffer-list-filter
+
+This option specifies an additional filter used by
+@code{auto-revert-buffers} to determine whether a buffer should be reverted
+or not.
+
+This option is provided by @code{magit}, which also redefines
+@code{auto-revert-buffers} to respect it.  Magit users who do not turn on
+the local mode @code{auto-revert-mode} themselves, are best served by
+setting the value to @code{magit-auto-revert-repository-buffers-p}.
+
+However the default is nil, to not disturb users who do use the
+local mode directly.  If you experience delays when running Magit
+commands, then you should consider using one of the predicates
+provided by Magit - especially if you also use Tramp.
+
+Users who do turn on @code{auto-revert-mode} in buffers in which Magit
+doesn't do that for them, should likely not use any filter.  Users
+who turn on @code{global-auto-revert-mode}, do not have to worry about this
+option, because it is disregarded if the global mode is enabled.
+@end defopt
+
 @defopt auto-revert-verbose
 
 This option controls whether Emacs reports when a buffer has been
@@ -6517,6 +6539,21 @@ anything to @code{magit-refresh-buffer-hook}, @code{magit-status-refresh-hook},
 check whether those additions impacts performance significantly.
 Setting @code{magit-refresh-verbose} and then inspecting the output in the
 @code{*Messages*} buffer, should help doing so.
+
+Magit also reverts buffers which visit files located inside the
+current repository, when the visited file changes on disk.  That is
+implemented on top of @code{auto-revert-mode} from the built-in library
+@code{autorevert}.  To figure out whether that impacts performance, check
+whether performance is significantly worse, when many buffers exist
+and/or when some buffers visit files using Tramp.  If so, then this
+should help.
+
+@lisp
+(setq auto-revert-buffer-list-filter
+      'magit-auto-revert-repository-buffers-p)
+@end lisp
+
+For alternative approaches see @ref{Automatic Reverting of File-Visiting Buffers,Automatic Reverting of File-Visiting Buffers}.
 
 If you have enabled any features that are disabled by default, then
 you should check whether they impact performance significantly.  It's

--- a/lisp/magit-autorevert.el
+++ b/lisp/magit-autorevert.el
@@ -208,7 +208,8 @@ the timer when no buffers need to be checked."
 		  (delq buf auto-revert-buffer-list)))))
       (setq auto-revert-remaining-buffers bufs)
       ;; Check if we should cancel the timer.
-      (when (and (not global-auto-revert-mode)
+      (when (and auto-revert-timer
+                 (not global-auto-revert-mode)
 		 (null auto-revert-buffer-list))
 	(cancel-timer auto-revert-timer)
 	(setq auto-revert-timer nil)))))

--- a/lisp/magit-autorevert.el
+++ b/lisp/magit-autorevert.el
@@ -179,34 +179,24 @@ Auto-Revert mode from `auto-revert-buffer-list', and for canceling
 the timer when no buffers need to be checked."
   (cl-incf auto-revert-buffers-counter)
   (save-match-data
-    (let ((bufs (if global-auto-revert-mode
-		    (buffer-list)
-		  auto-revert-buffer-list))
-	  remaining new)
-      ;; Partition `bufs' into two halves depending on whether or not
-      ;; the buffers are in `auto-revert-remaining-buffers'.  The two
-      ;; halves are then re-joined with the "remaining" buffers at the
-      ;; head of the list.
-      (dolist (buf auto-revert-remaining-buffers)
-	(if (memq buf bufs)
-	    (push buf remaining)))
-      (dolist (buf bufs)
-	(if (not (memq buf remaining))
-	    (push buf new)))
-      (setq bufs (nreverse (nconc new remaining)))
+    (let ((bufs (nconc auto-revert-remaining-buffers
+                       (--filter (not (memq it auto-revert-remaining-buffers))
+                                 (if global-auto-revert-mode
+                                     (buffer-list)
+                                   auto-revert-buffer-list)))))
       (while (and bufs
 		  (not (and auto-revert-stop-on-user-input
 			    (input-pending-p))))
-	(let ((buf (car bufs)))
+	(let ((buf (pop bufs)))
           (if (buffer-live-p buf)
 	      (with-current-buffer buf
 		;; Test if someone has turned off Auto-Revert Mode in a
 		;; non-standard way, for example by changing major mode.
-		(if (and (not auto-revert-mode)
-			 (not auto-revert-tail-mode)
-			 (memq buf auto-revert-buffer-list))
-		    (setq auto-revert-buffer-list
-			  (delq buf auto-revert-buffer-list)))
+		(when (and (not auto-revert-mode)
+                           (not auto-revert-tail-mode)
+                           (memq buf auto-revert-buffer-list))
+                  (setq auto-revert-buffer-list
+                        (delq buf auto-revert-buffer-list)))
 		(when (auto-revert-active-p)
 		  ;; Enable file notification.
 		  (when (and auto-revert-use-notify buffer-file-name
@@ -215,8 +205,7 @@ the timer when no buffers need to be checked."
 		  (auto-revert-handler)))
 	    ;; Remove dead buffer from `auto-revert-buffer-list'.
 	    (setq auto-revert-buffer-list
-		  (delq buf auto-revert-buffer-list))))
-	(setq bufs (cdr bufs)))
+		  (delq buf auto-revert-buffer-list)))))
       (setq auto-revert-remaining-buffers bufs)
       ;; Check if we should cancel the timer.
       (when (and (not global-auto-revert-mode)

--- a/lisp/magit-autorevert.el
+++ b/lisp/magit-autorevert.el
@@ -150,6 +150,10 @@ This function calls the hook `magit-auto-revert-mode-hook'.")
                  (and magit-auto-revert-mode auto-revert-buffer-list)))
     (auto-revert-buffers)))
 
+(when (version< emacs-version "25")
+  (defvar auto-revert-buffers-counter 1
+    "Incremented each time `auto-revert-buffers' is called"))
+
 (defun auto-revert-buffers ()
   "Revert buffers as specified by Auto-Revert and Global Auto-Revert Mode.
 
@@ -173,6 +177,7 @@ are checked first the next time this function is called.
 This function is also responsible for removing buffers no longer in
 Auto-Revert mode from `auto-revert-buffer-list', and for canceling
 the timer when no buffers need to be checked."
+  (cl-incf auto-revert-buffers-counter)
   (save-match-data
     (let ((bufs (if global-auto-revert-mode
 		    (buffer-list)

--- a/lisp/magit-autorevert.el
+++ b/lisp/magit-autorevert.el
@@ -1,4 +1,4 @@
-;;; magit-autorevert.el --- revert buffers when files in Git repositories change  -*- lexical-binding: t -*-
+;;; magit-autorevert.el --- revert buffers when files in repository change  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2010-2016  The Magit Project Contributors
 ;;
@@ -30,10 +30,15 @@
 
 (require 'autorevert)
 
+(defgroup magit-auto-revert nil
+  "Revert buffers when files in repository change."
+  :group 'auto-revert
+  :group 'magit-extensions)
+
 (defcustom magit-auto-revert-tracked-only t
   "Whether `magit-auto-revert-mode' only reverts tracked files."
   :package-version '(magit . "2.4.0")
-  :group 'magit
+  :group 'magit-auto-revert
   :type 'boolean
   :set (lambda (var val)
          (set var val)
@@ -59,7 +64,7 @@ If `magit-auto-revert-immediately' and `auto-revert-use-notify'
 are both nil, then reverts happen after `auto-revert-interval'
 seconds of user inactivity.  That is not desirable."
   :package-version '(magit . "2.4.0")
-  :group 'magit
+  :group 'magit-auto-revert
   :type 'boolean)
 
 (defun magit-turn-on-auto-revert-mode-if-desired (&optional file)
@@ -84,6 +89,7 @@ seconds of user inactivity.  That is not desirable."
   magit-turn-on-auto-revert-mode-if-desired
   :package-version '(magit . "2.4.0")
   :group 'magit
+  :group 'magit-auto-revert
   ;; When `global-auto-revert-mode' is enabled, then this mode is
   ;; redundant.  When `magit-revert-buffers' is nil, then the user has
   ;; opted out of the automatic reverts while the old implementation
@@ -132,6 +138,9 @@ notices that.
 
 Unlike `global-auto-revert-mode', this mode never reverts any
 buffers that are not visiting files.
+
+The behavior of this mode can be customized using the options
+in the `autorevert' and `magit-autorevert' groups.
 
 This function calls the hook `magit-auto-revert-mode-hook'.")
 


### PR DESCRIPTION
```
Add new option `auto-revert-buffer-list-filter' and redefine
`auto-revert-buffers' from `autorevert.el' to use it.  Add new
predicates `magit-auto-revert-buffer-p' and the more restrictive
`magit-auto-revert-buffer-p', which are both intended to be used as
potential value of the option.

For now the option defaults to `nil', but that might change in a future
release.  When Magit explicitly calls `auto-revert-buffers' (as opposed
to when that is called due to a file notification event or by a timer),
and `auto-revert-buffer-list-filter' is `nil', then it is let-bound to
`magit-auto-revert-repository-buffer-p'.

Users who use Tramp and experience delays, should consider setting
the option to `magit-auto-revert-repository-buffer-p'.
```