### PR TITLE
Replace setenv with push on process-environment

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -166,7 +166,7 @@ to inverse the meaning of the prefix argument.  \n(git commit
   (when (setq args (magit-commit-assert args (not override-date)))
     (let ((process-environment process-environment))
       (unless override-date
-        (setenv "GIT_COMMITTER_DATE" (magit-rev-format "%cD")))
+        (push (magit-rev-format "GIT_COMMITTER_DATE=%cD") process-environment))
       (magit-run-git-with-editor "commit" "--amend" "--no-edit" args))))
 
 ;;;###autoload
@@ -186,7 +186,7 @@ and ignore the option.
                        magit-commit-reword-override-date)))
   (let ((process-environment process-environment))
     (unless override-date
-      (setenv "GIT_COMMITTER_DATE" (magit-rev-format "%cD")))
+      (push (magit-rev-format "GIT_COMMITTER_DATE=%cD") process-environment))
     (magit-run-git-with-editor "commit" "--amend" "--only" args)))
 
 ;;;###autoload

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1139,11 +1139,12 @@ Return a list of two integers: (A>B B>A)."
                         (error "Cannot read tree %s" it)))
                   (if (file-remote-p default-directory)
                       (let ((magit-tramp-process-environment
-                             (setenv-internal magit-tramp-process-environment
-                                              "GIT_INDEX_FILE" ,file t)))
+                             (cons (concat "GIT_INDEX_FILE=" ,file)
+                                   magit-tramp-process-environment)))
                         ,@body)
-                    (let ((process-environment process-environment))
-                      (setenv "GIT_INDEX_FILE" ,file)
+                    (let ((process-environment
+                           (cons (concat "GIT_INDEX_FILE=" ,file)
+                                 process-environment)))
                       ,@body)))
          (ignore-errors
            (delete-file (concat (file-remote-p default-directory) ,file)))))))

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -400,7 +400,7 @@ START has to be selected from a list of recent commits."
   (if commit
       (let ((process-environment process-environment))
         (when editor
-          (setenv "GIT_SEQUENCE_EDITOR" editor))
+          (push (concat "GIT_SEQUENCE_EDITOR=" editor) process-environment))
         (magit-run-git-sequencer "rebase" "-i" args
                                  (unless (member "--root" args) commit)))
     (magit-log-select


### PR DESCRIPTION
Let-binding process-environment does not nessarily protect from changes
made by setenv, because setenv may destructively modify the list object.

See https://github.com/magit/magit/issues/2246#issuecomment-139842749 until https://github.com/magit/magit/issues/2246#issuecomment-139882266

---

Unfortunately, I forgot about this until after `with-editor` was split from the magit repo, so the fix is split over the repos now, see magit/with-editor#3.