### PR TITLE
magit-section-cycle-diffs: fix hanging when hiding

### DIFF
--- a/Documentation/RelNotes/2.6.0.txt
+++ b/Documentation/RelNotes/2.6.0.txt
@@ -92,6 +92,8 @@ Fixes since v2.5.0
 
 * Invoking `magit-commit-popup's default action failed due to a typo.
 
+* `magit-section-cycle-diffs' hung when hiding sections.
+
 This release also contains documentation updates.
 
 Authors

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -436,7 +436,7 @@ hidden."
         (dolist (s sections)
           (magit-section-show s)
           (magit-section-hide-children s))
-      (let ((children (cl-mapcan 'magit-section-children sections)))
+      (let ((children (-mapcat 'magit-section-children sections)))
         (cond ((and (-any? 'magit-section-hidden   children)
                     (-any? 'magit-section-children children))
                (mapc 'magit-section-show-headings sections))


### PR DESCRIPTION
Replace cl-mapcan, which uses nconc, with -mapcat, which uses append, to
avoid modifying section children.

Fixes #2579.