### PR TITLE
Recenter hunk after movement/refresh

### DIFF
--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -58,7 +58,7 @@ That function in turn is used by all section movement commands."
   :group 'magit-section
   :type 'hook
   :options '(magit-section-set-window-start
-             magit-hunk-maybe-recenter
+             magit-diff-maybe-recenter
              magit-hunk-set-window-start
              magit-status-maybe-update-revision-buffer
              magit-status-maybe-update-blob-buffer
@@ -276,15 +276,15 @@ It the SECTION has a different type, then do nothing."
   (when (eq (magit-section-type section) 'hunk)
     (magit-section-set-window-start section)))
 
-(defun magit-hunk-maybe-recenter (section)
-  "Ensure the beginning of the `hunk' SECTION is visible and maybe the end too.
+(defun magit-diff-maybe-recenter (section)
+  "Ensure beginning and maybe end of the diff-related SECTION are visible.
 
 First make the beginning visible. Then, if the end isn't visible
 yet, attempt to scroll the window to make the end visible, while
 still keeping the beginning visible.
 
-It the SECTION has a different type, then do nothing."
-  (when (eq (magit-section-type section) 'hunk)
+It the SECTION's type isn't `hunk' of `file', then do nothing."
+  (when (memq (magit-section-type section) '(hunk file))
     (magit-section-set-window-start section)
     (unless (pos-visible-in-window-p (magit-section-end section))
       (recenter 0))))
@@ -925,8 +925,8 @@ invisible."
                         (siblings (magit-section-siblings section 'prev))
                         (previous (nth (length siblings) children)))
                    (if (not arg)
-                       (--when-let (or previous (car (last children)))
-                         (magit-section-goto it)
+                       (-when-let (sibling (or previous (car (last children))))
+                         (magit-section-goto sibling)
                          t)
                      (when previous
                        (magit-section-goto previous))
@@ -939,6 +939,16 @@ invisible."
                        (while (looking-at "^ ")    (forward-line -1))
                        (while (looking-at "^[-+]") (forward-line -1))
                        (forward-line))))))
+          (and (eq (magit-section-type section) 'file)
+               (-when-let (sibling
+                           (or (--when-let
+                                   (car (magit-section-siblings section 'next))
+                                 (magit-get-section (magit-section-ident it)))
+                               (--when-let
+                                   (car (magit-section-siblings section 'prev))
+                                 (magit-get-section (magit-section-ident it)))))
+                 (magit-section-goto sibling)
+                 t))
           (goto-char (--if-let (magit-section-goto-successor-1 section)
                          (if (eq (magit-section-type it) 'button)
                              (point-min)

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -57,7 +57,9 @@ That function in turn is used by all section movement commands."
   :package-version '(magit . "2.3.0")
   :group 'magit-section
   :type 'hook
-  :options '(magit-hunk-set-window-start
+  :options '(magit-section-set-window-start
+             magit-hunk-maybe-recenter
+             magit-hunk-set-window-start
              magit-status-maybe-update-revision-buffer
              magit-status-maybe-update-blob-buffer
              magit-log-maybe-update-revision-buffer
@@ -273,6 +275,19 @@ If there is no previous sibling section, then move to the parent."
 It the SECTION has a different type, then do nothing."
   (when (eq (magit-section-type section) 'hunk)
     (magit-section-set-window-start section)))
+
+(defun magit-hunk-maybe-recenter (section)
+  "Ensure the beginning of the `hunk' SECTION is visible and maybe the end too.
+
+First make the beginning visible. Then, if the end isn't visible
+yet, attempt to scroll the window to make the end visible, while
+still keeping the beginning visible.
+
+It the SECTION has a different type, then do nothing."
+  (when (eq (magit-section-type section) 'hunk)
+    (magit-section-set-window-start section)
+    (unless (pos-visible-in-window-p (magit-section-end section))
+      (recenter 0))))
 
 (defmacro magit-define-section-jumper (name heading type &optional value)
   "Define an interactive function to go some section.

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -926,9 +926,10 @@ invisible."
                         (previous (nth (length siblings) children)))
                    (if (not arg)
                        (--when-let (or previous (car (last children)))
-                         (goto-char (magit-section-start it)))
+                         (magit-section-goto it)
+                         t)
                      (when previous
-                       (goto-char (magit-section-start previous)))
+                       (magit-section-goto previous))
                      (if (and (stringp arg)
                               (re-search-forward
                                arg (magit-section-end parent) t))

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -58,7 +58,7 @@ That function in turn is used by all section movement commands."
   :group 'magit-section
   :type 'hook
   :options '(magit-section-set-window-start
-             magit-diff-maybe-recenter
+             magit-hunk-maybe-recenter
              magit-hunk-set-window-start
              magit-status-maybe-update-revision-buffer
              magit-status-maybe-update-blob-buffer
@@ -276,15 +276,15 @@ It the SECTION has a different type, then do nothing."
   (when (eq (magit-section-type section) 'hunk)
     (magit-section-set-window-start section)))
 
-(defun magit-diff-maybe-recenter (section)
-  "Ensure beginning and maybe end of the diff-related SECTION are visible.
+(defun magit-hunk-maybe-recenter (section)
+  "Ensure the beginning of the `hunk' SECTION is visible and maybe the end too.
 
 First make the beginning visible. Then, if the end isn't visible
 yet, attempt to scroll the window to make the end visible, while
 still keeping the beginning visible.
 
-It the SECTION's type isn't `hunk' of `file', then do nothing."
-  (when (memq (magit-section-type section) '(hunk file))
+It the SECTION has a different type, then do nothing."
+  (when (eq (magit-section-type section) 'hunk)
     (magit-section-set-window-start section)
     (unless (pos-visible-in-window-p (magit-section-end section))
       (recenter 0))))
@@ -925,8 +925,8 @@ invisible."
                         (siblings (magit-section-siblings section 'prev))
                         (previous (nth (length siblings) children)))
                    (if (not arg)
-                       (-when-let (sibling (or previous (car (last children))))
-                         (magit-section-goto sibling)
+                       (--when-let (or previous (car (last children)))
+                         (magit-section-goto it)
                          t)
                      (when previous
                        (magit-section-goto previous))
@@ -939,16 +939,6 @@ invisible."
                        (while (looking-at "^ ")    (forward-line -1))
                        (while (looking-at "^[-+]") (forward-line -1))
                        (forward-line))))))
-          (and (eq (magit-section-type section) 'file)
-               (-when-let (sibling
-                           (or (--when-let
-                                   (car (magit-section-siblings section 'next))
-                                 (magit-get-section (magit-section-ident it)))
-                               (--when-let
-                                   (car (magit-section-siblings section 'prev))
-                                 (magit-get-section (magit-section-ident it)))))
-                 (magit-section-goto sibling)
-                 t))
           (goto-char (--if-let (magit-section-goto-successor-1 section)
                          (if (eq (magit-section-type it) 'button)
                              (point-min)


### PR DESCRIPTION
Closes #2683.

This isn't enabled by default (yet?). Use to enable:

```lisp
(add-hook    'magit-section-movement-hook 'magit-hunk-maybe-recenter)
(remove-hook 'magit-section-movement-hook 'magit-hunk-set-window-start)
```