### PR TITLE
Add gpg status letters X, Y, R, and E

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -819,7 +819,7 @@ Do not add this to a hook variable."
           "\\(?4:[-_/|\\*o. ]*\\)"                 ; graph
           "\\(?1:[0-9a-fA-F]+\\) "                 ; sha1
           "\\(?:\\(?3:([^()]+)\\) \\)?"            ; refs
-          "\\(?7:[BGUN]\\)?"                       ; gpg
+          "\\(?7:[BGUXYREN]\\)?"                   ; gpg
           "\\[\\(?5:[^]]*\\)\\]"                   ; author
           "\\[\\(?6:[^]]*\\)\\]"                   ; date
           "\\(?2:.*\\)$"))                         ; msg
@@ -955,7 +955,11 @@ Do not add this to a hook variable."
                               (pcase (and gpg (aref gpg 0))
                                 (?G 'magit-signature-good)
                                 (?B 'magit-signature-bad)
-                                (?U 'magit-signature-untrusted)))))
+                                (?U 'magit-signature-untrusted)
+                                (?X 'magit-signature-expired)
+                                (?Y 'magit-signature-expired-key)
+                                (?R 'magit-signature-revoked)
+                                (?E 'magit-signature-error)))))
         (when (and refs magit-log-show-refname-after-summary)
           (insert ?\s)
           (insert (magit-format-ref-labels refs)))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -454,13 +454,33 @@ an alist that supports the keys `:right-align' and `:pad-right'."
   :group 'magit-faces)
 
 (defface magit-signature-bad
-  '((t :foreground "red"))
+  '((t :foreground "red" :weight bold))
   "Face for bad signatures."
   :group 'magit-faces)
 
 (defface magit-signature-untrusted
   '((t :foreground "cyan"))
   "Face for good untrusted signatures."
+  :group 'magit-faces)
+
+(defface magit-signature-expired
+  '((t :foreground "orange"))
+  "Face for signatures that have expired."
+  :group 'magit-faces)
+
+(defface magit-signature-expired-key
+  '((t :inherit magit-signature-expired))
+  "Face for signatures made by an expired key."
+  :group 'magit-faces)
+
+(defface magit-signature-revoked
+  '((t :foreground "violet red"))
+  "Face for signatures made by a revoked key."
+  :group 'magit-faces)
+
+(defface magit-signature-error
+  '((t :foreground "firebrick3"))
+  "Face for signatures that cannot be checked (e.g. missing key)."
   :group 'magit-faces)
 
 (defface magit-cherry-unmatched


### PR DESCRIPTION
```
This adds support for Git 2.11's additional status letters for the %G?
specifier.

The magit-signature-bad face was given a bold weight to help distinguish
it from the new magit-signature-error face.
```

This covers the new status codes implemented [in upcoming Git 2.11](https://github.com/git/git/commit/56d268bafff7538f82c01d3c9c07bdc54b2993b1).

I'm not sure on the colours, but they seem to look alright.
