### PR TITLE
magit-apply: add literal CR chars if necessary

### DIFF
--- a/Documentation/RelNotes/2.6.0.txt
+++ b/Documentation/RelNotes/2.6.0.txt
@@ -94,6 +94,13 @@ Fixes since v2.5.0
 
 * `magit-section-cycle-diffs' hung when hiding sections.
 
+* Staging hunks/regions belonging to files with CRLF line endings on
+  Windows (or, to be precise, when the Magit status buffer uses CRLF
+  end-of-line style) ended up erroneously staging changes with LF line
+  endings. Magit now tries harder to not mangle line endings. A new
+  variable `magit-preserve-crlf-line-endings' has been added to allow
+  disabling the new behavior, should it cause unforseen troubles.
+
 This release also contains documentation updates.
 
 Authors

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -67,6 +67,38 @@ information see command `magit-reverse-in-index'."
   :group 'magit-commands
   :type 'boolean)
 
+(defcustom magit-preserve-crlf-line-endings t
+  "Whether to try harder to preserve CRLF line endings.
+
+Magit buffers may contain diffs for more than one file and these
+files might use different line ending types, but Emacs normalizes
+file endings in a buffer to a single newline character. When the
+diffs have been constructing using a `process-coding-system' with
+LF line endings no information is lost: each sequence of CR and
+LF bytes in a diff is converted into a sequence of ?\r and ?\n
+characters; but, when `process-coding-system' has CRLF line
+endings, each CRLF sequence in the diff is converted into a
+single ?\n character. Because both LF and CRLF sequences are
+normalized into a single ?\n character, ambiguity ensues.
+
+This isn't an issue when staging (or otherwise applying) complete
+files, because the buffer contents are not used in that case.
+But when applying hunks, then a patch has to be built from parts
+of the buffer contents.
+
+If this option is non-nil (the default), then Magit peeks the
+file that is being changed to determine whether its line ending
+style is CRLF.  If so, then CR characters are inserted into the
+patch that is being sent to git.
+
+Only Windows users are likely to be affected by this variable.
+
+Also see the Git variables `core.eol', `core.safecrlf', and
+`core.autocrlf' for an alternative approach."
+  :package-version '(magit . "2.6.0")
+  :group 'magit
+  :type 'boolean)
+
 ;;; Commands
 ;;;; Apply
 
@@ -86,9 +118,25 @@ With a prefix argument and if necessary, attempt a 3-way merge."
       (`(,_   file) (magit-apply-diff   it args))
       (`(,_  files) (magit-apply-diffs  it args)))))
 
+(defun magit-apply--maybe-fix-up-eols (section string)
+  (if (and magit-preserve-crlf-line-endings
+           ;; diff was read using CRLF eol type
+           (eql 1 (coding-system-eol-type (car default-process-coding-system)))
+           ;; file has CRLF eol type, too
+           (with-temp-buffer
+             (insert-file-contents-literally (magit-section-value section)
+                                             nil 0 500)
+             (search-forward "\r" nil t)))
+      (replace-regexp-in-string "\n" "\r\n" string)
+      string))
+
 (defun magit-apply--section-content (section)
-  (buffer-substring-no-properties (magit-section-start section)
-                                  (magit-section-end section)))
+  (magit-apply--maybe-fix-up-eols
+   (pcase (magit-section-type section)
+     ('file section)
+     ('hunk (magit-section-parent section)))
+   (buffer-substring-no-properties (magit-section-start section)
+                                   (magit-section-end section))))
 
 (defun magit-apply-diffs (sections &rest args)
   (setq sections (magit-apply--get-diffs sections))
@@ -126,9 +174,11 @@ With a prefix argument and if necessary, attempt a 3-way merge."
     (user-error "Not enough context to apply region.  Increase the context"))
   (when (string-match "^diff --cc" (magit-section-parent-value section))
     (user-error "Cannot un-/stage resolution hunks.  Stage the whole file"))
-  (magit-apply-patch (magit-section-parent section) args
-                     (concat (magit-diff-file-header section)
-                             (magit-diff-hunk-region-patch section args))))
+  (let ((parent (magit-section-parent section))
+        (patch (magit-diff-hunk-region-patch section args)))
+    (magit-apply-patch parent args
+                       (concat (magit-diff-file-header section)
+                               (magit-apply--maybe-fix-up-eols parent patch)))))
 
 (defun magit-apply-patch (section:s args patch)
   (let* ((files (if (atom section:s)

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -87,8 +87,8 @@ With a prefix argument and if necessary, attempt a 3-way merge."
       (`(,_  files) (magit-apply-diffs  it args)))))
 
 (defun magit-apply--section-content (section)
-  (buffer-substring (magit-section-start section)
-                    (magit-section-end section)))
+  (buffer-substring-no-properties (magit-section-start section)
+                                  (magit-section-end section)))
 
 (defun magit-apply-diffs (sections &rest args)
   (setq sections (magit-apply--get-diffs sections))

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -405,6 +405,14 @@ Unless optional argument KEEP-EMPTY-LINES is t, trim all empty lines."
       (insert-file-contents file)
       (split-string (buffer-string) "\n" (not keep-empty-lines)))))
 
+(defun magit--buffer-has-crlf-eol-style-p ()
+  (eql 1 (coding-system-eol-type buffer-file-coding-system)))
+
+(defun magit--file-has-crlf-eol-style-p (file)
+  (with-temp-buffer
+    (insert-file-contents-literally file nil 0 500)
+    (search-forward "\r" nil t)))
+
 ;;; magit-utils.el ends soon
 (provide 'magit-utils)
 ;; Local Variables:


### PR DESCRIPTION
A tentative fix for #2401, #2403 and #2583.