### PR TITLE
magit-display-buffer-traditional: fix alist syntax

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -530,7 +530,7 @@ and `magit-post-display-buffer-hook'."
                     display-buffer--maybe-pop-up-frame-or-window
                     display-buffer-use-some-window
                     display-buffer-pop-up-frame)
-                   . (inhibit-same-window t)))
+                   . ((inhibit-same-window . t))))
                 (t nil)))) ; display in another window
 
 (defun magit-maybe-set-dedicated ()


### PR DESCRIPTION
This possibly a bug reported in the chatroom:

> Here is what I got when I press `c c` in a magit buffer:
`*ERROR*: Wrong type argument: listp, inhibit-same-window error: There was a problem with the editor '/usr/bin/emacsclient --socket-name=/tmp/emacs1000/server'. Please supply the message using either -m or -F option.`

I made this fix because I think there is a missing layer of nesting around the alist, but committing is working for me either way (Emacs 24.5), so I'm not really sure if this fixes anything (hence I didn't commit this to `master` directly).