### PR TITLE
magit-branch-description: Fix for detached head

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -830,13 +830,13 @@ Insert a header line with the name and description of the
 current branch.  The description is taken from the Git variable
 `branch.<NAME>.description'; if that is undefined then no header
 line is inserted at all."
-  (let ((branch (magit-get-current-branch)))
-    (-when-let* ((desc (magit-get "branch" branch "description"))
-                 (desc-lines (split-string desc "\n")))
-      (magit-insert-section (branchdesc branch t)
-        (magit-insert-heading branch ": " (car desc-lines))
-        (insert (mapconcat 'identity (cdr desc-lines) "\n"))
-        (insert "\n\n")))))
+  (-when-let* ((branch (magit-get-current-branch))
+               (desc (magit-get "branch" branch "description"))
+               (desc-lines (split-string desc "\n")))
+    (magit-insert-section (branchdesc branch t)
+      (magit-insert-heading branch ": " (car desc-lines))
+      (insert (mapconcat 'identity (cdr desc-lines) "\n"))
+      (insert "\n\n"))))
 
 (defconst magit-refs-branch-line-re
   (concat "^"


### PR DESCRIPTION
When `magit-show-refs-popup` is called in a detached HEAD throws an error because `(magit-get-current-branch) => nil`