### PR TITLE
Use higher contrast for magit-blame with dark themes.

### DIFF
--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -94,7 +94,7 @@ and then turned on again when turning off the latter."
      :foreground "black")
     (((class color) (background dark))
      :background "grey25"
-     :foreground "black"))
+     :foreground "white"))
   "Face for blame headings."
   :group 'magit-faces)
 


### PR DESCRIPTION
Currently, magit uses black text for both light and dark themes. For
dark themes, this means there's very little contrast and commit messages
are hard to read.

Instead, use a constrasting color for dark themes.

Before:

![screen shot 2016-07-20 at 14 44 45](https://cloud.githubusercontent.com/assets/70800/16988606/dc13739c-4e88-11e6-831d-45ee380959a5.png)

After:

![screen shot 2016-07-20 at 14 45 24](https://cloud.githubusercontent.com/assets/70800/16988617/e5032010-4e88-11e6-9dcf-ad40df9242e9.png)
