### PR TITLE
magit-log-wash-rev: set author to nil for stash lines

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -919,7 +919,10 @@ Do not add this to a hook variable."
       (magit-delete-line)
       (magit-insert-section section (commit hash)
         (pcase style
-          (`stash      (setf (magit-section-type section) 'stash))
+          (`stash      (setf (magit-section-type section) 'stash)
+                       ;; Replace blank space with nil for
+                       ;; `magit-format-log-margin'.
+                       (setq author nil))
           (`module     (setf (magit-section-type section) 'module-commit))
           (`bisect-log (setq hash (magit-rev-parse "--short" hash))))
         (when cherry


### PR DESCRIPTION
```
magit-log-stash-re matches the space after the hash as the author to fit
in with the other regexps used by magit-bind-match-strings in
magit-log-wash-rev.  This, however, results in a non-nil author argument
to magit-format-log-margin.  Because magit-stashes-mode derives from
magit-reflog-mode and uses its date-only margin specifications, a
non-nil author argument pushes the date outside of the margin width in
magit-stashes-mode.

Make magit-log-wash-rev set author to nil when washing stash lines so
that magit-format-log-margin receives the expected argument of nil for
author.

See #2846.
```