### PR TITLE
Properly decode git utf-8 output on Windows

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -96,7 +96,9 @@
   :type 'string)
 
 (defcustom magit-git-global-arguments
-  '("--no-pager" "--literal-pathspecs" "-c" "core.preloadindex=true")
+  `("--no-pager" "--literal-pathspecs" "-c" "core.preloadindex=true"
+    ,@(and (eq system-type 'windows-nt)
+           (list "-c" "i18n.logOutputEncoding=UTF-8")))
   "Global git arguments.
 
 The arguments set here are used every time the git executable is
@@ -110,12 +112,10 @@ anything that is part of the default value, unless you really
 know what you are doing.  And think very hard before adding
 something; it will be used every time Magit runs Git for any
 purpose."
-  :package-version '(magit . "2.1.0")
+  :package-version '(magit . "2.9.0")
   :group 'magit
+  :group 'magit-process
   :type '(repeat string))
-
-(define-obsolete-variable-alias 'magit-git-standard-options
-  'magit-git-global-arguments "2.1.0")
 
 (defcustom magit-git-debug nil
   "Whether to enable additional reporting of git errors.
@@ -1487,6 +1487,8 @@ Return a list of two integers: (A>B B>A)."
 
 ;;; magit-git.el ends soon
 
+(define-obsolete-variable-alias 'magit-git-standard-options
+  'magit-git-global-arguments "Magit 2.1.0")
 (define-obsolete-function-alias 'magit-get-tracked-ref
   'magit-get-upstream-ref "Magit 2.4.0")
 (define-obsolete-function-alias 'magit-get-tracked-branch

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -45,14 +45,17 @@
 
 ;;; Options
 
-(defcustom magit-log-output-coding-system 'utf-8
-  "Default coding system for receiving log output from Git.
+(defcustom magit-git-output-coding-system
+  (and (eq system-type 'windows-nt) 'utf-8)
+  "Coding system for receiving output from Git.
 
-Should be consistent with the Git config value `i18n.logOutputEncoding'."
-  :package-version '(magit . "2.8.0")
+If non-nil, the Git config value `i18n.logOutputEncoding' should
+be set via `magit-git-global-arguments' to value consistent with
+this."
+  :package-version '(magit . "2.9.0")
   :group 'magit-process
-  :group 'magit-log
-  :type '(coding-system :tag "Coding system to decode Git log output"))
+  :type '(choice (coding-system :tag "Coding system to decode Git output")
+                 (const :tag "Use system default" nil)))
 
 (defcustom magit-process-connection-type (not (eq system-type 'cygwin))
   "Connection type used for the Git process.
@@ -303,8 +306,7 @@ before use.
 Process output goes into a new section in the buffer returned by
 `magit-process-buffer'."
   (run-hooks 'magit-pre-call-git-hook)
-  (let ((coding-system-for-read
-         (or coding-system-for-read magit-log-output-coding-system)))
+  (let ((default-process-coding-system (magit--process-coding-system)))
     (apply #'magit-call-process magit-git-executable
            (magit-process-git-arguments args))))
 
@@ -450,8 +452,7 @@ and still alive), as well as the respective Magit status buffer.
 
 See `magit-start-process' for more information."
   (run-hooks 'magit-pre-start-git-hook)
-  (let ((coding-system-for-read
-         (or coding-system-for-read magit-log-output-coding-system)))
+  (let ((default-process-coding-system (magit--process-coding-system)))
     (apply #'magit-start-process magit-git-executable input
            (magit-process-git-arguments args))))
 
@@ -697,12 +698,13 @@ Return the matched string suffixed with \": \", if needed."
             (t                             (concat prompt ": "))))))
 
 (defun magit--process-coding-system ()
-  (if magit-process-ensure-unix-line-ending
-      (cons (coding-system-change-eol-conversion
-             (car default-process-coding-system) 'unix)
-            (coding-system-change-eol-conversion
-             (cdr default-process-coding-system) 'unix))
-      default-process-coding-system))
+  (let ((fro (or magit-git-output-coding-system
+                 (car default-process-coding-system)))
+        (to (cdr default-process-coding-system)))
+    (if magit-process-ensure-unix-line-ending
+        (cons (coding-system-change-eol-conversion fro 'unix)
+              (coding-system-change-eol-conversion to 'unix))
+      (cons fro to))))
 
 (defvar magit-credential-hook nil
   "Hook run before Git needs credentials.")
@@ -863,6 +865,10 @@ as argument."
                              process))))))
 
 ;;; magit-process.el ends soon
+
+(define-obsolete-variable-alias 'magit-git-output-coding-system
+  'magit-log-output-coding-system "Magit 2.9.0")
+
 (provide 'magit-process)
 ;; Local Variables:
 ;; indent-tabs-mode: nil


### PR DESCRIPTION
All git commands which print file names and similar encoding in utf-8 on
Windows.  The encoding of commit messages is controlled by
i18n.logOutputEncoding, but it's easier to set that to UTF-8 than try to
distinguish between commands that respect and those that don't.

magit-log-output-coding-system should probably be obsoleted/removed.