### PR TITLE
cache git config more aggressively

### DIFF
--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -78,7 +78,7 @@ Then show the status buffer for the new repository."
          (when (or (eq  magit-clone-set-remote.pushDefault t)
                    (and magit-clone-set-remote.pushDefault
                         (y-or-n-p "Set `remote.pushDefault' to \"origin\"? ")))
-           (magit-call-git "config" "remote.pushDefault" "origin"))
+           (magit-set "origin" "remote" "pushDefault"))
          (unless magit-clone-set-remote-head
            (magit-remote-unset-head "origin")))
        (with-current-buffer (process-get process 'command-buf)
@@ -128,7 +128,7 @@ the variable isn't already set."
         ((or `(ask ,_) `(ask-if-unset nil))
          (y-or-n-p (format "Set `remote.pushDefault' to \"%s\"? " remote))))
       (progn (magit-call-git "remote" "add" "-f" remote url)
-             (magit-call-git "config" "remote.pushDefault" remote)
+             (magit-set remote "remote" "pushDefault")
              (magit-refresh))
     (magit-run-git-async "remote" "add" "-f" remote url)))
 

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -78,7 +78,7 @@ Then show the status buffer for the new repository."
          (when (or (eq  magit-clone-set-remote.pushDefault t)
                    (and magit-clone-set-remote.pushDefault
                         (y-or-n-p "Set `remote.pushDefault' to \"origin\"? ")))
-           (magit-set "origin" "remote" "pushDefault"))
+           (magit-call-git "config" "remote.pushDefault" "origin"))
          (unless magit-clone-set-remote-head
            (magit-remote-unset-head "origin")))
        (with-current-buffer (process-get process 'command-buf)
@@ -128,7 +128,7 @@ the variable isn't already set."
         ((or `(ask ,_) `(ask-if-unset nil))
          (y-or-n-p (format "Set `remote.pushDefault' to \"%s\"? " remote))))
       (progn (magit-call-git "remote" "add" "-f" remote url)
-             (magit-set remote "remote" "pushDefault")
+             (magit-call-git "config" "remote.pushDefault" remote)
              (magit-refresh))
     (magit-run-git-async "remote" "add" "-f" remote url)))
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -831,11 +831,11 @@ current branch.  The description is taken from the Git variable
 `branch.<NAME>.description'; if that is undefined then no header
 line is inserted at all."
   (let ((branch (magit-get-current-branch)))
-    (--when-let (magit-git-lines
-                 "config" (format "branch.%s.description" branch))
+    (-when-let* ((desc (magit-get "branch" branch "description"))
+                 (desc-lines (split-string desc "\n")))
       (magit-insert-section (branchdesc branch t)
-        (magit-insert-heading branch ": " (car it))
-        (insert (mapconcat 'identity (cdr it) "\n"))
+        (magit-insert-heading branch ": " (car desc-lines))
+        (insert (mapconcat 'identity (cdr desc-lines) "\n"))
         (insert "\n\n")))))
 
 (defconst magit-refs-branch-line-re
@@ -1660,9 +1660,8 @@ already set.  When nil, then always unset."
                        (magit-read-upstream-branch)))))
   (if upstream
       (-let (((remote . merge) (magit-split-branch-name upstream)))
-        (magit-call-git "config" (format "branch.%s.remote" branch) remote)
-        (magit-call-git "config" (format "branch.%s.merge"  branch)
-                        (concat "refs/heads/" merge)))
+        (magit-set remote "branch" branch "remote")
+        (magit-set (concat "refs/heads/" merge) "branch" branch "merge"))
     (magit-call-git "branch" "--unset-upstream" branch))
   (when (called-interactively-p 'any)
     (magit-refresh)))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1660,8 +1660,9 @@ already set.  When nil, then always unset."
                        (magit-read-upstream-branch)))))
   (if upstream
       (-let (((remote . merge) (magit-split-branch-name upstream)))
-        (magit-set remote "branch" branch "remote")
-        (magit-set (concat "refs/heads/" merge) "branch" branch "merge"))
+        (magit-call-git "config" (format "branch.%s.remote" branch) remote)
+        (magit-call-git "config" (format "branch.%s.merge"  branch)
+                        (concat "refs/heads/" merge)))
     (magit-call-git "branch" "--unset-upstream" branch))
   (when (called-interactively-p 'any)
     (magit-refresh)))


### PR DESCRIPTION
It shaves a couple 100 ms or so from refreshing the status

With `master`:
```
Refreshing magit...done (1.107s, cached 27/53)
Refreshing magit...done (1.107s, cached 27/53)
Refreshing magit...done (1.108s, cached 27/53)
```

With the patch:
```
Refreshing magit...done (0.921s, cached 33/53)
Refreshing magit...done (0.936s, cached 33/53)
Refreshing magit...done (0.951s, cached 33/53)
```