### PR TITLE
magit-get: return all lines of config value

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1428,12 +1428,16 @@ Return a list of two integers: (A>B B>A)."
 
 (defun magit-get (&rest keys)
   "Return the value of Git config entry specified by KEYS."
-  (magit-git-str "config" (mapconcat 'identity keys ".")))
+  (car (magit-git-items "config" "-z" (mapconcat 'identity keys "."))))
+
+(defun magit-get-line (&rest keys)
+  "Return the first line of Git config entry specified by KEYS."
+  (car (split-string (apply #'magit-get keys) "\n")))
 
 (defun magit-get-all (&rest keys)
   "Return all values of the Git config entry specified by KEYS."
   (let ((magit-git-debug nil))
-    (magit-git-lines "config" "--get-all" (mapconcat 'identity keys "."))))
+    (magit-git-items "config" "-z" "--get-all" (mapconcat 'identity keys "."))))
 
 (defun magit-get-boolean (&rest keys)
   "Return the boolean value of Git config entry specified by KEYS."

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -718,8 +718,8 @@ Do so depending on the value of `status.showUntrackedFiles'."
 
 (defun magit-insert-user-header ()
   "Insert a header line about the current user."
-  (let ((name  (magit-get "user.name"))
-        (email (magit-get "user.email")))
+  (let ((name  (magit-get-line "user.name"))
+        (email (magit-get-line "user.email")))
     (when (and name email)
       (magit-insert-section (user name)
         (insert (format "%-10s" "User: "))


### PR DESCRIPTION
```
New function magit-get-line gets only first line, as previous behaviour
of magit-get.  This is used only for user.name and user.email.

Also make sure to include newlines in values returned by magit-get-all.
```
Fixes #2719.