### PR TITLE
Don't busy wait for subprocesses

### DIFF
--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -145,10 +145,10 @@ With a prefix argument and if necessary, attempt a 3-way merge."
       (magit-wip-commit-before-change files (concat " before " command)))
     (with-temp-buffer
       (insert patch)
-      (magit-run-git-with-input nil
-        "apply" args "-p0"
-        (unless (magit-diff-context-p) "--unidiff-zero")
-        "--ignore-space-change" "-"))
+      (magit-run-git-with-input
+       "apply" args "-p0"
+       (unless (magit-diff-context-p) "--unidiff-zero")
+       "--ignore-space-change" "-"))
     (unless inhibit-magit-refresh
       (when magit-wip-after-apply-mode
         (magit-wip-commit-after-apply files (concat " after " command)))

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -126,11 +126,8 @@ bisect run'."
   (unless (or no-assert (magit-bisect-in-progress-p))
     (user-error "Not bisecting"))
   (magit-with-toplevel
-    (let ((file (magit-git-dir "BISECT_CMD_OUTPUT")))
-      (ignore-errors (delete-file file))
-      (magit-run-git-with-logfile file "bisect" subcommand args))
-    (magit-process-wait)
-    (magit-refresh)))
+    (magit-run-git-with-logfile
+     (magit-git-dir "BISECT_CMD_OUTPUT") "bisect" subcommand args)))
 
 (defun magit-bisect-in-progress-p ()
   (file-exists-p (magit-git-dir "BISECT_LOG")))

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -344,12 +344,9 @@ waits for that process to return."
 
 (defun magit-run-git-with-logfile (file &rest args)
   "Call Git in a separate process and log its output to FILE.
-See `magit-run-git' for more information.
 This function might have a short halflive."
-  (magit-start-git nil args)
-  (process-put magit-this-process 'logfile file)
-  (set-process-filter magit-this-process 'magit-process-logfile-filter)
-  (magit-process-wait)
+  (apply #'magit-process-file magit-git-executable nil `(:file ,file) nil
+         (magit-process-git-arguments args))
   (magit-refresh))
 
 ;;; Asynchronous Processes
@@ -596,17 +593,6 @@ Magit status buffer."
           (delete-region (line-beginning-position) (point))
           (insert (substring string (1+ ret-pos)))))
       (set-marker (process-mark proc) (point)))))
-
-(defun magit-process-logfile-filter (process string)
-  "Special filter used by `magit-run-git-with-logfile'."
-  (magit-process-filter process string)
-  (let ((file (process-get process 'logfile)))
-    (with-temp-file file
-      (when (file-exists-p file)
-        (insert-file-contents file)
-        (goto-char (point-max)))
-      (insert string)
-      (write-region (point-min) (point-max) file))))
 
 (defmacro magit-process-kill-on-abort (proc &rest body)
   (declare (indent 1) (debug (form body)))

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -222,10 +222,10 @@ When the region is active offer to drop all contained stashes."
         (if (eq keep 'worktree)
             (with-temp-buffer
               (magit-git-insert "diff" "--cached")
-              (magit-run-git-with-input nil
-                "apply" "--reverse" "--cached" "--ignore-space-change" "-")
-              (magit-run-git-with-input nil
-                "apply" "--reverse" "--ignore-space-change" "-"))
+              (magit-run-git-with-input
+               "apply" "--reverse" "--cached" "--ignore-space-change" "-")
+              (magit-run-git-with-input
+               "apply" "--reverse" "--ignore-space-change" "-"))
           (unless (eq keep t)
             (if (eq keep 'index)
                 (magit-call-git "checkout" "--" ".")


### PR DESCRIPTION
Re: https://github.com/magit/magit/issues/2454#issuecomment-171090747

We can send input to synchronous subprocesses with `call-process-region`, but there is no file-handler equivalent (like `process-file` for `call-process`), so this may have problems when using magit over tramp.