### PR TITLE
Make magit-submodule-read-name autoloadable

### DIFF
--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -65,6 +65,7 @@ PATH also becomes the name."
              (magit-submodule-read-name path)))))
   (magit-run-git "submodule" "add" (and name (list "--name" name)) url path))
 
+;;;###autoload
 (defun magit-submodule-read-name (path)
   (setq path (directory-file-name (file-relative-name path)))
   (push (file-name-nondirectory path) minibuffer-history)


### PR DESCRIPTION
This fixes the following use case:
1. `git clone` some repo inside of your other repo, not with Magit (e.g. in shell).
2. Open Magit Status buffer.
3. Try to stage that new cloned directory using `s`.

If no Magit's submodule related functionality was used after the Emacs startup, the following error will occur:
```
Debugger entered--Lisp error: (void-function magit-submodule-read-name)
  magit-submodule-read-name("layers/my-web-dev/local/ede-php-autoload/")
  magit-stage-untracked(nil)
  magit-stage(nil)
  call-interactively(magit-stage nil nil)
  command-execute(magit-stage)
```