### PR TITLE
Fix backwards obsolete variable alias

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -867,8 +867,8 @@ as argument."
 
 ;;; magit-process.el ends soon
 
-(define-obsolete-variable-alias 'magit-git-output-coding-system
-  'magit-log-output-coding-system "Magit 2.9.0")
+(define-obsolete-variable-alias 'magit-log-output-coding-system
+  'magit-git-output-coding-system "Magit 2.9.0")
 
 (provide 'magit-process)
 ;; Local Variables:


### PR DESCRIPTION
Just saw a warning when installing magit and went poking around briefly. I can't vouch for this change being correct ― take this PR as a linter suggestion :)

CC @npostavs who authored d176dfc5b8f00053bf02485a9d461639f9e38c05.