### PR TITLE
magit-show-commit: use magit-buffer-refname

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -820,6 +820,7 @@ for a revision."
           (atpoint (or (and (bound-and-true-p magit-blame-mode)
                             (magit-blame-chunk-get :hash))
                        mcommit
+                       magit-buffer-refname
                        (magit-branch-or-commit-at-point)
                        (magit-tag-at-point))))
      (nconc (cons (or (and (not current-prefix-arg) atpoint)


### PR DESCRIPTION
This allows `magit-show-commit` work with buffers opened with `magit-diff-visit-file` 