### PR TITLE
log: add ++order pseudo option

### DIFF
--- a/Documentation/RelNotes/2.4.2.txt
+++ b/Documentation/RelNotes/2.4.2.txt
@@ -52,6 +52,12 @@ Updates since v2.4.1
 * Added the switch `--cover-letter' to `magit-patch-popup', and taught
   `magit-format-patch' to immediately open the letter in a buffer.
 
+* Added new option `++order' to the various log popups.  This option
+  and its value is converted to `--VALUE-order' before calling `git'.
+  This option was added instead of the switches `--author-date-order',
+  `--date-order', and `--topo-order' because adding all three would be
+  to noisy and because they are mutually exclusive.
+
 Fixes since v2.4.1
 ------------------
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1694,6 +1694,8 @@ invoked while no log buffer exists for the current repository yet,
 then the default value of ~magit-log-arguments~ is used instead.
 
 For information about the various arguments, see [[info:gitman#git-log]].
+The switch ~++order=VALUE~ is converted to one of ~--author-date-order~,
+~--date-order~, or ~--topo-order~ before being passed to ~git log~.
 
 The log popup also features several reflog commands.  See [[*Reflog]].
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -2258,6 +2258,8 @@ the <a href="http://git-scm.com/docs/git-log">git-log(1)</a> manpage
 the git-log(1) manpage
 @end iftex
 .
+The switch @code{++order=VALUE} is converted to one of @code{--author-date-order},
+@code{--date-order}, or @code{--topo-order} before being passed to @code{git log}.
 
 The log popup also features several reflog commands.  See @ref{Reflog,Reflog}.
 


### PR DESCRIPTION
```
Before `git log' is called, `++order=TYPE' is converted to
`--TYPE-order', one of `--topo-order', `--date-order', and
`--author-date-order'.  We do that instead of adding the
individual arguments to the popup because they are mutually
exclusive.
```