### PR TITLE
move trailing newline into `Untracked Files` section

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -640,8 +640,8 @@ Do so depending on the value of `status.showUntrackedFiles'."
             (magit-insert-heading "Untracked files:")
             (dolist (file files)
               (magit-insert-section (file file)
-                (insert (propertize file 'face 'magit-filename) ?\n))))
-          (insert ?\n))))))
+                (insert (propertize file 'face 'magit-filename) ?\n)))
+            (insert ?\n)))))))
 
 (defun magit-insert-un/tracked-files-1 (files directory)
   (while (and files (string-prefix-p (or directory "") (car files)))


### PR DESCRIPTION
This patch aims to streamline the placement of the trailing `\n` in the "Untracked Files" section with that of all the other sections.

Without this patch, the trailing newline for this section is inserted outside of it. As a consequence, it's not hidden when that section is closed, and a single empty lines between the section headers remains visible.