### PR TITLE
let-bind `shell-file-name' around with-editor calls

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -249,12 +249,11 @@ depending on the value of option `magit-commit-squash-confirm'."
           (unless edit
             (push "--no-edit" args))
           (if rebase
-              (with-editor "GIT_EDITOR"
-                (let ((magit-process-popup-time -1))
-                  (magit-call-git
-                   "commit" (-remove-first
-                             (apply-partially #'string-match-p "\\`--gpg-sign=")
-                             args))))
+              (magit-with-editor
+                (magit-call-git
+                 "commit" (-remove-first
+                           (apply-partially #'string-match-p "\\`--gpg-sign=")
+                           args)))
             (magit-run-git-with-editor "commit" args)))
       (magit-log-select
         `(lambda (commit)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -203,6 +203,13 @@ change the upstream and many which create new branches."
                value)))
        ,@body)))
 
+(defmacro magit-with-editor (&rest body)
+  "Like `with-editor' but let-bind some more variables."
+  (declare (indent 0) (debug (body)))
+  `(let ((magit-process-popup-time -1)
+     (with-editor "GIT_EDITOR"
+       ,@body)))
+
 (defun magit-process-git-arguments (args)
   "Prepare ARGS for a function that invokes Git.
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -207,6 +207,18 @@ change the upstream and many which create new branches."
   "Like `with-editor' but let-bind some more variables."
   (declare (indent 0) (debug (body)))
   `(let ((magit-process-popup-time -1)
+         ;; The user may have customized `shell-file-name' to
+         ;; something which results in `w32-shell-dos-semantics' nil
+         ;; (which changes the quoting style used by
+         ;; `shell-quote-argument'), but Git for Windows expects shell
+         ;; quoting in the dos style.
+         (shell-file-name (if (and (eq system-type 'windows-nt)
+                                   ;; If we have Cygwin mount points
+                                   ;; the git flavor is cygwin, so dos
+                                   ;; shell quoting is probably wrong.
+                                   (not magit-cygwin-mount-points))
+                              "cmdproxy"
+                            shell-file-name)))
      (with-editor "GIT_EDITOR"
        ,@body)))
 

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -428,9 +428,7 @@ If the sequence stops at a commit, make the section representing
 that commit the current section by moving `point' there.
 
 See `magit-start-process' and `with-editor' for more information."
-  (with-editor "GIT_EDITOR"
-    (let ((magit-process-popup-time -1))
-      (magit-run-git-async args)))
+  (apply #'magit-run-git-with-editor args)
   (set-process-sentinel magit-this-process #'magit-sequencer-process-sentinel)
   magit-this-process)
 

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -410,9 +410,7 @@ current when this function was called (if it is a Magit buffer
 and still alive), as well as the respective Magit status buffer.
 
 See `magit-start-process' and `with-editor' for more information."
-  (with-editor "GIT_EDITOR"
-    (let ((magit-process-popup-time -1))
-      (magit-run-git-async args))))
+  (magit-with-editor (magit-run-git-async args)))
 
 (defun magit-run-git-sequencer (&rest args)
   "Export GIT_EDITOR and start Git.

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -2050,9 +2050,8 @@ edit it.
                      (magit-merge-arguments)))
   (magit-merge-assert)
   (cl-pushnew "--no-ff" args :test #'equal)
-  (with-editor "GIT_EDITOR"
-    (let ((magit-process-popup-time -1))
-      (magit-run-git-async "merge" "--edit" args rev))))
+  (apply #'magit-run-git-with-editor "merge" "--edit"
+         (append args (list rev))))
 
 ;;;###autoload
 (defun magit-merge-nocommit (rev &optional args)


### PR DESCRIPTION
Fixes #2794.

https://github.com/magit/magit/issues/2794#issuecomment-252183157:
> If it's around every call, why not just move it inside?

The need to do this binding is git specific, so the decision can't be made by `with-editor`.

> `magit-with-editor` is probably the best we can do.

Yes.