### PR TITLE
Sort tags according to semver

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -1184,7 +1184,7 @@ reference, but it is not checked out."
 
 (defun magit-insert-tags ()
   "Insert sections showing all tags."
-  (-when-let (tags (magit-git-lines "tag" "-l" "-n"))
+  (-when-let (tags (magit-git-lines "tag" "-l" "-n" "--sort=v:refname"))
     (magit-insert-section (tags)
       (magit-insert-heading "Tags:")
       (let ((head (or (car magit-refresh-args)


### PR DESCRIPTION
I think sorting the tags as versions beats the lexicographic default sorting.  Git can by default handle things like `-RC` or `-alpha` tags even.

The only problem is that on git version 2.5.0 and less `--sort` and `-n` does not work together.  I can't find what the minimal git version is, and I don't know the version when it started working (I updated straight to 2.10.2)

Alternatively we could add a switch to configure this.