### PR TITLE
Redefine popup when magit-define-popup re-eval'd

### DIFF
--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -546,6 +546,7 @@ usually specified in that order):
        (defun ,name (&optional arg) ,doc
          (interactive "P")
          (magit-invoke-popup ',name ,mode arg))
+       (makunbound ',name)
        (defvar ,name
          (list :variable ',opt ,@args))
        (magit-define-popup-keys-deferred ',name)


### PR DESCRIPTION
`defvar` will not change the value of a defined symbol, so we should
undefine it when `magit-define-popup` is re-evaluated.

`setq` could also have been used, but this would not behave correctly
with respect to the variable's reported default value.