### PR TITLE
Another approach at solving issues #2401, #2403 and #2583

### DIFF
--- a/Documentation/RelNotes/2.6.0.txt
+++ b/Documentation/RelNotes/2.6.0.txt
@@ -101,6 +101,14 @@ Fixes since v2.5.0
 * `magit-show-stash' did not properly handle untracked files that were
   within subdirectories.
 
+* Staging hunks/regions belonging to files with CRLF line endings on
+  Windows (or, to be precise, when `default-process-coding-system' had
+  CRLF end-of-line conversion) ended up erroneously staging changes
+  with LF line endings. Magit now ensures line endings are preserved
+  by enforcing a `process-coding-system' with LF end-of-line
+  conversion. The new behavior may be disabled by setting
+  `magit-process-ensure-unix-coding-system' to nil.
+
 This release also contains documentation updates.
 
 Authors

--- a/Documentation/RelNotes/2.6.0.txt
+++ b/Documentation/RelNotes/2.6.0.txt
@@ -63,6 +63,10 @@ Updates since v2.5.0
   useful when using Magit as a library in another packages that runs
   git in many different repositories.
 
+* Added new variable `magit-diff-hide-trailing-cr-characters'. When it
+  is non-nil (the default on Windows), ^M characters at the end of
+  diff lines are hidden.
+
 Fixes since v2.5.0
 ------------------
 

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -87,8 +87,8 @@ With a prefix argument and if necessary, attempt a 3-way merge."
       (`(,_  files) (magit-apply-diffs  it args)))))
 
 (defun magit-apply--section-content (section)
-  (buffer-substring (magit-section-start section)
-                    (magit-section-end section)))
+  (buffer-substring-no-properties (magit-section-start section)
+                                  (magit-section-end section)))
 
 (defun magit-apply-diffs (sections &rest args)
   (setq sections (magit-apply--get-diffs sections))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -164,6 +164,13 @@ many spaces.  Otherwise, highlight neither."
                                (integer :tag "Spaces" :value ,tab-width)
                                (const :tag "Neither" nil)))))
 
+(defcustom magit-diff-hide-trailing-cr-characters
+  (and (memq system-type '(ms-dos windows-nt)) t)
+  "Whether to hide ^M characters at the end of a line in diffs."
+  :package-version '(magit . "2.6.0")
+  :group 'magit-diff
+  :type 'boolean)
+
 ;;;; Revision Mode
 
 (defgroup magit-revision nil
@@ -1940,6 +1947,10 @@ are highlighted."
               (stage nil))
           (forward-line)
           (while (< (point) end)
+            (when (and magit-diff-hide-trailing-cr-characters
+                       (char-equal ?\r (char-before (line-end-position))))
+              (put-text-property (1- (line-end-position)) (line-end-position)
+                                 'invisible t))
             (put-text-property
              (point) (1+ (line-end-position)) 'face
              (cond


### PR DESCRIPTION
As discussed in pull request #2584, here's another approach:

  1. Diffs are always read using LF eol style to ensure CR bytes are not lost.
  2. When appropriate, CR characters (aka ^M) are hidden.  This is similar to what git does with `git config core.whitespace cr-at-eol`.

This approach seems to be more robust and removes the need for peeking files to guess end-of-line styles. However, it touches `magit-process-file` which makes me uncomfortable because (a) lots of functionality go through there and (b) git seems to be invoked through other means as well.