### PR TITLE
Pass absolute file name to `make-temp-name`

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1162,7 +1162,7 @@ Return a list of two integers: (A>B B>A)."
   (declare (indent 2) (debug (form form body)))
   (let ((file (cl-gensym "file")))
     `(let ((,file (magit-convert-git-filename
-                   (magit-git-dir (make-temp-name "index.magit.")))))
+                   (make-temp-name (magit-git-dir "index.magit.")))))
        (setq ,file (or (file-remote-p ,file 'localname) ,file))
        (unwind-protect
            (progn (--when-let ,tree


### PR DESCRIPTION
On OS X `make-temp-name` triggers a 'bad file descriptor' error when
passed a non-absolute file path. Moving `magit-git-dir` inside
`make-temp-name` ensures that an absolute file path is available.

This fixes #2633, where the above is also discussed.