### PR TITLE
magit-emacs-Q-command: new command, for debugging

### DIFF
--- a/Documentation/RelNotes/2.9.0.txt
+++ b/Documentation/RelNotes/2.9.0.txt
@@ -139,6 +139,10 @@ Changes since v2.8.0
   a regular file whose contents describe the location of the real git
   directory.
 
+* Added command `magit-emacs-Q-command' to make troubleshooting and
+  bug reporting easier for users not installing from the git
+  repository. #2856
+
 * The command `magit-branch-spinoff' learned to remove only a subset
   of commits from the previously current branch, instead of resetting
   it to its upstream, when the region selects commits reachable from

--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -43,10 +43,11 @@ If you run Magit from its Git repository, then you can do so using:
   $ cd /path/to/magit
   $ make emacs-Q
 
-If you installed Magit from Melpa, then run commands similar to the ones below, but use tab completion to replace the various Ns with the correct versions:
+Alternatively, run `M-x magit-emacs-Q-command RET` to save a shell command to the `kill-ring` and the system's clip-board, which you can then copy into a shell to run.
+
+Finally, if that didn't work and you have installed Magit from Melpa, then run a command similar to the one below, but use tab completion to replace the various Ns with the correct versions:
 
   $ cd ~/.emacs.d/elpa/magit-N
   $ emacs -Q --debug-init --eval '(setq debug-on-error t)' -L ../dash-N -L ../git-commit-N -L ../magit-popup-N -L ../with-editor-N -L . -l magit
-
 
 ---- now delete this line and everything above ----

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -467,6 +467,28 @@ ACTION is a member of option `magit-slow-confirm'."
     (replace-regexp-in-string
      "-" " " (concat (upcase (substring prompt 0 1)) (substring prompt 1)))))
 
+;;; Debug Utilities
+
+;;;###autoload
+(defun magit-emacs-Q-command ()
+  (interactive)
+  (let ((cmd (mapconcat
+              #'shell-quote-argument
+              `(,(concat invocation-directory invocation-name)
+                "-Q" "--eval" "(setq debug-on-error t)"
+                ,@(cl-mapcan
+                   (lambda (dir) (list "-L" dir))
+                   (delete-dups
+                    (mapcar (lambda (lib)
+                              (file-name-directory (locate-library lib)))
+                            '("magit" "magit-popup" "with-editor"
+                              "git-commit" "dash"))))
+                "-l" "magit")
+              " ")))
+    (message "Uncustomized Magit command saved to kill-ring, %s"
+             "please run it in a terminal.")
+    (kill-new cmd)))
+
 ;;; Text Utilities
 
 (defmacro magit-bind-match-strings (varlist string &rest body)


### PR DESCRIPTION
Refer: https://github.com/magit/magit/issues/2856#issuecomment-261773690

> It might be better to show the actual command, possibly prefixed with instructions.

I did that. Not sure if showing the command is a good idea, it's a bit long.

Fixes #2856.