### PR TITLE
Allow falling back from Ido to regular completion

### DIFF
--- a/Documentation/RelNotes/2.5.1.txt
+++ b/Documentation/RelNotes/2.5.1.txt
@@ -20,6 +20,9 @@ Updates since v2.5.0
 * Added new command `magit-reset-popup' featuring all the available
   reset variants.
 
+* When using Ido completion, then it's now possible to fall back to
+  regular completion using `C-x C-f' or `C-x C-b' if necessary.
+
 * When washing the diff that is to be displayed while writing a
   commit message takes too long, then it is now possible to abort that
   by pressing `C-g'.  Previously that would have aborted the commit.

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -718,8 +718,10 @@ like pretty much every other keymap:
   (define-key ido-common-completion-map
     (kbd \"C-x g\") 'ido-enter-magit-status)"
   (interactive)
-  (with-no-warnings ; FIXME these are internal variables
-    (setq ido-exit 'fallback fallback 'magit-status))
+  (with-no-warnings
+    ;; There is no public interface to do this.
+    (setq ido-exit 'fallback)
+    (setq fallback 'magit-status))
   (exit-minibuffer))
 
 (defun magit-status-maybe-update-revision-buffer (&optional _)


### PR DESCRIPTION
It has annoyed me for a long time that it was not possible to fall back from Ido completion to regular completion (except when using the file and buffer completion functions defined in `ido` itself).  In the case of Magit that meant that in some cases it was not possible to enter a value which was not among the completion candidates.

I've fixed that for Magit now. The implementation is quite a hack and seems to work reliably. It's also inspired by (and uses) code in `ido`, so it appears that's how this is done. I have also checked whether `ido-ubiquitous` provides a generalized variant of this but couldn't find anything.

@DarwinAwardWinner Did I overlook something? What do you think about this approach? And if you think this is the way to go, would you be willing to add a generalized variant of this to `ido-ubiquitous`?