### PR TITLE
allow magit-repository-directories to specify depth per element

### DIFF
--- a/Documentation/RelNotes/2.7.1.txt
+++ b/Documentation/RelNotes/2.7.1.txt
@@ -18,6 +18,11 @@ Changes since v2.7.0
 * Added support for showing and copying bad commit identified by git
   bisect.
 
+* In addition to the directory, each member of the value of option
+  `magit-repository-directories' can now specify the depth to look for
+  repositories inside that directory, overriding the default depth
+  specified using the option `magit-repository-directories-depth'.
+
 * Added new command `magit-branch-orphan'.
 
 Fixes since v2.7.0

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1449,15 +1449,20 @@ that it should be bound globally.  We recommend using ~C-x g~:
 
 - User Option: magit-repository-directories
 
-  Directories containing Git repositories.  Magit checks these
-  directories for Git repositories and offers them as choices when
-  ~magit-status~ is used with a prefix argument.
+  List of directories that are or contain Git repositories.  Each
+  element has the form ~(DIRECTORY . DEPTH)~ or, for backward
+  compatibility, just DIRECTORY.  DIRECTORY has to be a directory or
+  a directory file-name, a string.  DEPTH, an integer, specifies the
+  maximum depth to look for Git repositories.  If it is 0, then only
+  add DIRECTORY itself.  For elements that are strings, the value of
+  option ~magit-repository-directories-depth~ specifies the depth.
 
 - User Option: magit-repository-directories-depth
 
-  The maximum depth to look for Git repositories.  When looking for
-  a Git repository below the directories in
-  ~magit-repository-directories~, only descend this many levels deep.
+  The maximum depth to look for Git repositories.  This option is
+  obsolete and only used for elements of the option
+  ~magit-repository-directories~ (which see) that don't specify the
+  depth directly.
 
 - Command: ido-enter-magit-status
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -1988,16 +1988,21 @@ then offer to initialize it as a new repository.
 
 @defopt magit-repository-directories
 
-Directories containing Git repositories.  Magit checks these
-directories for Git repositories and offers them as choices when
-@code{magit-status} is used with a prefix argument.
+List of directories that are or contain Git repositories.  Each
+element has the form @code{(DIRECTORY . DEPTH)} or, for backward
+compatibility, just DIRECTORY.  DIRECTORY has to be a directory or
+a directory file-name, a string.  DEPTH, an integer, specifies the
+maximum depth to look for Git repositories.  If it is 0, then only
+add DIRECTORY itself.  For elements that are strings, the value of
+option @code{magit-repository-directories-depth} specifies the depth.
 @end defopt
 
 @defopt magit-repository-directories-depth
 
-The maximum depth to look for Git repositories.  When looking for
-a Git repository below the directories in
-@code{magit-repository-directories}, only descend this many levels deep.
+The maximum depth to look for Git repositories.  This option is
+obsolete and only used for elements of the option
+@code{magit-repository-directories} (which see) that don't specify the
+depth directly.
 @end defopt
 
 @cindex ido-enter-magit-status

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -290,18 +290,23 @@ and change branch related variables."
   :type 'boolean)
 
 (defcustom magit-repository-directories nil
-  "Directories containing Git repositories.
-Magit checks these directories for Git repositories and offers
-them as choices when `magit-status' is used with a prefix
-argument."
+  "List of directories that are or contain Git repositories.
+Each element has the form (DIRECTORY . DEPTH) or, for backward
+compatibility, just DIRECTORY.  DIRECTORY has to be a directory
+or a directory file-name, a string.  DEPTH, an integer, specifies
+the maximum depth to look for Git repositories.  If it is 0, then
+only add DIRECTORY itself.  For elements that are strings, the
+value of option `magit-repository-directories-depth' specifies
+the depth."
+  :package-version '(magit . "2.7.1")
   :group 'magit
-  :type '(repeat string))
+  :type '(repeat (choice (cons directory (integer :tag "Depth")) directory)))
 
 (defcustom magit-repository-directories-depth 3
   "The maximum depth to look for Git repositories.
-When looking for a Git repository below the directories in
-`magit-repository-directories', only descend this many levels
-deep."
+This option is obsolete and only used for elements of the option
+`magit-repository-directories' (which see) that don't specify the
+depth directly."
   :group 'magit
   :type 'integer)
 
@@ -2839,7 +2844,9 @@ With prefix argument simply read a directory name using
                           (or (magit-toplevel) default-directory)))))
 
 (defun magit-list-repos ()
-  (--mapcat (magit-list-repos-1 it magit-repository-directories-depth)
+  (--mapcat (if (consp it)
+                (magit-list-repos-1 (car it) (cdr it))
+              (magit-list-repos-1 it magit-repository-directories-depth))
             magit-repository-directories))
 
 (defun magit-list-repos-1 (directory depth)


### PR DESCRIPTION
An element can now be a cons-cell whose cdr is the depth.  For elements
that are strings the value of `magit-repository-directories` is still
used.

---

Suddenly I can no longer export the manuals and have yet to figure out what changed. @kyleam could you please regenerate the manual and amend to this commit for me.