### PR TITLE
magit-branch-config-popup: new popup 

### DIFF
--- a/Documentation/RelNotes/2.7.0.txt
+++ b/Documentation/RelNotes/2.7.0.txt
@@ -6,6 +6,18 @@ Changes since v2.6.2
 
 * Added new popup `magit-subtree-popup' and bound "O" to it.
 
+* Added new popup `magit-branch-config-popup' and made it available
+  from the popups `magit-branch-popup', `magit-pull-and-fetch-popup',
+  `magit-pull-popup', `magit-fetch-popup', and `magit-push-popup'.
+
+  With a prefix argument it reads a the branch to be configured in
+  the minibuffer instead of using the current branch.
+
+* Added new option `magit-branch-popup-show-variables', defaulting to
+  t to avoid changing key bindings.  When set to nil, no variables are
+  displayed directly in the `magit-branch-popup', instead the subpopup
+  `magit-branch-config-popup' has to be used.
+
 * Added new commands `magit-worktree-checkout',
   `magit-worktree-branch', `magit-worktree-delete',
   and `magit-worktree-status'.

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3106,6 +3106,8 @@ To show no diff while committing remove ~magit-commit-diff~ from
 
 ** Branching
 
+*** The two remotes
+
 The upstream branch of some local branch is the branch into which the
 commits on that local branch should eventually be merged, usually
 something like ~origin/master~.  For the ~master~ branch itself the
@@ -3142,18 +3144,168 @@ unpushed and unpulled for both the push-remote and the upstream.
 It's fairly simple to configure these two remotes.  The values of all
 the variables that are related to fetching, pulling, and pushing (as
 well as some other branch-related variables) can be inspected and
-changed in the branching popup.  It is also possible to set the
-push-remote and/or upstream while pushing (see [[*Pushing]]).
+changed using the popup ~magit-branch-config-popup~, which is a
+sub-popup of many popups that deal with branches.  It is also possible
+to set the push-remote and/or upstream while pushing (see [[*Pushing]]).
+
+*** The branch popup
+
+The popup ~magit-branch-popup~ is used to create and checkout branches,
+and to make changes to existing branches.  It is not used to fetch,
+pull, merge, rebase, or push branches, i.e. this popup deals with
+branches themselves, not with the commits reachable from them.  Those
+features are available from separate popups.
 
 - Key: b, magit-branch-popup
 
   This prefix command shows the following suffix commands in a popup
-  buffer.  It also displays the values of the following variables and
-  allows changing their values.
+  buffer.
+
+  By default it also displays the values of some branch-related Git
+  variables and allows changing their values, just like the
+  specialized ~magit-branch-config-popup~ does.
+
+- User Option: magit-branch-popup-show-variables
+
+  Whether the ~magit-branch-popup~ shows Git variables.  This defaults
+  to t to avoid changing key bindings.  When set to nil, no variables
+  are displayed directly in this popup, and the sub-popup
+  ~magit-branch-config-popup~ has to be used indead to view and change
+  branch related variables.
+
+- Key: b b, magit-checkout
+
+  Checkout a revision read in the minibuffer and defaulting to the
+  branch or arbitrary revision at point.  If the revision is a local
+  branch then that becomes the current branch.  If it is something
+  else then ~HEAD~ becomes detached.  Checkout fails if the working tree
+  or the staging area contain changes.
+
+- Key: b n, magit-branch
+
+  Create a new branch.  The user is asked for a branch or arbitrary
+  revision to use as the starting point of the new branch.  When a
+  branch name is provided, then that becomes the upstream branch of
+  the new branch.  The name of the new branch is also read in the
+  minibuffer.
+
+  Also see option ~magit-branch-prefer-remote-upstream~.
+
+- Key: b c, magit-branch-and-checkout
+
+  This command creates a new branch like ~magit-branch~, but then also
+  checks it out.
+
+  Also see option ~magit-branch-prefer-remote-upstream~.
+
+- Key: b s, magit-branch-spinoff
+
+  This command creates and checks out a new branch starting at and
+  tracking the current branch.  That branch in turn is reset to the
+  last commit it shares with its upstream.  If the current branch has
+  no upstream or no unpushed commits, then the new branch is created
+  anyway and the previously current branch is not touched.
+
+  This is useful to create a feature branch after work has already
+  began on the old branch (likely but not necessarily "master").
+
+  If the current branch is a member of the value of option
+  ~magit-branch-prefer-remote-upstream~ (which see), then the current
+  branch will be used as the starting point as usual, but the upstream
+  of the starting-point may be used as the upstream of the new branch,
+  instead of the starting-point itself.
+
+- Key: b x, magit-branch-reset
+
+  This command resets a branch, defaulting to the branch at point, to
+  the tip of another branch or any other commit.
+
+  When the branch being reset is the current branch, then a hard reset
+  is performed.  If there are any uncommitted changes, then the user
+  has to confirming the reset because those changes would be lost.
+
+  This is useful when you have started work on a feature branch but
+  realize it's all crap and want to start over.
+
+  When resetting to another branch and a prefix argument is used, then
+  the target branch is set as the upstream of the branch that is being
+  reset.
+
+- Key: b d, magit-branch-delete
+
+  Delete one or multiple branches.  If the region marks multiple
+  branches, then offer to delete those.  Otherwise, prompt for a single
+  branch to be deleted, defaulting to the branch at point.
+
+- Key: b r, magit-branch-rename
+
+  Rename a branch.  The branch and the new name are read in the
+  minibuffer.  With prefix argument the branch is renamed even if that
+  name conflicts with an existing branch.
+
+- User Option: magit-branch-read-upstream-first
+
+  When creating a branch, whether to read the upstream branch before
+  the name of the branch that is to be created.  The default is ~nil~,
+  and I recommend you leave it at that.
+
+- User Option: magit-branch-prefer-remote-upstream
+
+  This option specifies whether remote upstreams are favored over
+  local upstreams when creating new branches.
+
+  When a new branch is created, Magit offers the branch, commit, or
+  stash as the default starting point of the new branch.  If there is
+  no such thing at point, then it falls back to offer the current
+  branch as starting-point.  The user may then accept that default or
+  pick something else.
+
+  If the chosen starting-point is a branch, then it may also be set
+  as the upstream of the new branch, depending on the value of the
+  Git variable `branch.autoSetupMerge'.  By default this is done
+  for remote branches, but not for local branches.
+
+  You might prefer to always use some remote branch as upstream.
+  If the chosen starting-point is (1) a local branch, (2) whose
+  name is a member of the value of this option, (3) the upstream of
+  that local branch is a remote branch with the same name, and (4)
+  that remote branch can be fast-forwarded to the local branch,
+  then the chosen branch is used as starting-point, but its own
+  upstream is used as the upstream of the new branch.
+
+  Assuming the chosen branch matches these conditions you would end
+  up with with e.g.:
+
+  #+BEGIN_SRC text
+    feature --upstream--> origin/master
+  #+END_SRC
+
+  instead of
+
+  #+BEGIN_SRC text
+    feature --upstream--> master --upstream--> origin/master
+  #+END_SRC
+
+  Which you prefer is a matter of personal preference.  If you do
+  prefer the former, then you should add branches such as ~master~,
+  ~next~, and ~maint~ to the value of this options.
+
+*** The branch config popup
+
+- Command: magit-branch-popup
+
+  This prefix command shows the following branch-related Git variables
+  in a popup buffer.  The values can be changed from that buffer.
+
+  This popup is a sub-popup of several popups that deal with branches,
+  including ~magit-branch-popup~, ~magit-pull-popup~, ~magit-fetch-popup~,
+  ~magit-pull-and-fetch-popup~, and ~magit-push-popup~.  In all of these
+  popups "C" is bound to this popup.
 
 The following variables are used to configure a specific branch.  The
 values are being displayed for the current branch (if any).  To change
-the value for another branch use a prefix argument.
+the value for another branch invoke ~magit-branch-config-popup~ with a
+prefix argument.
 
 - Variable: branch.NAME.merge
 
@@ -3273,123 +3425,6 @@ info:gitman#git-config.  Also see [[info:gitman#git-branch]],
   This affects all commands that use ~magit-read-upstream-branch~ or
   ~magit-read-starting-point~, which includes all commands that change
   the upstream and many which create new branches.
-
-- Key: b b, magit-checkout
-
-  Checkout a revision read in the minibuffer and defaulting to the
-  branch or arbitrary revision at point.  If the revision is a local
-  branch then that becomes the current branch.  If it is something
-  else then ~HEAD~ becomes detached.  Checkout fails if the working tree
-  or the staging area contain changes.
-
-- Key: b n, magit-branch
-
-  Create a new branch.  The user is asked for a branch or arbitrary
-  revision to use as the starting point of the new branch.  When a
-  branch name is provided, then that becomes the upstream branch of
-  the new branch.  The name of the new branch is also read in the
-  minibuffer.
-
-  Also see option ~magit-branch-prefer-remote-upstream~.
-
-- Key: b c, magit-branch-and-checkout
-
-  This command creates a new branch like ~magit-branch~, but then also
-  checks it out.
-
-  Also see option ~magit-branch-prefer-remote-upstream~.
-
-- Key: b s, magit-branch-spinoff
-
-  This command creates and checks out a new branch starting at and
-  tracking the current branch.  That branch in turn is reset to the
-  last commit it shares with its upstream.  If the current branch has
-  no upstream or no unpushed commits, then the new branch is created
-  anyway and the previously current branch is not touched.
-
-  This is useful to create a feature branch after work has already
-  began on the old branch (likely but not necessarily "master").
-
-  If the current branch is a member of the value of option
-  ~magit-branch-prefer-remote-upstream~ (which see), then the current
-  branch will be used as the starting point as usual, but the upstream
-  of the starting-point may be used as the upstream of the new branch,
-  instead of the starting-point itself.
-
-- Key: b x, magit-branch-reset
-
-  This command resets a branch, defaulting to the branch at point, to
-  the tip of another branch or any other commit.
-
-  When the branch being reset is the current branch, then a hard reset
-  is performed.  If there are any uncommitted changes, then the user
-  has to confirming the reset because those changes would be lost.
-
-  This is useful when you have started work on a feature branch but
-  realize it's all crap and want to start over.
-
-  When resetting to another branch and a prefix argument is used, then
-  the target branch is set as the upstream of the branch that is being
-  reset.
-
-- Key: b d, magit-branch-delete
-
-  Delete one or multiple branches.  If the region marks multiple
-  branches, then offer to delete those.  Otherwise, prompt for a single
-  branch to be deleted, defaulting to the branch at point.
-
-- Key: b r, magit-branch-rename
-
-  Rename a branch.  The branch and the new name are read in the
-  minibuffer.  With prefix argument the branch is renamed even if that
-  name conflicts with an existing branch.
-
-- User Option: magit-branch-read-upstream-first
-
-  When creating a branch, whether to read the upstream branch before
-  the name of the branch that is to be created.  The default is ~nil~,
-  and I recommend you leave it at that.
-
-- User Option: magit-branch-prefer-remote-upstream
-
-  This option specifies whether remote upstreams are favored over
-  local upstreams when creating new branches.
-
-  When a new branch is created, Magit offers the branch, commit, or
-  stash as the default starting point of the new branch.  If there is
-  no such thing at point, then it falls back to offer the current
-  branch as starting-point.  The user may then accept that default or
-  pick something else.
-
-  If the chosen starting-point is a branch, then it may also be set
-  as the upstream of the new branch, depending on the value of the
-  Git variable `branch.autoSetupMerge'.  By default this is done
-  for remote branches, but not for local branches.
-
-  You might prefer to always use some remote branch as upstream.
-  If the chosen starting-point is (1) a local branch, (2) whose
-  name is a member of the value of this option, (3) the upstream of
-  that local branch is a remote branch with the same name, and (4)
-  that remote branch can be fast-forwarded to the local branch,
-  then the chosen branch is used as starting-point, but its own
-  upstream is used as the upstream of the new branch.
-
-  Assuming the chosen branch matches these conditions you would end
-  up with with e.g.:
-
-  #+BEGIN_SRC text
-    feature --upstream--> origin/master
-  #+END_SRC
-
-  instead of
-
-  #+BEGIN_SRC text
-    feature --upstream--> master --upstream--> origin/master
-  #+END_SRC
-
-  Which you prefer is a matter of personal preference.  If you do
-  prefer the former, then you should add branches such as ~master~,
-  ~next~, and ~maint~ to the value of this options.
 
 ** Merging
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -188,6 +188,12 @@ Committing
 * Editing commit messages::
 
 
+Branching
+
+* The two remotes::
+* The branch popup::
+* The branch config popup::
+
 
 
 
@@ -4254,6 +4260,15 @@ To show no diff while committing remove @code{magit-commit-diff} from
 @node Branching
 @section Branching
 
+@menu
+* The two remotes::
+* The branch popup::
+* The branch config popup::
+@end menu
+
+@node The two remotes
+@subsection The two remotes
+
 The upstream branch of some local branch is the branch into which the
 commits on that local branch should eventually be merged, usually
 something like @code{origin/master}.  For the @code{master} branch itself the
@@ -4290,8 +4305,18 @@ unpushed and unpulled for both the push-remote and the upstream.
 It's fairly simple to configure these two remotes.  The values of all
 the variables that are related to fetching, pulling, and pushing (as
 well as some other branch-related variables) can be inspected and
-changed in the branching popup.  It is also possible to set the
-push-remote and/or upstream while pushing (see @ref{Pushing,Pushing}).
+changed using the popup @code{magit-branch-config-popup}, which is a
+sub-popup of many popups that deal with branches.  It is also possible
+to set the push-remote and/or upstream while pushing (see @ref{Pushing,Pushing}).
+
+@node The branch popup
+@subsection The branch popup
+
+The popup @code{magit-branch-popup} is used to create and checkout branches,
+and to make changes to existing branches.  It is not used to fetch,
+pull, merge, rebase, or push branches, i.e. this popup deals with
+branches themselves, not with the commits reachable from them.  Those
+features are available from separate popups.
 
 @table @asis
 @kindex b
@@ -4299,13 +4324,178 @@ push-remote and/or upstream while pushing (see @ref{Pushing,Pushing}).
 @item @kbd{b} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-popup})
 
 This prefix command shows the following suffix commands in a popup
-buffer.  It also displays the values of the following variables and
-allows changing their values.
+buffer.
+
+By default it also displays the values of some branch-related Git
+variables and allows changing their values, just like the
+specialized @code{magit-branch-config-popup} does.
+
 @end table
+
+@defopt magit-branch-popup-show-variables
+
+Whether the @code{magit-branch-popup} shows Git variables.  This defaults
+to t to avoid changing key bindings.  When set to nil, no variables
+are displayed directly in this popup, and the sub-popup
+@code{magit-branch-config-popup} has to be used indead to view and change
+branch related variables.
+@end defopt
+
+@table @asis
+@kindex b b
+@cindex magit-checkout
+@item @kbd{b b} @tie{}@tie{}@tie{}@tie{}(@code{magit-checkout})
+
+Checkout a revision read in the minibuffer and defaulting to the
+branch or arbitrary revision at point.  If the revision is a local
+branch then that becomes the current branch.  If it is something
+else then @code{HEAD} becomes detached.  Checkout fails if the working tree
+or the staging area contain changes.
+
+@kindex b n
+@cindex magit-branch
+@item @kbd{b n} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch})
+
+Create a new branch.  The user is asked for a branch or arbitrary
+revision to use as the starting point of the new branch.  When a
+branch name is provided, then that becomes the upstream branch of
+the new branch.  The name of the new branch is also read in the
+minibuffer.
+
+Also see option @code{magit-branch-prefer-remote-upstream}.
+
+@kindex b c
+@cindex magit-branch-and-checkout
+@item @kbd{b c} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-and-checkout})
+
+This command creates a new branch like @code{magit-branch}, but then also
+checks it out.
+
+Also see option @code{magit-branch-prefer-remote-upstream}.
+
+@kindex b s
+@cindex magit-branch-spinoff
+@item @kbd{b s} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-spinoff})
+
+This command creates and checks out a new branch starting at and
+tracking the current branch.  That branch in turn is reset to the
+last commit it shares with its upstream.  If the current branch has
+no upstream or no unpushed commits, then the new branch is created
+anyway and the previously current branch is not touched.
+
+This is useful to create a feature branch after work has already
+began on the old branch (likely but not necessarily "master").
+
+If the current branch is a member of the value of option
+@code{magit-branch-prefer-remote-upstream} (which see), then the current
+branch will be used as the starting point as usual, but the upstream
+of the starting-point may be used as the upstream of the new branch,
+instead of the starting-point itself.
+
+@kindex b x
+@cindex magit-branch-reset
+@item @kbd{b x} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-reset})
+
+This command resets a branch, defaulting to the branch at point, to
+the tip of another branch or any other commit.
+
+When the branch being reset is the current branch, then a hard reset
+is performed.  If there are any uncommitted changes, then the user
+has to confirming the reset because those changes would be lost.
+
+This is useful when you have started work on a feature branch but
+realize it's all crap and want to start over.
+
+When resetting to another branch and a prefix argument is used, then
+the target branch is set as the upstream of the branch that is being
+reset.
+
+@kindex b d
+@cindex magit-branch-delete
+@item @kbd{b d} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-delete})
+
+Delete one or multiple branches.  If the region marks multiple
+branches, then offer to delete those.  Otherwise, prompt for a single
+branch to be deleted, defaulting to the branch at point.
+
+@kindex b r
+@cindex magit-branch-rename
+@item @kbd{b r} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-rename})
+
+Rename a branch.  The branch and the new name are read in the
+minibuffer.  With prefix argument the branch is renamed even if that
+name conflicts with an existing branch.
+
+@end table
+
+@defopt magit-branch-read-upstream-first
+
+When creating a branch, whether to read the upstream branch before
+the name of the branch that is to be created.  The default is @code{nil},
+and I recommend you leave it at that.
+@end defopt
+
+@defopt magit-branch-prefer-remote-upstream
+
+This option specifies whether remote upstreams are favored over
+local upstreams when creating new branches.
+
+When a new branch is created, Magit offers the branch, commit, or
+stash as the default starting point of the new branch.  If there is
+no such thing at point, then it falls back to offer the current
+branch as starting-point.  The user may then accept that default or
+pick something else.
+
+If the chosen starting-point is a branch, then it may also be set
+as the upstream of the new branch, depending on the value of the
+Git variable `branch.autoSetupMerge'.  By default this is done
+for remote branches, but not for local branches.
+
+You might prefer to always use some remote branch as upstream.
+If the chosen starting-point is (1) a local branch, (2) whose
+name is a member of the value of this option, (3) the upstream of
+that local branch is a remote branch with the same name, and (4)
+that remote branch can be fast-forwarded to the local branch,
+then the chosen branch is used as starting-point, but its own
+upstream is used as the upstream of the new branch.
+
+Assuming the chosen branch matches these conditions you would end
+up with with e.g.:
+
+@example
+feature --upstream--> origin/master
+@end example
+
+instead of
+
+@example
+feature --upstream--> master --upstream--> origin/master
+@end example
+
+Which you prefer is a matter of personal preference.  If you do
+prefer the former, then you should add branches such as @code{master},
+@code{next}, and @code{maint} to the value of this options.
+@end defopt
+
+@node The branch config popup
+@subsection The branch config popup
+
+@cindex magit-branch-popup
+@deffn Command magit-branch-popup
+
+This prefix command shows the following branch-related Git variables
+in a popup buffer.  The values can be changed from that buffer.
+
+This popup is a sub-popup of several popups that deal with branches,
+including @code{magit-branch-popup}, @code{magit-pull-popup}, @code{magit-fetch-popup},
+@code{magit-pull-and-fetch-popup}, and @code{magit-push-popup}.  In all of these
+popups "C" is bound to this popup.
+@end deffn
 
 The following variables are used to configure a specific branch.  The
 values are being displayed for the current branch (if any).  To change
-the value for another branch use a prefix argument.
+the value for another branch invoke @code{magit-branch-config-popup} with a
+prefix argument.
 
 @defvar branch.NAME.merge
 
@@ -4497,142 +4687,6 @@ choice.
 This affects all commands that use @code{magit-read-upstream-branch} or
 @code{magit-read-starting-point}, which includes all commands that change
 the upstream and many which create new branches.
-@end defopt
-
-@table @asis
-@kindex b b
-@cindex magit-checkout
-@item @kbd{b b} @tie{}@tie{}@tie{}@tie{}(@code{magit-checkout})
-
-Checkout a revision read in the minibuffer and defaulting to the
-branch or arbitrary revision at point.  If the revision is a local
-branch then that becomes the current branch.  If it is something
-else then @code{HEAD} becomes detached.  Checkout fails if the working tree
-or the staging area contain changes.
-
-@kindex b n
-@cindex magit-branch
-@item @kbd{b n} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch})
-
-Create a new branch.  The user is asked for a branch or arbitrary
-revision to use as the starting point of the new branch.  When a
-branch name is provided, then that becomes the upstream branch of
-the new branch.  The name of the new branch is also read in the
-minibuffer.
-
-Also see option @code{magit-branch-prefer-remote-upstream}.
-
-@kindex b c
-@cindex magit-branch-and-checkout
-@item @kbd{b c} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-and-checkout})
-
-This command creates a new branch like @code{magit-branch}, but then also
-checks it out.
-
-Also see option @code{magit-branch-prefer-remote-upstream}.
-
-@kindex b s
-@cindex magit-branch-spinoff
-@item @kbd{b s} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-spinoff})
-
-This command creates and checks out a new branch starting at and
-tracking the current branch.  That branch in turn is reset to the
-last commit it shares with its upstream.  If the current branch has
-no upstream or no unpushed commits, then the new branch is created
-anyway and the previously current branch is not touched.
-
-This is useful to create a feature branch after work has already
-began on the old branch (likely but not necessarily "master").
-
-If the current branch is a member of the value of option
-@code{magit-branch-prefer-remote-upstream} (which see), then the current
-branch will be used as the starting point as usual, but the upstream
-of the starting-point may be used as the upstream of the new branch,
-instead of the starting-point itself.
-
-@kindex b x
-@cindex magit-branch-reset
-@item @kbd{b x} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-reset})
-
-This command resets a branch, defaulting to the branch at point, to
-the tip of another branch or any other commit.
-
-When the branch being reset is the current branch, then a hard reset
-is performed.  If there are any uncommitted changes, then the user
-has to confirming the reset because those changes would be lost.
-
-This is useful when you have started work on a feature branch but
-realize it's all crap and want to start over.
-
-When resetting to another branch and a prefix argument is used, then
-the target branch is set as the upstream of the branch that is being
-reset.
-
-@kindex b d
-@cindex magit-branch-delete
-@item @kbd{b d} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-delete})
-
-Delete one or multiple branches.  If the region marks multiple
-branches, then offer to delete those.  Otherwise, prompt for a single
-branch to be deleted, defaulting to the branch at point.
-
-@kindex b r
-@cindex magit-branch-rename
-@item @kbd{b r} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-rename})
-
-Rename a branch.  The branch and the new name are read in the
-minibuffer.  With prefix argument the branch is renamed even if that
-name conflicts with an existing branch.
-
-@end table
-
-@defopt magit-branch-read-upstream-first
-
-When creating a branch, whether to read the upstream branch before
-the name of the branch that is to be created.  The default is @code{nil},
-and I recommend you leave it at that.
-@end defopt
-
-@defopt magit-branch-prefer-remote-upstream
-
-This option specifies whether remote upstreams are favored over
-local upstreams when creating new branches.
-
-When a new branch is created, Magit offers the branch, commit, or
-stash as the default starting point of the new branch.  If there is
-no such thing at point, then it falls back to offer the current
-branch as starting-point.  The user may then accept that default or
-pick something else.
-
-If the chosen starting-point is a branch, then it may also be set
-as the upstream of the new branch, depending on the value of the
-Git variable `branch.autoSetupMerge'.  By default this is done
-for remote branches, but not for local branches.
-
-You might prefer to always use some remote branch as upstream.
-If the chosen starting-point is (1) a local branch, (2) whose
-name is a member of the value of this option, (3) the upstream of
-that local branch is a remote branch with the same name, and (4)
-that remote branch can be fast-forwarded to the local branch,
-then the chosen branch is used as starting-point, but its own
-upstream is used as the upstream of the new branch.
-
-Assuming the chosen branch matches these conditions you would end
-up with with e.g.:
-
-@example
-feature --upstream--> origin/master
-@end example
-
-instead of
-
-@example
-feature --upstream--> master --upstream--> origin/master
-@end example
-
-Which you prefer is a matter of personal preference.  If you do
-prefer the former, then you should add branches such as @code{master},
-@code{next}, and @code{maint} to the value of this options.
 @end defopt
 
 @node Merging

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -806,6 +806,9 @@ TYPE is one of `:action', `:sequence-action', `:switch', or
   (interactive (list last-command-event))
   (let ((action   (magit-popup-lookup event :actions))
         (variable (magit-popup-lookup event :variables)))
+    (when (and variable (not (magit-popup-event-arg variable)))
+      (setq action variable)
+      (setq variable nil))
     (if (or action variable)
         (let ((magit-current-popup magit-this-popup)
               (magit-current-popup-args (magit-popup-get-args))
@@ -1142,12 +1145,14 @@ of events shared by all popups and before point is adjusted.")
         'type type 'event (magit-popup-event-key ev)))
 
 (defun magit-popup-format-variable-button (type ev)
-  (list (format-spec
-         (button-type-get type 'format)
-         `((?k . ,(propertize (magit-popup-event-keydsc ev)
-                              'face 'magit-popup-key))
-           (?d . ,(funcall (magit-popup-event-arg ev)))))
-        'type type 'event (magit-popup-event-key ev)))
+  (if (not (magit-popup-event-arg ev))
+      (magit-popup-format-action-button 'magit-popup-action-button ev)
+    (list (format-spec
+           (button-type-get type 'format)
+           `((?k . ,(propertize (magit-popup-event-keydsc ev)
+                                'face 'magit-popup-key))
+             (?d . ,(funcall (magit-popup-event-arg ev)))))
+          'type type 'event (magit-popup-event-key ev))))
 
 (defun magit-popup-format-variable
     (variable choices &optional default other width)

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -291,6 +291,8 @@ Don't confuse this with `magit-current-popup'.")
 This is intended for internal use only.
 Don't confuse this with `magit-current-popup-args'.")
 
+(defvar-local magit-previous-popup nil)
+
 (defun magit-popup-get (prop)
   "While a popup is active, get the value of PROP."
   (if (memq prop '(:switches :options :variables :actions))
@@ -820,7 +822,9 @@ TYPE is one of `:action', `:sequence-action', `:switch', or
           (unless action
             (magit-refresh-popup-buffer)))
       (if (eq event ?q)
-          (magit-popup-quit)
+          (progn (magit-popup-quit)
+                 (when magit-previous-popup
+                   (magit-popup-mode-setup magit-previous-popup nil)))
         (user-error "%c isn't bound to any action" event)))))
 
 (defun magit-popup-set-variable
@@ -1015,6 +1019,7 @@ restored."
                                  val (plist-get def :actions)))))
 
 (defun magit-popup-mode-setup (popup mode)
+  (setq magit-previous-popup magit-current-popup)
   (let ((val (symbol-value (plist-get (symbol-value popup) :variable)))
         (def (symbol-value popup)))
     (magit-popup-mode-display-buffer (get-buffer-create

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -178,7 +178,9 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
   'magit-commands
   :man-page "git-fetch"
   :switches '((?p "Prune deleted branches" "--prune"))
-  :actions  '("Fetch from"
+  :actions  '("Configure"
+              (?C "variables..."           magit-branch-config-popup)
+              "Fetch from"
               (?p magit-get-push-remote    magit-fetch-from-pushremote)
               (?u magit-get-remote         magit-fetch-from-upstream)
               (?e "elsewhere"              magit-fetch)
@@ -271,9 +273,11 @@ removed on the respective remote."
   "Popup console for pull commands."
   'magit-commands
   :man-page "git-pull"
-  :variables '((?r "branch.%s.rebase"
+  :variables '("Configure"
+               (?r "branch.%s.rebase"
                    magit-cycle-branch*rebase
-                   magit-pull-format-branch*rebase))
+                   magit-pull-format-branch*rebase)
+               (?C "variables..." magit-branch-config-popup))
   :actions '((lambda ()
                (--if-let (magit-get-current-branch)
                    (concat
@@ -315,10 +319,11 @@ missing.  To add them use something like:
       \\='magit-fetch-from-push-remote ?F))"
   'magit-commands
   :man-page "git-pull"
-  :variables '("Pull variables"
+  :variables '("Configure"
                (?r "branch.%s.rebase"
                    magit-cycle-branch*rebase
-                   magit-pull-format-branch*rebase))
+                   magit-pull-format-branch*rebase)
+               (?C "variables..." magit-branch-config-popup))
   :actions '((lambda ()
                (--if-let (magit-get-current-branch)
                    (concat
@@ -418,7 +423,9 @@ removed after restarting Emacs."
               (?d "Dry run"       "--dry-run")
               ,@(and (not magit-push-current-set-remote-if-missing)
                      '((?u "Set upstream"  "--set-upstream"))))
-  :actions '((lambda ()
+  :actions '("Configure"
+             (?C "variables..."      magit-branch-config-popup)
+             (lambda ()
                (--when-let (magit-get-current-branch)
                  (concat (propertize "Push " 'face 'magit-popup-heading)
                          (propertize it      'face 'magit-branch-local)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1334,15 +1334,7 @@ Non-interactively DIRECTORY is (re-)initialized unconditionally."
              (?W "Create new worktree"   magit-worktree-branch)
              (?k "Delete"                magit-branch-delete))
   :default-action 'magit-checkout
-  :max-action-columns 3
-  :setup-function 'magit-branch-popup-setup)
-
-(defun magit-branch-popup-setup (val def)
-  (magit-popup-default-setup val def)
-  (use-local-map (copy-keymap magit-popup-mode-map))
-  (dolist (ev (-filter #'magit-popup-event-p (magit-popup-get :variables)))
-    (local-set-key (vector (magit-popup-event-key ev))
-                   'magit-invoke-popup-action)))
+  :max-action-columns 3)
 
 ;;;;; Branch Actions
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1547,6 +1547,14 @@ With prefix, forces the rename even if NEW already exists.
 
 ;;;;; Branch Variables
 
+(defun magit-branch-config-branch (&optional prompt)
+  (if prompt
+      (or (and (not current-prefix-arg)
+               (magit-get-current-branch))
+          (magit-read-local-branch prompt))
+    (or (magit-get-current-branch)
+        "<name>")))
+
 ;;;###autoload
 (defun magit-edit-branch*description (branch)
   "Edit the description of the current branch.
@@ -1554,10 +1562,7 @@ With a prefix argument edit the description of another branch.
 
 The description for the branch named NAME is stored in the Git
 variable `branch.<name>.description'."
-  (interactive
-   (list (or (and (not current-prefix-arg)
-                  (magit-get-current-branch))
-             (magit-read-local-branch "Edit branch description"))))
+  (interactive (list (magit-branch-config-branch "Edit branch description")))
   (magit-run-git-with-editor "branch" "--edit-description" branch))
 
 (defun magit-edit-branch*description-check-buffers ()
@@ -1572,7 +1577,7 @@ variable `branch.<name>.description'."
 (add-hook 'find-file-hook 'magit-edit-branch*description-check-buffers)
 
 (defun magit-format-branch*description ()
-  (let* ((branch (or (magit-get-current-branch) "<name>"))
+  (let* ((branch (magit-branch-config-branch))
          (width (+ (length branch) 19))
          (var (format "branch.%s.description" branch)))
     (concat var " " (make-string (- width (length var)) ?\s)
@@ -1598,9 +1603,7 @@ Non-interactively, when UPSTREAM is non-nil, then always set it
 as the new upstream, regardless of whether another upstream was
 already set.  When nil, then always unset."
   (interactive
-   (let ((branch (or (and (not current-prefix-arg)
-                          (magit-get-current-branch))
-                     (magit-read-local-branch "Change upstream of branch"))))
+   (let ((branch (magit-branch-config-branch "Change upstream of branch")))
      (list branch (and (not (magit-get-upstream-branch branch))
                        (magit-read-upstream-branch)))))
   (if upstream
@@ -1613,7 +1616,7 @@ already set.  When nil, then always unset."
     (magit-refresh)))
 
 (defun magit-format-branch*merge/remote ()
-  (let* ((branch (or (magit-get-current-branch) "<name>"))
+  (let* ((branch (magit-branch-config-branch))
          (width (+ (length branch) 20))
          (varM (format "branch.%s.merge" branch))
          (varR (format "branch.%s.remote" branch))
@@ -1643,16 +1646,14 @@ When `false' then pulling is done by merging.
 
 When that variable is undefined then the value of `pull.rebase'
 is used instead.  It defaults to `false'."
-  (interactive
-   (list (or (and (not current-prefix-arg)
-                  (magit-get-current-branch))
-             (magit-read-local-branch "Cycle branch.<name>.rebase for"))))
+  (interactive (list (magit-branch-config-branch
+                      "Cycle branch.<name>.rebase for")))
   (magit-popup-set-variable (format "branch.%s.rebase" branch)
                             '("true" "false")
                             "false" "pull.rebase"))
 
 (defun magit-format-branch*rebase ()
-  (let ((branch (or (magit-get-current-branch) "<name>")))
+  (let ((branch (magit-branch-config-branch)))
     (magit-popup-format-variable (format "branch.%s.rebase" branch)
                                  '("true" "false")
                                  "false" "pull.rebase"
@@ -1670,16 +1671,14 @@ to be the name of an existing remote.
 If that variable is undefined, then the value of the Git variable
 `remote.pushDefault' is used instead, provided that it is defined,
 which by default it is not."
-  (interactive
-   (list (or (and (not current-prefix-arg)
-                  (magit-get-current-branch))
-             (magit-read-local-branch "Cycle branch.<name>.pushRemote for"))))
+  (interactive (list (magit-branch-config-branch
+                      "Cycle branch.<name>.pushRemote for")))
   (magit-popup-set-variable (format "branch.%s.pushRemote" branch)
                             (magit-list-remotes)
                             "remote.pushDefault"))
 
 (defun magit-format-branch*pushRemote ()
-  (let ((branch (or (magit-get-current-branch) "<name>")))
+  (let ((branch (magit-branch-config-branch)))
     (magit-popup-format-variable (format "branch.%s.pushRemote" branch)
                                  (magit-list-remotes)
                                  nil "remote.pushDefault"

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -279,6 +279,16 @@ prefer the former, then you should add branches such as \"master\",
   :group 'magit-commands
   :type '(repeat string))
 
+(defcustom magit-branch-popup-show-variables t
+  "Whether the `magit-branch-popup' shows Git variables.
+This defaults to t to avoid changing key bindings.  When set to
+nil, no variables are displayed directly in this popup, instead
+the sub-popup `magit-branch-config-popup' has to be used to view
+and change branch related variables."
+  :package-version '(magit . "2.7.0")
+  :group 'magit-commands
+  :type 'boolean)
+
 (defcustom magit-repository-directories nil
   "Directories containing Git repositories.
 Magit checks these directories for Git repositories and offers
@@ -1297,44 +1307,26 @@ Non-interactively DIRECTORY is (re-)initialized unconditionally."
   "Popup console for branch commands."
   'magit-commands
   :man-page "git-branch"
-  :variables '("Configure existing branches"
-               (?d "branch.%s.description"
-                   magit-edit-branch*description
-                   magit-format-branch*description)
-               (?u "branch.%s.merge"
-                   magit-set-branch*merge/remote
-                   magit-format-branch*merge/remote)
-               (?r "branch.%s.rebase"
-                   magit-cycle-branch*rebase
-                   magit-format-branch*rebase)
-               (?p "branch.%s.pushRemote"
-                   magit-cycle-branch*pushRemote
-                   magit-format-branch*pushRemote)
-               "Configure repository defaults"
-               (?\M-r "pull.rebase"
-                      magit-cycle-pull.rebase
-                      magit-format-pull.rebase)
-               (?\M-p "remote.pushDefault"
-                      magit-cycle-remote.pushDefault
-                      magit-format-remote.pushDefault)
-               "Configure branch creation"
-               (?U "branch.autoSetupMerge"
-                   magit-cycle-branch*autoSetupMerge
-                   magit-format-branch*autoSetupMerge)
-               (?R "branch.autoSetupRebase"
-                   magit-cycle-branch*autoSetupRebase
-                   magit-format-branch*autoSetupRebase))
   :actions '((?b "Checkout"              magit-checkout)
              (?n "Create new branch"     magit-branch)
-             (?m "Rename"                magit-branch-rename)
+             (?C "Configure..."          magit-branch-config-popup)
              (?c "Checkout new branch"   magit-branch-and-checkout)
              (?s "Create new spin-off"   magit-branch-spinoff)
-             (?x "Reset"                 magit-branch-reset)
+             (?m "Rename"                magit-branch-rename)
              (?w "Checkout new worktree" magit-worktree-checkout)
              (?W "Create new worktree"   magit-worktree-branch)
+             (?x "Reset"                 magit-branch-reset) nil nil
              (?k "Delete"                magit-branch-delete))
   :default-action 'magit-checkout
-  :max-action-columns 3)
+  :max-action-columns 3
+  :setup-function 'magit-branch-popup-setup)
+
+(defvar magit-branch-config-variables)
+
+(defun magit-branch-popup-setup (val def)
+  (magit-popup-default-setup val def)
+  (magit-popup-put :variables (magit-popup-convert-variables
+                               val magit-branch-config-variables)))
 
 ;;;###autoload
 (defun magit-checkout (revision)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1336,8 +1336,6 @@ Non-interactively DIRECTORY is (re-)initialized unconditionally."
   :default-action 'magit-checkout
   :max-action-columns 3)
 
-;;;;; Branch Actions
-
 ;;;###autoload
 (defun magit-checkout (revision)
   "Checkout REVISION, updating the index and the working tree.
@@ -1545,7 +1543,47 @@ With prefix, forces the rename even if NEW already exists.
   (unless (string= old new)
     (magit-run-git "branch" (if force "-M" "-m") old new)))
 
-;;;;; Branch Variables
+;;;;; Branch Config Popup
+
+;;;###autoload
+(defun magit-branch-config-popup (&optional arg)
+  "Popup console for setting branch variables."
+  (interactive "P")
+  (magit-invoke-popup 'magit-branch-config-popup nil arg))
+
+(defvar magit-branch-config-variables
+  '("Configure existing branches"
+    (?d "branch.%s.description"
+        magit-edit-branch*description
+        magit-format-branch*description)
+    (?u "branch.%s.merge"
+        magit-set-branch*merge/remote
+        magit-format-branch*merge/remote)
+    (?r "branch.%s.rebase"
+        magit-cycle-branch*rebase
+        magit-format-branch*rebase)
+    (?p "branch.%s.pushRemote"
+        magit-cycle-branch*pushRemote
+        magit-format-branch*pushRemote)
+    "Configure repository defaults"
+    (?\M-r "pull.rebase"
+           magit-cycle-pull.rebase
+           magit-format-pull.rebase)
+    (?\M-p "remote.pushDefault"
+           magit-cycle-remote.pushDefault
+           magit-format-remote.pushDefault)
+    "Configure branch creation"
+    (?U "branch.autoSetupMerge"
+        magit-cycle-branch*autoSetupMerge
+        magit-format-branch*autoSetupMerge)
+    (?R "branch.autoSetupRebase"
+        magit-cycle-branch*autoSetupRebase
+        magit-format-branch*autoSetupRebase)))
+
+(defvar magit-branch-config-popup
+  `(:man-page "git-branch"
+    :variables ,magit-branch-config-variables
+    :default-action magit-checkout))
 
 (defun magit-branch-config-branch (&optional prompt)
   (if prompt

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1612,8 +1612,7 @@ already set.  When nil, then always unset."
      (list branch (and (not (magit-get-upstream-branch branch))
                        (magit-read-upstream-branch)))))
   (if upstream
-      (-let (((remote . merge) (magit-split-branch-name upstream))
-             (branch (magit-get-current-branch)))
+      (-let (((remote . merge) (magit-split-branch-name upstream)))
         (magit-call-git "config" (format "branch.%s.remote" branch) remote)
         (magit-call-git "config" (format "branch.%s.merge"  branch)
                         (concat "refs/heads/" merge)))


### PR DESCRIPTION
Replaces  #2596.

I am not going to merge this before releasing v2.6 because I realized that we should also use this separate popup to allow customizing variables for branches that are not currently checked out. 

Currently one has to use a prefix argument to do that but that's not nice because one cannot see the value before changing and cycling a value also isn't much less fun if you have to use the prefix on every turn.

But how exactly we should use this popup to provide a better interface for that I don't know yet.