### PR TITLE
Fix magit-clone (and others?) while TRAMPing

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -611,7 +611,9 @@ Sorted from longest to shortest CYGWIN name."
             (cl-assoc filename magit-cygwin-mount-points
                       :test (lambda (f cyg) (string-prefix-p cyg f))))
       (concat win (substring filename (length cyg)))
-    filename))
+    (if (file-remote-p filename)
+        (tramp-file-name-localname (tramp-dissect-file-name filename))
+      filename)))
 
 (defun magit-convert-git-filename (filename)
   (-if-let ((cyg . win)


### PR DESCRIPTION
`magit-clone` would fail when called in a tramp directory. This was
specifically because the filename as passed to the the git process was
being expanded to include the magic portion of the name instead of just
the local portion.

All we need to do is test if the file is remote and get its local part
if it is.