### PR TITLE
magit-file-popup: autoload it

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -2276,6 +2276,7 @@ the current repository."
     map)
   "Keymap for `magit-file-mode'.")
 
+;;;###autoload (autoload 'magit-file-popup "magit" nil t)
 (magit-define-popup magit-file-popup
   "Popup console for Magit commands in file-visiting buffers."
   :actions '((?s "Stage"     magit-stage-file)


### PR DESCRIPTION
Trivial addition to support cases where users have `magit-file-popup` bound to a key and may invoke it before e.g. `magit-status`.