### PR TITLE
add feature: stage hunk in magit-diff buffer

### DIFF
--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -292,6 +292,7 @@ ignored) files.
       (`(unstaged      ,_) (user-error "Already unstaged"))
       (`(staged    region) (magit-apply-region it "--reverse" "--cached"))
       (`(staged      hunk) (magit-apply-hunk   it "--reverse" "--cached"))
+      (`(committed   hunk) (magit-apply-hunk   it "--reverse" "--cached"))
       (`(staged     hunks) (magit-apply-hunks  it "--reverse" "--cached"))
       (`(staged      file) (magit-unstage-1 (list (magit-section-value it))))
       (`(staged     files) (magit-unstage-1 (magit-region-values)))


### PR DESCRIPTION
in magit-diff buffer, if the file of the diff hunk is managed by git, press "s" will cause "Cannot  stage committed changes".