### PR TITLE
Include subtrees in the dispatch pop-up

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -2619,6 +2619,7 @@ Currently this only adds the following key bindings.
              (?m "Merging"         magit-merge-popup)
              (?M "Remoting"        magit-remote-popup)
              (?o "Submodules"      magit-submodule-popup)
+             (?O "Subtrees"        magit-subtree-popup)
              (?P "Pushing"         magit-push-popup)
              (?r "Rebasing"        magit-rebase-popup)
              (?t "Tagging"         magit-tag-popup)


### PR DESCRIPTION
Until I looked at the manual, I didn't realize that magit supports subtree commands.  Mostly because I don't check the manual, figuring the dispatch pop-up will tell me what I want to know.  This adds subtrees to the dispatcher.