### PR TITLE
Inhibit fsync when refining hunks

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2235,7 +2235,9 @@ are highlighted."
              (goto-char (magit-section-start section))
              ;; `diff-refine-hunk' does not handle combined diffs.
              (unless (looking-at "@@@")
-               (diff-refine-hunk))))
+               ;; Avoid fsyncing many small temp files
+               (let ((write-region-inhibit-fsync t))
+                 (diff-refine-hunk)))))
           ((or `(nil t ,_) `(t t nil))
            (setf (magit-section-refined section) nil)
            (remove-overlays (magit-section-start section)


### PR DESCRIPTION
I noticed that Emacs would sometimes thrash the disk very hard when I saved a file to disk.  By running `pkill -SIGUSR2 -f emacs` I saw that it was happening in magit's hunk-refining code.  I followed the calls and tracked it down to `smerge-refine-chopup-region`.  The problem seems to be that it writes many small files, and when Emacs is running in interactive mode, `write-region` calls `fsync`.  This results in many calls to `fsync`, which results in much disk thrashing and an unresponsive Emacs.

When `magit-diff-refine-hunk` is set to `all`, and the status buffer shows many changed hunks, this is a big problem, causing Emacs to thrash the disk for many seconds at a time, even when the status buffer is buried.

However, there seems to be a simple fix for this problem: Set `write-region-inhibit-fsync` in `magit-diff-update-hunk-refinement`, which causes the calls to `write-region` to happen without `fsync`.  This way those many small writes never touch the disk, the thrashing is eliminated, and the diff refinement seems instanteous.  It's effectively a one-line change that solves the whole problem.  :)

I searched the bug tracker and found #1581; I guess this basically fixes that issue too.
