### PR TITLE
magit-clone: run asynchronously

### DIFF
--- a/Documentation/RelNotes/2.7.0.txt
+++ b/Documentation/RelNotes/2.7.0.txt
@@ -34,6 +34,9 @@ Changes since v2.6.2
 
 * Added new section inserter `magit-insert-worktrees'
 
+* The command `magit-clone' now runs asynchronously, which avoid
+  blocking Emacs and allows handling password prompts.
+
 * The command `magit-stage' learned to stage an untracked file while
   leaving its content unstaged (i.e. `git add --intent-to-add') when
   called with a prefix argument.

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -811,10 +811,10 @@ as argument."
                             (--when-let (magit-section-content section)
                               (when (re-search-backward
                                      magit-process-error-message-re it t)
-                                (match-string 1))))))
+                                (match-string-no-properties 1))))))
                    "Git failed")))
       (if magit-process-raise-error
-          (signal 'magit-git-error (format "%s (in %s)" msg default-dir))
+          (signal 'magit-git-error (list (format "%s (in %s)" msg default-dir)))
         (--when-let (magit-mode-get-buffer 'magit-status-mode)
           (setq magit-this-error msg))
         (message "%s ... [%s buffer %s for details]" msg


### PR DESCRIPTION
should fix #2639.

```
This allows intercepting password prompts, and is also nicer if the
clone happens to take a long time.
```

---

I'm having some trouble with the error reporting for when the clone happens to fail. See FIXME in code.