### PR TITLE
Doc fix: Flip upstream ref format specifiers `%u`/`%U`

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2439,9 +2439,9 @@ should also change the others to keep things aligned.  The following
 - ~%h~ Hash of this ref's tip.
 - ~%m~ Commit summary of the tip of this ref.
 - ~%n~ Name of this ref.
-- ~%u~ Upstream of this local branch and additional local vs. upstream
+- ~%u~ Upstream of this local branch.
+- ~%U~ Upstream of this local branch and additional local vs. upstream
   information.
-- ~%U~ Upstream of this local branch.
 
 - Variable: magit-refs-local-branch-format
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -3315,11 +3315,11 @@ is the current branch, or "#" otherwise.  For all other refs " ".
 @code{%n} Name of this ref.
 
 @item
-@code{%u} Upstream of this local branch and additional local vs. upstream
-information.
+@code{%u} Upstream of this local branch.
 
 @item
-@code{%U} Upstream of this local branch.
+@code{%U} Upstream of this local branch and additional local vs. upstream
+information.
 
 @end itemize
 


### PR DESCRIPTION
Section [5.5 References buffer](https://github.com/magit/magit/blob/master/Documentation/magit.texi#L3317-L3322) in the manual seems to be diametrically opposed to the function [`magit-insert-branch-1`](https://github.com/magit/magit/blob/master/lisp/magit.el#L1060-L1073) on the meaning of the upstream format specifiers `%u` and `%U`.

An alternative reconciliation approach would see the formatter function, rather than the documentation, changed. I think it is safe to suggest that assigning superset semantics to the upper case flag is more conventional than the alternative, without being accused of seeing authoritarian values in such detached objects as format specifiers. :)