### PR TITLE
magit-process-password-prompt-regexps: add regexp for PCSC-Lite PIN

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -139,7 +139,8 @@ itself from the hook, to avoid further futile attempts."
     ;; match-group 99 is used to identify a host
     "^\\(Enter \\)?[Pp]assword\\( for '\\(?99:.*\\)'\\)?: ?$"
     "^.*'s password: ?$"
-    "^Yubikey for .*: ?$")
+    "^Yubikey for .*: ?$"
+    "^Enter PIN for .*: ?$")
   "List of regexps matching password prompts of Git and its subprocesses.
 Also see `magit-process-find-password-functions'."
   :package-version '(magit . "2.1.0")


### PR DESCRIPTION
This adds a regexp to the `magit-process-password-prompt-regexps` list.

I'm running pcsc-lite version 1.8.14 on NixOS. The output I get when I run a command like `git push` is `Enter PIN for 'PIV_II (PIV Card Holder pin)':`. I don't know how consistent that is across different environments. I'll be able to try it on Debian Jessie and Fedora 24 before the end of the month, so you could wait to merge this until I double check that. 