### PR TITLE
Don’t raise errors when initializing ‘magit-need-cygwin-noglob’

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -70,9 +70,13 @@ If t, use ptys: this enables Magit to prompt for passphrases when needed."
   (equal "x0\n" (with-temp-buffer
                   (let ((process-environment
                          (append magit-git-environment process-environment)))
-                    (process-file magit-git-executable
-                                  nil (current-buffer) nil
-                                  "-c" "alias.echo=!echo" "echo" "x{0}"))
+                    (condition-case e
+                        (process-file magit-git-executable
+                                      nil (current-buffer) nil
+                                      "-c" "alias.echo=!echo" "echo" "x{0}")
+                      (file-error
+                       (lwarn 'magit-process :warning
+                              "Could not run Git: %S" e))))
                   (buffer-string)))
   "Whether to use a workaround for Cygwin's globbing behavior.
 


### PR DESCRIPTION
When magit-process.el is loaded in an environment where Git can’t be
executed (e.g. in a container or when Git isn’t installed), loading
fails.  Work around this by catching ‘file-error’ and turning it into a
warning.