### PR TITLE
magit-diff-dwmin: on branch, show diff for MERGE-BASE...BRANCH

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -727,7 +727,8 @@ If no DWIM context is found, nil is returned."
                       (if (magit-anything-modified-p)
                           current
                         (cons 'commit current)))
-                  (format "%s...%s" current atpoint))))
+                  (let ((base (magit-git-string "merge-base" current atpoint)))
+                    (format "%s...%s" base atpoint)))))
       (commit (cons 'commit (magit-section-value it)))
       (stash (cons 'stash (magit-section-value it)))))))
 


### PR DESCRIPTION
This shows all the changes that would be made if BRANCH were to be
merged into CURRENT. It can also be very quick for small changes being
merged into a master branch that has diverged from a feature branch from
further development.

Re: #2812 

@tarsius Thanks for your addressing of #2812. It showed me how to do what I was hoping for. I've modified the behavior of the diff-dwim again in this PR to match what I was asking for, but this version may be strange depending on people's workflows. For my workflow, the change in this PR would be better for dwim, but I'm not sure if that's true for everyone. 

If this doesn't seem like the right behavior for DWIM, I'd like to propose making a new diff function that does this, since it is extremely useful for my workflow. Perhaps we could call it "Diff merge-base" on <kbd>d m</kbd>.