### PR TITLE
Fixed magit-current-file for magit-log-mode

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -629,7 +629,7 @@ Sorted from longest to shortest CYGWIN name."
   (or (magit-file-relative-name)
       (magit-file-at-point)
       (and (derived-mode-p 'magit-log-mode)
-           (nth 3 magit-refresh-args))))
+           (car (nth 2 magit-refresh-args)))))
 
 ;;; Predicates
 


### PR DESCRIPTION
The structure of magit-refresh-args has apparently changed.