### PR TITLE
magit-diff-wash-submodule: rewrite from scratch

### DIFF
--- a/Documentation/RelNotes/2.5.1.txt
+++ b/Documentation/RelNotes/2.5.1.txt
@@ -54,6 +54,8 @@ Fixes since v2.5.0
 * `magit-clone' did not switch to the cloned repo before trying to
   delete the symbolic-ref "origin/HEAD".
 
+* `magit-diff-wash-submodule did not handle some less common cases.
+
 * `magit-merge-preview' did not recognize sections for added or
   deleted files.
 


### PR DESCRIPTION
```
The old implementation was a hack, which got extended when I got myself
into a situation where the current version failed (seriously, is nobody
else using submodules?).  This time it was "(not checked out)" which was
not handled.  Upon inspecting `show_submodule_summary' in `submodules.c'
it turned out that "(revision walker failed)" also wasn't handled, and
why there sometimes is a trailing colon and sometimes not (there's a
colon when commits follow, so the colon cases should be handled
separately even though that leads to a bit of duplication).

At present these are the lines we have to look for.

    Submodule <module> contains untracked content
    Submodule <module> contains modified content
    Submodule <module> a...b:
    Submodule <module> a...b (rewind):
    Submodule <module> a...b (submodule deleted)
    Submodule <module> a...b (not checked out)
    Submodule <module> a...b (new submodule)
    Submodule <module> a...b (commits not present)
    Submodule <module> a...b (revision walker failed)

This commit also changes how some of these variants are represented in
Magit.  Previously some information was lost in some cases.

The new implementation is longer than the old, but that's a good thing
because it's now possible to figure out what it does by looking at it.

Ps: Seems I am getting back in the mood for writing long messages. ;-)
```

But I haven't really gotten around to testing. We should probably even write automated tests for this.