### PR TITLE
magit-insert-worktrees: use relative filenames

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -2194,28 +2194,26 @@ If there is only one worktree, then insert nothing."
     (when (> (length worktrees) 1)
       (magit-insert-section (worktrees)
         (magit-insert-heading "Worktrees:")
-        (let* ((section-data
-                (mapcar
-                 (-lambda ((path barep commit branch))
-                   (setq path (abbreviate-file-name path))
-                   (cons (cond
-                          (branch (propertize branch
-                                              'face 'magit-branch-local))
-                          (commit (propertize (magit-rev-abbrev commit)
-                                              'face 'magit-hash))
-                          (barep  "(bare)")
-                          (t      "(detached)"))
-                         (let ((relpath (file-relative-name path)))
-                           (if (< (length relpath) (length path))
-                               relpath path))))
-                 worktrees))
-               (head-width (-max (mapcar (-lambda ((head . _path)) (length head))
-                                         section-data))))
-          (pcase-dolist (`(,head . ,path) section-data)
+        (setq worktrees
+              (mapcar (-lambda ((path barep commit branch))
+                        (cons (cond
+                               (branch (propertize branch
+                                                   'face 'magit-branch-local))
+                               (commit (propertize (magit-rev-abbrev commit)
+                                                   'face 'magit-hash))
+                               (barep  "(bare)")
+                               (t      "(detached)"))
+                              path))
+                      worktrees))
+        (let ((align (1+ (-max (--map (length (car it)) worktrees)))))
+          (pcase-dolist (`(,head . ,path) worktrees)
             (magit-insert-section (worktree path)
               (insert head)
-              (indent-to head-width)
-              (insert ?\s path ?\n))))
+              (indent-to align)
+              (insert (let ((r (file-relative-name path))
+                            (a (abbreviate-file-name path)))
+                        (if (< (length r) (length a)) r a)))
+              (insert ?\n))))
         (insert ?\n)))))
 
 ;;;; Tag

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -2194,19 +2194,19 @@ If there is only one worktree, then insert nothing."
     (when (> (length worktrees) 1)
       (magit-insert-section (worktrees)
         (magit-insert-heading "Worktrees:")
-        (setq worktrees
-              (mapcar (-lambda ((path barep commit branch))
-                        (cons (cond
-                               (branch (propertize branch
-                                                   'face 'magit-branch-local))
-                               (commit (propertize (magit-rev-abbrev commit)
-                                                   'face 'magit-hash))
-                               (barep  "(bare)")
-                               (t      "(detached)"))
-                              path))
-                      worktrees))
-        (let ((align (1+ (-max (--map (length (car it)) worktrees)))))
-          (pcase-dolist (`(,head . ,path) worktrees)
+        (let* ((cols
+                (mapcar (-lambda ((path barep commit branch))
+                          (cons (cond
+                                 (branch (propertize branch
+                                                     'face 'magit-branch-local))
+                                 (commit (propertize (magit-rev-abbrev commit)
+                                                     'face 'magit-hash))
+                                 (barep  "(bare)")
+                                 (t      "(detached)"))
+                                path))
+                        worktrees))
+               (align (1+ (-max (--map (length (car it)) cols)))))
+          (pcase-dolist (`(,head . ,path) cols)
             (magit-insert-section (worktree path)
               (insert head)
               (indent-to align)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -2197,13 +2197,15 @@ If there is only one worktree, then insert nothing."
         (dolist (worktree worktrees)
           (-let [(path barep commit branch) worktree]
             (magit-insert-section (worktree path)
-              (insert (cond (branch (propertize branch
-                                                'face 'magit-branch-local))
-                            (commit (propertize (magit-rev-abbrev commit)
-                                                'face 'magit-hash))
-                            (barep  "(bare)")
-                            (t      "(detached)")))
-              (insert ?\s path ?\n))))
+              (insert
+               (format "%-20s"
+                       (cond (branch (propertize branch
+                                                 'face 'magit-branch-local))
+                             (commit (propertize (magit-rev-abbrev commit)
+                                                 'face 'magit-hash))
+                             (barep  "(bare)")
+                             (t      "(detached)"))))
+              (insert ?\s (file-relative-name path) ?\n))))
         (insert ?\n)))))
 
 ;;;; Tag


### PR DESCRIPTION
IMO, relative path names that are lined up are nicer to look at. Should the padding width be configurable, or is it enough to just choose a "sufficiently" large number?

