### PR TITLE
Replaced obsolete function string-as-multibyte

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -620,7 +620,7 @@ Sorted from longest to shortest CYGWIN name."
 
 (defun magit-decode-git-path (path)
   (if (eq (aref path 0) ?\")
-      (string-as-multibyte (read path))
+      (decode-coding-string (read path))
     path))
 
 (defun magit-file-at-point ()


### PR DESCRIPTION
Saw the following error in my 'macs and wanted to get rid of it.

magit-git.el:623:8:Warning: ‘string-as-multibyte’ is an obsolete function (as
    of 25.2); use ‘decode-coding-string’.

See the build error here
https://travis-ci.org/magit/magit#L207