### PR TITLE
git-rebase: disable save check when showing commits

### DIFF
--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -128,7 +128,7 @@
     (define-key map (kbd "q")    'undefined)
     (define-key map [remap undo] 'git-rebase-undo)
     (define-key map (kbd "RET") 'git-rebase-show-commit)
-    (define-key map (kbd "SPC") 'magit-diff-show-or-scroll-up)
+    (define-key map (kbd "SPC") 'git-rebase-show-or-scroll-up)
     (define-key map (kbd "x")   'git-rebase-exec)
     (define-key map (kbd "c")   'git-rebase-pick)
     (define-key map (kbd "r")   'git-rebase-reword)
@@ -351,15 +351,26 @@ Like `undo' but works in read-only buffers."
   (let ((inhibit-read-only t))
     (undo arg)))
 
+(defun git-rebase--show-commit (&optional scroll)
+  (let ((disable-magit-save-buffers t))
+    (save-excursion
+      (goto-char (line-beginning-position))
+      (--if-let (and (looking-at git-rebase-line)
+                     (match-string 2))
+          (if scroll
+              (magit-diff-show-or-scroll-up)
+            (apply #'magit-show-commit it (magit-diff-arguments)))
+        (ding)))))
+
 (defun git-rebase-show-commit ()
   "Show the commit on the current line if any."
   (interactive)
-  (save-excursion
-    (goto-char (line-beginning-position))
-    (--if-let (and (looking-at git-rebase-line)
-                   (match-string 2))
-        (apply #'magit-show-commit it (magit-diff-arguments))
-      (ding))))
+  (git-rebase--show-commit))
+
+(defun git-rebase-show-or-scroll-up ()
+  "Update the commit buffer for commit on current line."
+  (interactive)
+  (git-rebase--show-commit t))
 
 (defun git-rebase-backward-line (&optional n)
   "Move N lines backward (forward if N is negative).


### PR DESCRIPTION
```
The git-rebase-todo buffer is frequently in a modified state, but there
is no need to save it before showing a commit.  It will be taken care of
by with-editor-return when the user exits through with-editor-finish.

The unsaved buffer should almost always be the git-rebase-todo because
the initial 'git rebase' call will fail if there are unstaged changes.
The user could unwisely go and modify some other tracked buffers after
starting a rebase, and this could put things into a bad state [1], but
this is unrelated to whether the user happened to call a command to show
a commit.

Closes #2770.

[1] And, when the user has done this, I don't think there is really any
    good action to take to fix the situation.  It's bad whether or not
    the buffer is saved.  The user should just never start an
    interactive rebase and then change buffers of tracked files before
    triggering the rebase with with-editor-finish.
```