### PR TITLE
magit-read-{remote,upstream}-branch: remove duplicate choices

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1265,12 +1265,12 @@ Return a list of two integers: (A>B B>A)."
     (prompt &optional remote default local-branch require-match)
   (let ((choice (magit-completing-read
                  prompt
-                 (nconc (and local-branch
-                             (if remote
-                                 (concat remote "/" local-branch)
-                               (--map (concat it "/" local-branch)
-                                      (magit-list-remotes))))
-                        (magit-list-remote-branch-names remote t))
+                 (-union (and local-branch
+                              (if remote
+                                  (concat remote "/" local-branch)
+                                (--map (concat it "/" local-branch)
+                                       (magit-list-remotes))))
+                         (magit-list-remote-branch-names remote t))
                  nil require-match nil 'magit-revision-history default)))
     (if (or remote (string-match "\\`\\([^/]+\\)/\\(.+\\)" choice))
         choice
@@ -1336,9 +1336,9 @@ Return a list of two integers: (A>B B>A)."
     (&optional (branch (magit-get-current-branch)) prompt)
   (magit-completing-read
    (or prompt (format "Change upstream of %s to" branch))
-   (nconc (--map (concat it "/" branch)
-                 (magit-list-remotes))
-          (delete branch (magit-list-branch-names)))
+   (-union (--map (concat it "/" branch)
+                  (magit-list-remotes))
+           (delete branch (magit-list-branch-names)))
    nil nil nil 'magit-revision-history
    (or (let ((r (magit-remote-branch-at-point))
              (l (magit-branch-at-point)))


### PR DESCRIPTION
In both cases, the collection to choose from is created from an
argument (local branch) turned into a remote ref, plus a list of all
remote or all branches.  The latter part can already contain the refs
constructed in the former, leading to duplicates.

Since we use dash anyway and the order in the collection is irrelevant,
replacing nconc by -union should get rid of these duplicates.