### PR TITLE
git-commit-setup: use normal-mode

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -222,11 +222,21 @@ to consider doing so."
   :safe 'numberp
   :type 'number)
 
-(defcustom git-commit-fill-column 72
-  "Automatically wrap commit message lines beyond this column."
+(defcustom git-commit-fill-column nil
+  "Override `fill-column' in commit message buffers.
+
+If this is non-nil, then it should be an integer.  If that is the
+case and the buffer-local value of `fill-column' is not already
+set by the time `git-commit-turn-on-auto-fill' is called as a
+member of `git-commit-setup-hook', then that function sets the
+buffer-local value of `fill-column' to the value of this option.
+
+This option exists mostly for historic reasons.  If you are not
+already using it, then you probably shouldn't start doing so."
   :group 'git-commit
   :safe 'numberp
-  :type 'number)
+  :type '(choice (const :tag "use regular fill-column")
+                 number))
 
 (defcustom git-commit-known-pseudo-headers
   '("Signed-off-by" "Acked-by" "Cc"
@@ -455,8 +465,12 @@ Don't use it directly, instead enable `global-git-commit-mode'."
 
 (defun git-commit-turn-on-auto-fill ()
   "Unconditionally turn on Auto Fill mode.
-And set `fill-column' to `git-commit-fill-column'."
-  (setq fill-column git-commit-fill-column)
+If `git-commit-fill-column' is non-nil, and `fill-column'
+doesn't already have a buffer-local value, then set that
+to `git-commit-fill-column'."
+  (when (and (numberp git-commit-fill-column)
+             (not (local-variable-p 'fill-column)))
+    (setq fill-column git-commit-fill-column))
   (turn-on-auto-fill))
 
 (defun git-commit-turn-on-flyspell ()

--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -391,7 +391,11 @@ to consider doing so."
     (when (file-accessible-directory-p (file-name-directory it))
       (find-alternate-file it)))
   (when git-commit-major-mode
-    (funcall git-commit-major-mode))
+    (let ((auto-mode-alist (list (cons (concat "\\`"
+                                               (regexp-quote buffer-file-name)
+                                               "\\'")
+                                       git-commit-major-mode))))
+      (normal-mode)))
   (setq with-editor-show-usage nil)
   (with-editor-mode 1)
   (add-hook 'with-editor-finish-query-functions


### PR DESCRIPTION
This ensures file and directory local variables are setup in the
standard way.

See #2848. This still leaves `git-commit-fill-column` overriding `fill-column`. Actually, I don't quite see why `git-commit-fill-column` exists at all...