### PR TITLE
"make clean" should do "rm *.elc"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ emacs-Q: clean-lisp
 
 clean: clean-lisp clean-docs clean-archives
 	@printf "Cleaning...\n"
-	@$(RM) $(ELCS) $(ELGS) # temporary cleanup kludge
+	@$(RM) *.elc $(ELGS) # temporary cleanup kludge
 	@$(RM) Documentation/*.texi~ Documentation/*.info-1 Documentation/*.info-2
 	@$(RM) magit-pkg.el t/magit-tests.elc
 

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -90,4 +90,4 @@ install: lisp
 
 clean:
 	@printf "Cleaning lisp/*...\n"
-	@$(RM) $(ELCS) $(ELGS)
+	@$(RM) *.elc $(ELGS)

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -555,11 +555,16 @@ Each TYPE is a symbol.  Note that it is not necessary to specify
 all TYPEs up to the root section as printed by
 `magit-describe-type', unless of course you want to be that
 precise."
-  ;; When recursing SECTION actually is a type list.  Matching
-  ;; macros also pass such a list instead of a section struct.
+  ;; For backward compatibility reasons SECTION can also be a
+  ;; type-list as understood by `magit-section-match-1'.  This
+  ;; includes uses of the macros `magit-section-when' and
+  ;; `magit-section-case' that did not get recompiled after
+  ;; this function was changed.
   (and section
        (magit-section-match-1 condition
-                              (mapcar #'car (magit-section-ident section)))))
+                              (if (magit-section-p section)
+                                  (mapcar #'car (magit-section-ident section))
+                                section))))
 
 (defun magit-section-match-1 (condition type-list)
   (if (listp condition)

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -597,6 +597,11 @@ See `magit-section-match' for the forms CONDITION can take."
   (declare (indent 1)
            (debug (sexp body)))
   `(--when-let (magit-current-section)
+     ;; Quoting CONDITION here often leads to double-quotes, which
+     ;; isn't an issue because `magit-section-match-1' implicitly
+     ;; deals with that.  We shouldn't force users of this function
+     ;; to not quote CONDITION because that would needlessly break
+     ;; backward compatibility.
      (when (magit-section-match ',condition it)
        ,@(or body '((magit-section-value it))))))
 


### PR DESCRIPTION
`make clean` should do `rm *.elc` instead of `rm $(ELCS)` to ensure removing all
the .elc files, including those obsolete residue ones. Obsolete residue .elc
files are usually not included in `$(ELCS)` because `$(ELCS)` is computed from
`$(ELS)` by the following substitution rule:

  `ELCS = $(ELS:.el=.elc)`

while the obsolete source files are not in `$(ELS)`.

A real life example is the residue file `lisp/with-editor.elc`. Apparently,
`with-editor.el` used to be part of Magit, but was moved out into a dependency
package. The old "make clean" wasn't able to delete the file `with-editor.elc`
for the reason explained above. This caused the `make` command always used the residue file `with-editor.elc` instead of the new one in the `with-editor`
package.