### PR TITLE
Displace obsolete decoding function

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -56,6 +56,18 @@
   (list (format "INSIDE_EMACS=%s,magit" emacs-version))
   "Prepended to `process-environment' while running git.")
 
+(defcustom magit-git-output-coding-system
+  (and (eq system-type 'windows-nt) 'utf-8)
+  "Coding system for receiving output from Git.
+
+If non-nil, the Git config value `i18n.logOutputEncoding' should
+be set via `magit-git-global-arguments' to value consistent with
+this."
+  :package-version '(magit . "2.9.0")
+  :group 'magit-process
+  :type '(choice (coding-system :tag "Coding system to decode Git output")
+                 (const :tag "Use system default" nil)))
+
 (defcustom magit-git-executable
   ;; Git might be installed in a different location on a remote, so
   ;; it is better not to use the full path to the executable, except
@@ -671,7 +683,9 @@ Sorted from longest to shortest CYGWIN name."
 
 (defun magit-decode-git-path (path)
   (if (eq (aref path 0) ?\")
-      (decode-coding-string (read path) 'utf-8-emacs t)
+      (let ((coding-system (or magit-git-output-coding-system
+                               (car default-process-coding-system))))
+        (decode-coding-string (read path) coding-system t))
     path))
 
 (defun magit-file-at-point ()

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -671,7 +671,7 @@ Sorted from longest to shortest CYGWIN name."
 
 (defun magit-decode-git-path (path)
   (if (eq (aref path 0) ?\")
-      (string-as-multibyte (read path))
+      (decode-coding-string (read path) 'utf-8-emacs t)
     path))
 
 (defun magit-file-at-point ()

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -45,18 +45,6 @@
 
 ;;; Options
 
-(defcustom magit-git-output-coding-system
-  (and (eq system-type 'windows-nt) 'utf-8)
-  "Coding system for receiving output from Git.
-
-If non-nil, the Git config value `i18n.logOutputEncoding' should
-be set via `magit-git-global-arguments' to value consistent with
-this."
-  :package-version '(magit . "2.9.0")
-  :group 'magit-process
-  :type '(choice (coding-system :tag "Coding system to decode Git output")
-                 (const :tag "Use system default" nil)))
-
 (defcustom magit-process-connection-type (not (eq system-type 'cygwin))
   "Connection type used for the Git process.
 


### PR DESCRIPTION
##### Motivation
- As of `Emacs 25.2`, `string-as-multibyte` is obsolete.
##### Changelog
- Displace `string-as-multibyte` with the recommended `decode-coding-string` using the internal `utf-8-emacs` coding system.
##### Caveat
- I do not know whether `utf-8-emacs` is the correct coding system to use here; it was merely suggested as equivalent in the documentation for `string-as-multibyte`.
