### PR TITLE
display 'k' rather than 'C-k' for rebase-kill-line

### DIFF
--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -160,6 +160,7 @@
 
 (put 'git-rebase-reword :advertised-binding "r")
 (put 'git-rebase-move-line-up :advertised-binding (kbd "M-p"))
+(put 'git-rebase-kill-line :advertised-binding "k")
 
 (easy-menu-define git-rebase-mode-menu git-rebase-mode-map
   "Git-Rebase mode menu"


### PR DESCRIPTION
reverse the lines defining key-bindings for git-rebase-kill-line.

this is a pragmatic change to display 'k' rather than 'C-k' for git-rebase-kill-line in the help-text at interactive rebasings.