### PR TITLE
doc fix: correct git commit style convention name

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -203,7 +203,7 @@ usually honor this wish and return non-nil."
 
 (defcustom git-commit-style-convention-checks '(non-empty-second-line)
   "List of checks performed by `git-commit-check-style-conventions'.
-Valid members are `non-empty-second-line' and `overlong-first-line'.
+Valid members are `non-empty-second-line' and `overlong-summary-line'.
 That function is a member of `git-commit-finish-query-functions'."
   :options '(non-empty-second-line overlong-summary-line)
   :type '(list :convert-widget custom-hook-convert-widget)


### PR DESCRIPTION
The docstring refers to `overlong-summary-line`, whereas the symbol used in the file is called `overlong-first-line`.

Although the latter is consistent with `non-empty-second-line` in its use of line numbers, I think "summary line" indeed makes more sense.