### PR TITLE
Update docs for magit-stash-drop keybinding

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -4250,7 +4250,7 @@ Also see [[info:gitman#git-stash]].
   staged changes, apply without preserving the stash index and forgo
   removing the stash.
 
-- Key: z d, magit-stash-drop
+- Key: z k, magit-stash-drop
 
   Remove a stash from the stash list.  When the region is active, offer
   to drop all contained stashes.


### PR DESCRIPTION
The keybinding assigned to magit-stash-drop (in magit-stash.el) is z k,
not z d.