### PR TITLE
remove "e" binding for magit-ediff-dwim

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -2626,7 +2626,6 @@ Currently this only adds the following key bindings.
              (?c "Committing"      magit-commit-popup)
              (?d "Diffing"         magit-diff-popup)
              (?D "Change diffs"    magit-diff-refresh-popup)
-             (?e "Ediff dwimming"  magit-ediff-dwim)
              (?E "Ediffing"        magit-ediff-popup)
              (?f "Fetching"        magit-fetch-popup)
              (?F "Pulling"         magit-pull-popup)


### PR DESCRIPTION
The reason I submit this pull request, with all due respect, is that occasionally I press the "e" key accidentally, which rearranges my buffers and opens several copies of the file I've selected.

The function can still be reached from the ediff popup.  We could have the "e" key open the popup ("E" does currently).