### PR TITLE
Add INSIDE_EMACS to magit-git-environment

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -51,7 +51,7 @@
   "Git and other external processes used by Magit."
   :group 'magit)
 
-(defvar magit-git-environment nil
+(defvar magit-git-environment (list (format "INSIDE_EMACS=%s,magit" emacs-version))
   "Prepended to `process-environment' while running git.")
 
 (defcustom magit-git-executable
@@ -78,7 +78,8 @@
                                          (car (process-lines
                                                it "-c"
                                                "alias.P=!cygpath -wp \"$PATH\""
-                                               "P")))))))
+                                               "P")))
+                                 (format "INSIDE_EMACS=%s,magit" emacs-version)))))
                  ;; For 1.x, we search for bin/ next to cmd/.
                  (let ((alt (directory-file-name (file-name-directory it))))
                    (if (and (equal (file-name-nondirectory alt) "cmd")


### PR DESCRIPTION
This follows core Emacs behavior. For example M-x shell, term and epa
all export similar env vars. This will enable functionality such as the
pinentry package distributed with Emacs 25.1 being used for the
passphrase for git commit signing with gpg.