### PR TITLE
set show-trailing-whitespace nil

### DIFF
--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -999,6 +999,7 @@ restored."
   :mode 'magit-popup
   (setq truncate-lines t)
   (setq buffer-read-only t)
+  (setq show-trailing-whitespace nil)
   (setq-local scroll-margin 0)
   (setq-local magit-popup-show-common-commands magit-popup-show-common-commands)
   (hack-dir-local-variables-non-file-buffer))


### PR DESCRIPTION
I have `(setq-default show-trailing-whitespace t)` in my `init.el`. (see [GNU Emacs Manual: Useless Whitespace](http://www.gnu.org/software/emacs/manual/html_node/emacs/Useless-Whitespace.html))

## Before

<img width="710" alt="2016-08-23 1 30 29" src="https://cloud.githubusercontent.com/assets/822086/17862798/cffc6650-68d1-11e6-81ff-8f1414a82da4.png">

## After

<img width="698" alt="2016-08-23 1 32 47" src="https://cloud.githubusercontent.com/assets/822086/17862822/e5eb6ec0-68d1-11e6-9091-6c0f9e9e6045.png">
