### PR TITLE
Generalize margin and add commands to change its appearance

### DIFF
--- a/Documentation/RelNotes/2.9.0.txt
+++ b/Documentation/RelNotes/2.9.0.txt
@@ -85,9 +85,9 @@ Breaking changes since v2.8.0
   optionally in some other buffers that contain logs is now more
   flexible and easier to customize and to change on the fly.
 
-  The popup that "L" is bound to now features two commands that
-  for changing the appearance of the margin: `magit-toggle-margin'
-  and `magit-toggle-margin-details'.
+  The popup that "L" is bound to now features three commands that
+  for changing the appearance of the margin: `magit-toggle-margin',
+  `magit-toggle-margin-details' and `magit-cycle-margin-style'.
 
   The binding for `magit-toggle-margin' has changed from "L t" to the
   simpler "L L".  You can easily revert this change using:

--- a/Documentation/RelNotes/2.9.0.txt
+++ b/Documentation/RelNotes/2.9.0.txt
@@ -115,7 +115,7 @@ Breaking changes since v2.8.0
   before loading `magit'.  If you do that then the default values of
   the other `magit-*-margin' options will use the same commit date
   style without you having to customize each option individually.
-  #2792
+  #2885, #2792
 
 Changes since v2.8.0
 --------------------

--- a/Documentation/RelNotes/2.9.0.txt
+++ b/Documentation/RelNotes/2.9.0.txt
@@ -83,7 +83,17 @@ Breaking changes since v2.8.0
 
 * The margin that by default is displayed in pure log buffers and
   optionally in some other buffers that contain logs is now more
-  flexible and easier to customize.
+  flexible and easier to customize and to change on the fly.
+
+  The popup that "L" is bound to now features two commands that
+  for changing the appearance of the margin: `magit-toggle-margin'
+  and `magit-toggle-margin-details'.
+
+  The binding for `magit-toggle-margin' has changed from "L t" to the
+  simpler "L L".  You can easily revert this change using:
+
+    (magit-change-popup-key 'magit-log-refresh-popup :action ?L ?t)
+    (magit-change-popup-key 'magit-margin-popup :action ?L ?t)
 
   For each mode that supports the margin there now exists a dedicated
   option named `magit-*-margin', which controls whether the margin is

--- a/Documentation/RelNotes/2.9.0.txt
+++ b/Documentation/RelNotes/2.9.0.txt
@@ -107,7 +107,8 @@ Breaking changes since v2.8.0
 
   You might also want to customize the options `magit-status-margin',
   `magit-stashes-margin' and `magit-log-select-margin', for all of
-  which no corresponding `magit-*-show-margin' used to exist.
+  which no corresponding `magit-*-show-margin' used to exist.  Another
+  new option is `magit-refs-margin-for-tags'.
 
   If you choose to display the commit dates instead of the commit
   ages in all supported modes, then you should set `magit-log-margin'

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2010,6 +2010,10 @@ and then some other unrelated commands.
 
   This command shows or hides the margin.
 
+- Key: L l, magit-cycle-margin-style
+
+  This command cycles the style used for the margin.
+
 - Key: L d, magit-toggle-margin-details
 
   This command shows or hides details in the margin.

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1697,15 +1697,19 @@ The following functions can also be added to the above hook:
   This option specifies whether the margin is initially shown in
   Magit-Status mode buffers and how it is formatted.
 
-  The value has the form ~(INIT NAME DATE-STYLE)~.
+  The value has the form ~(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)~.
 
   - If INIT is non-nil, then the margin is shown initially.
-  - If NAME is an integer, then the name of the author is
-    shown using an area of that width.  Otherwise it must be ~nil~.
-  - DATE-STYLE can be ~age~, in which case the age of the commit
-    is shown.  If it is ~age-abbreviated~, then the time unit is
-    abbreviated to a single character.  DATE-STYLE can also be
-    a format-string suitable for ~format-time-string~.
+  - STYLE controls how to format the committer date.  It can be one
+    of ~age~ (to show the age of the commit), ~age-abbreviated~ (to
+    abbreviate the time unit to a character), or a string (suitable
+    for ~format-time-string~) to show the actual date.
+  - WIDTH controls the width of the margin.  This exists for forward
+    compatibility and currently the value should not be changed.
+  - AUTHOR controls whether the name of the author is also shown by
+    default.
+  - AUTHOR-WIDTH has to be an integer.  When the name of the author
+    is shown, then this specifies how much space is used to do so.
 
 - User Option: magit-log-section-args
 
@@ -1950,25 +1954,48 @@ the status buffer.
   entry.  Only considered when moving past the last entry with
   ~magit-goto-*-section~ commands.
 
+- User Option: magit-log-show-refname-after-summary
+
+  Whether to show the refnames after the commit summaries.  This is
+  useful if you use really long branch names.
+
+For a description of ~magit-log-margin~ see [[*Log Margin]].
+
+*** Log Margin
+
+In buffers which show one or more logs, it is possible to show
+additional information about each commit in the margin.  The options
+used to configure the margin are named ~magit-INFIX-margin~, where INFIX
+is the same as in the respective major-mode ~magit-INFIX-mode~.  In
+regular log buffers that would be ~magit-log-margin~.
+
 - User Option: magit-log-margin
 
   This option specifies whether the margin is initially shown in
   Magit-Log mode buffers and how it is formatted.
 
-  The value has the form ~(INIT NAME DATE-STYLE)~.
+  The value has the form ~(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)~.
 
   - If INIT is non-nil, then the margin is shown initially.
-  - If NAME is an integer, then the name of the author is
-    shown using an area of that width.  Otherwise it must be ~nil~.
-  - DATE-STYLE can be ~age~ in which case the age of the commit
-    is shown.  If it is ~age-abbreviated~, then the time unit is
-    abbreviated to a single character.  DATE-STYLE can also be
-    a format-string suitable for ~format-time-string~.
+  - STYLE controls how to format the committer date.  It can be one
+    of ~age~ (to show the age of the commit), ~age-abbreviated~ (to
+    abbreviate the time unit to a character), or a string (suitable
+    for ~format-time-string~) to show the actual date.
+  - WIDTH controls the width of the margin.  This exists for forward
+    compatibility and currently the value should not be changed.
+  - AUTHOR controls whether the name of the author is also shown by
+    default.
+  - AUTHOR-WIDTH has to be an integer.  When the name of the author
+    is shown, then this specifies how much space is used to do so.
 
-- User Option: magit-log-show-refname-after-summary
-
-  Whether to show the refnames after the commit summaries.  This is
-  useful if you use really long branch names.
+You can change the STYLE and AUTHOR-WIDTH of all ~magit-INFIX-margin~
+options to the same values by customizing ~magit-log-margin~ *before*
+~magit~ is loaded.  If you do that, then the respective values for the
+other options will default to what you have set for that variable.
+Likewise if you set INIT in ~magit-log-margin~ to ~nil~, then that is used
+in the default of all other options.  But setting it to ~t~, i.e.
+re-enforcing the default for that option, does not carry to other
+options.
 
 *** Select from log
 
@@ -2001,15 +2028,19 @@ buffers:
   This option specifies whether the margin is initially shown in
   Magit-Log-Select mode buffers and how it is formatted.
 
-  The value has the form ~(INIT NAME DATE-STYLE)~.
+  The value has the form ~(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)~.
 
   - If INIT is non-nil, then the margin is shown initially.
-  - If NAME is an integer, then the name of the author is
-    shown using an area of that width.  Otherwise it must be ~nil~.
-  - DATE-STYLE can be ~age~ in which case the age of the commit
-    is shown.  If it is ~age-abbreviated~, then the time unit is
-    abbreviated to a single character.  DATE-STYLE can also be
-    a format-string suitable for ~format-time-string~.
+  - STYLE controls how to format the committer date.  It can be one
+    of ~age~ (to show the age of the commit), ~age-abbreviated~ (to
+    abbreviate the time unit to a character), or a string (suitable
+    for ~format-time-string~) to show the actual date.
+  - WIDTH controls the width of the margin.  This exists for forward
+    compatibility and currently the value should not be changed.
+  - AUTHOR controls whether the name of the author is also shown by
+    default.
+  - AUTHOR-WIDTH has to be an integer.  When the name of the author
+    is shown, then this specifies how much space is used to do so.
 
 *** Reflog
 
@@ -2034,15 +2065,19 @@ These reflog commands are available from the log popup.  See [[*Logging]].
   This option specifies whether the margin is initially shown in
   Magit-Reflog mode buffers and how it is formatted.
 
-  The value has the form ~(INIT NAME DATE-STYLE)~.
+  The value has the form ~(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)~.
 
   - If INIT is non-nil, then the margin is shown initially.
-  - If NAME is an integer, then the name of the author is
-    shown using an area of that width.  Otherwise it must be ~nil~.
-  - DATE-STYLE can be ~age~ in which case the age of the commit
-    is shown.  If it is ~age-abbreviated~, then the time unit is
-    abbreviated to a single character.  DATE-STYLE can also be
-    a format-string suitable for ~format-time-string~.
+  - STYLE controls how to format the committer date.  It can be one
+    of ~age~ (to show the age of the commit), ~age-abbreviated~ (to
+    abbreviate the time unit to a character), or a string (suitable
+    for ~format-time-string~) to show the actual date.
+  - WIDTH controls the width of the margin.  This exists for forward
+    compatibility and currently the value should not be changed.
+  - AUTHOR controls whether the name of the author is also shown by
+    default.
+  - AUTHOR-WIDTH has to be an integer.  When the name of the author
+    is shown, then this specifies how much space is used to do so.
 
 ** Diffing
 
@@ -2493,15 +2528,19 @@ information on how to use Ediff itself, see info:ediff.
   This option specifies whether the margin is initially shown in
   Magit-Refs mode buffers and how it is formatted.
 
-  The value has the form ~(INIT NAME DATE-STYLE TAGS)~.
+  The value has the form ~(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)~.
 
   - If INIT is non-nil, then the margin is shown initially.
-  - If NAME is an integer, then the name of the author is
-    shown using an area of that width.  Otherwise it must be ~nil~.
-  - DATE-STYLE can be ~age~ in which case the age of the commit
-    is shown.  If it is ~age-abbreviated~, then the time unit is
-    abbreviated to a single character.  DATE-STYLE can also be
-    a format-string suitable for ~format-time-string~.
+  - STYLE controls how to format the committer date.  It can be one
+    of ~age~ (to show the age of the commit), ~age-abbreviated~ (to
+    abbreviate the time unit to a character), or a string (suitable
+    for ~format-time-string~) to show the actual date.
+  - WIDTH controls the width of the margin.  This exists for forward
+    compatibility and currently the value should not be changed.
+  - AUTHOR controls whether the name of the author is also shown by
+    default.
+  - AUTHOR-WIDTH has to be an integer.  When the name of the author
+    is shown, then this specifies how much space is used to do so.
 
 - User Option: magit-refs-margin-for-tags
 
@@ -4459,15 +4498,19 @@ Also see [[man:git-stash]]
   This option specifies whether the margin is initially shown in
   stashes buffers and how it is formatted.
 
-  The value has the form ~(INIT NAME DATE-STYLE)~.
+  The value has the form ~(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)~.
 
   - If INIT is non-nil, then the margin is shown initially.
-  - If NAME is an integer, then the name of the author is
-    shown using an area of that width.  Otherwise it must be ~nil~.
-  - DATE-STYLE can be ~age~ in which case the age of the commit
-    is shown.  If it is ~age-abbreviated~, then the time unit is
-    abbreviated to a single character.  DATE-STYLE can also be
-    a format-string suitable for ~format-time-string~.
+  - STYLE controls how to format the committer date.  It can be one
+    of ~age~ (to show the age of the commit), ~age-abbreviated~ (to
+    abbreviate the time unit to a character), or a string (suitable
+    for ~format-time-string~) to show the actual date.
+  - WIDTH controls the width of the margin.  This exists for forward
+    compatibility and currently the value should not be changed.
+  - AUTHOR controls whether the name of the author is also shown by
+    default.
+  - AUTHOR-WIDTH has to be an integer.  When the name of the author
+    is shown, then this specifies how much space is used to do so.
 
 * Transferring
 ** Remotes

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1836,19 +1836,11 @@ The log popup also features several reflog commands.  See [[*Reflog]].
 
   Show log for all references and ~HEAD~.
 
-The following related commands are not available from the popup.
 
-- Key: Y, magit-cherry
-
-  Show commits in a branch that are not merged in the upstream branch.
-
-- Key: M-x magit-log-buffer-file, magit-log-buffer-file
-
-  Show log for the file visited in the current buffer.
-
-Two additional commands that show the log for the file or blob that is
-being visited in the current buffer exists, see [[*Minor mode for
-buffers visiting files]].
+Two additional commands that show the log for the file or blob that
+is being visited in the current buffer exists, see [[*Minor mode for
+buffers visiting files]].  The command ~magit-cherry~ also shows a log,
+see [[*Cherries]].
 
 *** Refreshing logs
 
@@ -2085,6 +2077,43 @@ These reflog commands are available from the log popup.  See [[*Logging]].
 
   This option specifies whether the margin is initially shown in
   Magit-Reflog mode buffers and how it is formatted.
+
+  The value has the form ~(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)~.
+
+  - If INIT is non-nil, then the margin is shown initially.
+  - STYLE controls how to format the committer date.  It can be one
+    of ~age~ (to show the age of the commit), ~age-abbreviated~ (to
+    abbreviate the time unit to a character), or a string (suitable
+    for ~format-time-string~) to show the actual date.
+  - WIDTH controls the width of the margin.  This exists for forward
+    compatibility and currently the value should not be changed.
+  - AUTHOR controls whether the name of the author is also shown by
+    default.
+  - AUTHOR-WIDTH has to be an integer.  When the name of the author
+    is shown, then this specifies how much space is used to do so.
+
+*** Cherries
+
+Cherries are commits that haven't been applied upstream (yet), and are
+usually visualized using a log.  Each commit is prefixed with ~-~ if it
+has an equivalent in the upstream and ~+~ if it does not, i.e. if it is
+a cherry.
+
+The command ~magit-cherry~ shows cherries for a single branch, but the
+references buffer (see [[*References buffer]]) can show cherries for
+multiple "upstreams" at once.
+
+Also see [[man:git-reflog]]
+
+- Key: Y, magit-cherry
+
+  Show commits that are in a certain branch but that have not been
+  merged in the upstream branch.
+
+- User Option: magit-cherry-margin
+
+  This option specifies whether the margin is initially shown in
+  Magit-Cherry mode buffers and how it is formatted.
 
   The value has the form ~(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)~.
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2502,8 +2502,12 @@ information on how to use Ediff itself, see info:ediff.
     is shown.  If it is ~age-abbreviated~, then the time unit is
     abbreviated to a single character.  DATE-STYLE can also be
     a format-string suitable for ~format-time-string~.
-  - If TAGS is non-nil, then the margin shows information not
-    only about branches, but also about tags.
+
+- User Option: magit-refs-margin-for-tags
+
+  This option specifies whether to show information about tags in the
+  margin.  This is disabled by default because it is slow if there are
+  many tags.
 
 The following variables control how individual refs are displayed.  If
 you change one of these variables (especially the "%c" part), then you

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1997,6 +1997,23 @@ in the default of all other options.  But setting it to ~t~, i.e.
 re-enforcing the default for that option, does not carry to other
 options.
 
+- Key: L, magit-margin-popup
+
+  This prefix command features the following commands for changing the
+  appearance of the margin.
+
+In some buffers that support the margin, "L" is bound to
+~magit-log-refresh-popup~, but that popup features the same commands,
+and then some other unrelated commands.
+
+- Key: L L, magit-toggle-margin
+
+  This command shows or hides the margin.
+
+- Key: L d, magit-toggle-margin-details
+
+  This command shows or hides details in the margin.
+
 *** Select from log
 
 When the user has to select a recent commit that is reachable from

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -145,6 +145,7 @@ Logging
 
 * Refreshing logs::
 * Log Buffer::
+* Log Margin::
 * Select from log::
 * Reflog::
 
@@ -2290,21 +2291,29 @@ Hook run after a status buffer has been refreshed.
 This option specifies whether the margin is initially shown in
 Magit-Status mode buffers and how it is formatted.
 
-The value has the form @code{(INIT NAME DATE-STYLE)}.
+The value has the form @code{(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)}.
 
 @itemize
 @item
 If INIT is non-nil, then the margin is shown initially.
 
 @item
-If NAME is an integer, then the name of the author is
-shown using an area of that width.  Otherwise it must be @code{nil}.
+STYLE controls how to format the committer date.  It can be one
+of @code{age} (to show the age of the commit), @code{age-abbreviated} (to
+abbreviate the time unit to a character), or a string (suitable
+for @code{format-time-string}) to show the actual date.
 
 @item
-DATE-STYLE can be @code{age}, in which case the age of the commit
-is shown.  If it is @code{age-abbreviated}, then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be
-a format-string suitable for @code{format-time-string}.
+WIDTH controls the width of the margin.  This exists for forward
+compatibility and currently the value should not be changed.
+
+@item
+AUTHOR controls whether the name of the author is also shown by
+default.
+
+@item
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+is shown, then this specifies how much space is used to do so.
 @end itemize
 @end defopt
 
@@ -2496,6 +2505,7 @@ being visited in the current buffer exists, see @ref{Minor mode for buffers visi
 @menu
 * Refreshing logs::
 * Log Buffer::
+* Log Margin::
 * Select from log::
 * Reflog::
 @end menu
@@ -2641,34 +2651,62 @@ entry.  Only considered when moving past the last entry with
 @code{magit-goto-*-section} commands.
 @end defopt
 
+@defopt magit-log-show-refname-after-summary
+
+Whether to show the refnames after the commit summaries.  This is
+useful if you use really long branch names.
+@end defopt
+
+For a description of @code{magit-log-margin} see @ref{Log Margin,Log Margin}.
+
+@node Log Margin
+@subsection Log Margin
+
+In buffers which show one or more logs, it is possible to show
+additional information about each commit in the margin.  The options
+used to configure the margin are named @code{magit-INFIX-margin}, where INFIX
+is the same as in the respective major-mode @code{magit-INFIX-mode}.  In
+regular log buffers that would be @code{magit-log-margin}.
+
 @defopt magit-log-margin
 
 This option specifies whether the margin is initially shown in
 Magit-Log mode buffers and how it is formatted.
 
-The value has the form @code{(INIT NAME DATE-STYLE)}.
+The value has the form @code{(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)}.
 
 @itemize
 @item
 If INIT is non-nil, then the margin is shown initially.
 
 @item
-If NAME is an integer, then the name of the author is
-shown using an area of that width.  Otherwise it must be @code{nil}.
+STYLE controls how to format the committer date.  It can be one
+of @code{age} (to show the age of the commit), @code{age-abbreviated} (to
+abbreviate the time unit to a character), or a string (suitable
+for @code{format-time-string}) to show the actual date.
 
 @item
-DATE-STYLE can be @code{age} in which case the age of the commit
-is shown.  If it is @code{age-abbreviated}, then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be
-a format-string suitable for @code{format-time-string}.
+WIDTH controls the width of the margin.  This exists for forward
+compatibility and currently the value should not be changed.
+
+@item
+AUTHOR controls whether the name of the author is also shown by
+default.
+
+@item
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+is shown, then this specifies how much space is used to do so.
 @end itemize
 @end defopt
 
-@defopt magit-log-show-refname-after-summary
-
-Whether to show the refnames after the commit summaries.  This is
-useful if you use really long branch names.
-@end defopt
+You can change the STYLE and AUTHOR-WIDTH of all @code{magit-INFIX-margin}
+options to the same values by customizing @code{magit-log-margin} @strong{before}
+@code{magit} is loaded.  If you do that, then the respective values for the
+other options will default to what you have set for that variable.
+Likewise if you set INIT in @code{magit-log-margin} to @code{nil}, then that is used
+in the default of all other options.  But setting it to @code{t}, i.e.
+re-enforcing the default for that option, does not carry to other
+options.
 
 @node Select from log
 @subsection Select from log
@@ -2709,21 +2747,29 @@ Abort selecting a commit, don't act on any commit.
 This option specifies whether the margin is initially shown in
 Magit-Log-Select mode buffers and how it is formatted.
 
-The value has the form @code{(INIT NAME DATE-STYLE)}.
+The value has the form @code{(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)}.
 
 @itemize
 @item
 If INIT is non-nil, then the margin is shown initially.
 
 @item
-If NAME is an integer, then the name of the author is
-shown using an area of that width.  Otherwise it must be @code{nil}.
+STYLE controls how to format the committer date.  It can be one
+of @code{age} (to show the age of the commit), @code{age-abbreviated} (to
+abbreviate the time unit to a character), or a string (suitable
+for @code{format-time-string}) to show the actual date.
 
 @item
-DATE-STYLE can be @code{age} in which case the age of the commit
-is shown.  If it is @code{age-abbreviated}, then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be
-a format-string suitable for @code{format-time-string}.
+WIDTH controls the width of the margin.  This exists for forward
+compatibility and currently the value should not be changed.
+
+@item
+AUTHOR controls whether the name of the author is also shown by
+default.
+
+@item
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+is shown, then this specifies how much space is used to do so.
 @end itemize
 @end defopt
 
@@ -2771,21 +2817,29 @@ Display the @code{HEAD} reflog.
 This option specifies whether the margin is initially shown in
 Magit-Reflog mode buffers and how it is formatted.
 
-The value has the form @code{(INIT NAME DATE-STYLE)}.
+The value has the form @code{(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)}.
 
 @itemize
 @item
 If INIT is non-nil, then the margin is shown initially.
 
 @item
-If NAME is an integer, then the name of the author is
-shown using an area of that width.  Otherwise it must be @code{nil}.
+STYLE controls how to format the committer date.  It can be one
+of @code{age} (to show the age of the commit), @code{age-abbreviated} (to
+abbreviate the time unit to a character), or a string (suitable
+for @code{format-time-string}) to show the actual date.
 
 @item
-DATE-STYLE can be @code{age} in which case the age of the commit
-is shown.  If it is @code{age-abbreviated}, then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be
-a format-string suitable for @code{format-time-string}.
+WIDTH controls the width of the margin.  This exists for forward
+compatibility and currently the value should not be changed.
+
+@item
+AUTHOR controls whether the name of the author is also shown by
+default.
+
+@item
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+is shown, then this specifies how much space is used to do so.
 @end itemize
 @end defopt
 
@@ -3392,21 +3446,29 @@ The default is @code{nil} because anything else can be very expensive.
 This option specifies whether the margin is initially shown in
 Magit-Refs mode buffers and how it is formatted.
 
-The value has the form @code{(INIT NAME DATE-STYLE TAGS)}.
+The value has the form @code{(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)}.
 
 @itemize
 @item
 If INIT is non-nil, then the margin is shown initially.
 
 @item
-If NAME is an integer, then the name of the author is
-shown using an area of that width.  Otherwise it must be @code{nil}.
+STYLE controls how to format the committer date.  It can be one
+of @code{age} (to show the age of the commit), @code{age-abbreviated} (to
+abbreviate the time unit to a character), or a string (suitable
+for @code{format-time-string}) to show the actual date.
 
 @item
-DATE-STYLE can be @code{age} in which case the age of the commit
-is shown.  If it is @code{age-abbreviated}, then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be
-a format-string suitable for @code{format-time-string}.
+WIDTH controls the width of the margin.  This exists for forward
+compatibility and currently the value should not be changed.
+
+@item
+AUTHOR controls whether the name of the author is also shown by
+default.
+
+@item
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+is shown, then this specifies how much space is used to do so.
 @end itemize
 @end defopt
 
@@ -6087,21 +6149,29 @@ List all stashes in a buffer.
 This option specifies whether the margin is initially shown in
 stashes buffers and how it is formatted.
 
-The value has the form @code{(INIT NAME DATE-STYLE)}.
+The value has the form @code{(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)}.
 
 @itemize
 @item
 If INIT is non-nil, then the margin is shown initially.
 
 @item
-If NAME is an integer, then the name of the author is
-shown using an area of that width.  Otherwise it must be @code{nil}.
+STYLE controls how to format the committer date.  It can be one
+of @code{age} (to show the age of the commit), @code{age-abbreviated} (to
+abbreviate the time unit to a character), or a string (suitable
+for @code{format-time-string}) to show the actual date.
 
 @item
-DATE-STYLE can be @code{age} in which case the age of the commit
-is shown.  If it is @code{age-abbreviated}, then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be
-a format-string suitable for @code{format-time-string}.
+WIDTH controls the width of the margin.  This exists for forward
+compatibility and currently the value should not be changed.
+
+@item
+AUTHOR controls whether the name of the author is also shown by
+default.
+
+@item
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+is shown, then this specifies how much space is used to do so.
 @end itemize
 @end defopt
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -2708,6 +2708,33 @@ in the default of all other options.  But setting it to @code{t}, i.e.
 re-enforcing the default for that option, does not carry to other
 options.
 
+@table @asis
+@kindex L
+@cindex magit-margin-popup
+@item @kbd{L} @tie{}@tie{}@tie{}@tie{}(@code{magit-margin-popup})
+
+This prefix command features the following commands for changing the
+appearance of the margin.
+@end table
+
+In some buffers that support the margin, "L" is bound to
+@code{magit-log-refresh-popup}, but that popup features the same commands,
+and then some other unrelated commands.
+
+@table @asis
+@kindex L L
+@cindex magit-toggle-margin
+@item @kbd{L L} @tie{}@tie{}@tie{}@tie{}(@code{magit-toggle-margin})
+
+This command shows or hides the margin.
+
+@kindex L d
+@cindex magit-toggle-margin-details
+@item @kbd{L d} @tie{}@tie{}@tie{}@tie{}(@code{magit-toggle-margin-details})
+
+This command shows or hides details in the margin.
+@end table
+
 @node Select from log
 @subsection Select from log
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -3407,11 +3407,14 @@ DATE-STYLE can be @code{age} in which case the age of the commit
 is shown.  If it is @code{age-abbreviated}, then the time unit is
 abbreviated to a single character.  DATE-STYLE can also be
 a format-string suitable for @code{format-time-string}.
-
-@item
-If TAGS is non-nil, then the margin shows information not
-only about branches, but also about tags.
 @end itemize
+@end defopt
+
+@defopt magit-refs-margin-for-tags
+
+This option specifies whether to show information about tags in the
+margin.  This is disabled by default because it is slow if there are
+many tags.
 @end defopt
 
 The following variables control how individual refs are displayed.  If

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -2728,6 +2728,12 @@ and then some other unrelated commands.
 
 This command shows or hides the margin.
 
+@kindex L l
+@cindex magit-cycle-margin-style
+@item @kbd{L l} @tie{}@tie{}@tie{}@tie{}(@code{magit-cycle-margin-style})
+
+This command cycles the style used for the margin.
+
 @kindex L d
 @cindex magit-toggle-margin-details
 @item @kbd{L d} @tie{}@tie{}@tie{}@tie{}(@code{magit-toggle-margin-details})

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -148,6 +148,7 @@ Logging
 * Log Margin::
 * Select from log::
 * Reflog::
+* Cherries::
 
 
 Diffing
@@ -2483,24 +2484,10 @@ Show log for all local and remote branches and @code{HEAD}.
 Show log for all references and @code{HEAD}.
 @end table
 
-The following related commands are not available from the popup.
 
-@table @asis
-@kindex Y
-@cindex magit-cherry
-@item @kbd{Y} @tie{}@tie{}@tie{}@tie{}(@code{magit-cherry})
-
-Show commits in a branch that are not merged in the upstream branch.
-
-@kindex M-x magit-log-buffer-file
-@cindex magit-log-buffer-file
-@item @kbd{M-x magit-log-buffer-file} @tie{}@tie{}@tie{}@tie{}(@code{magit-log-buffer-file})
-
-Show log for the file visited in the current buffer.
-@end table
-
-Two additional commands that show the log for the file or blob that is
-being visited in the current buffer exists, see @ref{Minor mode for buffers visiting files,Minor mode for buffers visiting files}.
+Two additional commands that show the log for the file or blob that
+is being visited in the current buffer exists, see @ref{Minor mode for buffers visiting files,Minor mode for buffers visiting files}.  The command @code{magit-cherry} also shows a log,
+see @ref{Cherries,Cherries}.
 
 @menu
 * Refreshing logs::
@@ -2508,6 +2495,7 @@ being visited in the current buffer exists, see @ref{Minor mode for buffers visi
 * Log Margin::
 * Select from log::
 * Reflog::
+* Cherries::
 @end menu
 
 @node Refreshing logs
@@ -2849,6 +2837,72 @@ Display the @code{HEAD} reflog.
 
 This option specifies whether the margin is initially shown in
 Magit-Reflog mode buffers and how it is formatted.
+
+The value has the form @code{(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)}.
+
+@itemize
+@item
+If INIT is non-nil, then the margin is shown initially.
+
+@item
+STYLE controls how to format the committer date.  It can be one
+of @code{age} (to show the age of the commit), @code{age-abbreviated} (to
+abbreviate the time unit to a character), or a string (suitable
+for @code{format-time-string}) to show the actual date.
+
+@item
+WIDTH controls the width of the margin.  This exists for forward
+compatibility and currently the value should not be changed.
+
+@item
+AUTHOR controls whether the name of the author is also shown by
+default.
+
+@item
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+is shown, then this specifies how much space is used to do so.
+@end itemize
+@end defopt
+
+@node Cherries
+@subsection Cherries
+
+Cherries are commits that haven't been applied upstream (yet), and are
+usually visualized using a log.  Each commit is prefixed with @code{-} if it
+has an equivalent in the upstream and @code{+} if it does not, i.e. if it is
+a cherry.
+
+The command @code{magit-cherry} shows cherries for a single branch, but the
+references buffer (see @ref{References buffer,References buffer}) can show cherries for
+multiple "upstreams" at once.
+
+Also see 
+@ifinfo
+@ref{git-reflog,,,gitman,}.
+@end ifinfo
+@ifhtml
+@html
+the <a href="http://git-scm.com/docs/git-reflog">git-reflog(1)</a> manpage.
+@end html
+@end ifhtml
+@iftex
+the git-reflog(1) manpage.
+@end iftex
+
+@table @asis
+@kindex Y
+@cindex magit-cherry
+@item @kbd{Y} @tie{}@tie{}@tie{}@tie{}(@code{magit-cherry})
+
+Show commits that are in a certain branch but that have not been
+merged in the upstream branch.
+
+@end table
+
+@defopt magit-cherry-margin
+
+This option specifies whether the margin is initially shown in
+Magit-Cherry mode buffers and how it is formatted.
 
 The value has the form @code{(INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH)}.
 

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -15,11 +15,13 @@ magit-utils.elc:
 magit-section.elc:	magit-utils.elc
 magit-git.elc:		magit-utils.elc magit-section.elc
 magit-mode.elc:		magit-section.elc magit-git.elc magit-popup.elc
+magit-margin.elc:	magit-section.elc magit-mode.elc
 magit-process.elc:	magit-utils.elc magit-section.elc \
 			magit-git.elc magit-mode.elc
 magit-autorevert.elc:	magit-git.elc magit-process.elc
-magit-core.elc:		magit-utils.elc magit-section.elc magit-git.elc \
-			magit-mode.elc magit-popup.elc magit-process.elc
+magit-core.elc:		magit-popup.elc magit-margin.elc magit-utils.elc \
+			magit-section.elc magit-git.elc magit-mode.elc \
+			magit-process.elc magit-autorevert.elc
 magit-diff.elc:		git-commit.elc magit-core.elc
 magit-log.elc:		magit-core.elc magit-diff.elc
 magit-wip.elc:		magit-core.elc magit-log.elc

--- a/lisp/magit-core.el
+++ b/lisp/magit-core.el
@@ -30,11 +30,12 @@
 
 ;;; Code:
 
+(require 'magit-popup)
 (require 'magit-utils)
 (require 'magit-section)
 (require 'magit-git)
 (require 'magit-mode)
-(require 'magit-popup)
+(require 'magit-margin)
 (require 'magit-process)
 (require 'magit-autorevert)
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -387,7 +387,7 @@ the upstream isn't ahead of the current branch) show."
                (?S "Search occurrences"      "-S")
                (?L "Trace line evolution"    "-L" magit-read-file-trace))
     :actions  ((?g "Refresh"       magit-log-refresh)
-               (?t "Toggle margin" magit-toggle-margin)
+               (?L "Toggle margin" magit-toggle-margin)
                (?s "Set defaults"  magit-log-set-default-arguments) nil
                (?w "Save defaults" magit-log-save-default-arguments))
     :max-action-columns 2))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -103,7 +103,7 @@ Only considered when moving past the last entry with
   '(list (boolean :tag "Show initially")
          (integer :tag "Show author name using width")
          (choice  :tag "Show committer"
-                  (string :tag "date using format" "%Y-%m-%d %H:%m ")
+                  (string :tag "date using format" "%Y-%m-%d %H:%M ")
                   (const  :tag "date's age" age)
                   (const  :tag "date's age (abbreviated)" age-abbreviated))))
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -906,8 +906,9 @@ Do not add this to a hook variable."
 
 (defconst magit-log-reflog-re
   (concat "^"
-          "\\(?1:[^ ]+\\) "                        ; sha1
-          "\\(?:\\(?:[^@]+@{\\(?6:[^}]+\\)} "      ; date
+          "\\(?1:[^\0]+\\)\0"                      ; sha1
+          "\\(?5:[^\0]*\\)\0"                      ; author
+          "\\(?:\\(?:[^@]+@{\\(?6:[^}]+\\)}\0"     ; date
           "\\(?10:merge \\|autosave \\|restart \\|[^:]+: \\)?" ; refsub
           "\\(?2:.*\\)?\\)\\| \\)$"))              ; msg
 
@@ -918,9 +919,9 @@ Do not add this to a hook variable."
 
 (defconst magit-log-stash-re
   (concat "^"
-          "\\(?1:[^ ]+\\)"                         ; "sha1"
-          "\\(?5: \\)"                             ; "author"
-          "\\(?6:[^ ]+\\) "                        ; date
+          "\\(?1:[^\0]+\\)\0"                      ; "sha1"
+          "\\(?5:[^\0]*\\)\0"                      ; author
+          "\\(?6:[^\0]+\\)\0"                      ; date
           "\\(?2:.*\\)$"))                         ; msg
 
 (defvar magit-log-count nil)
@@ -1355,7 +1356,7 @@ Type \\[magit-reset] to reset HEAD to the commit at point.
         (propertize (concat " Reflog for " ref) 'face 'magit-header-line))
   (magit-insert-section (reflogbuf)
     (magit-git-wash (apply-partially 'magit-log-wash-log 'reflog)
-      "reflog" "show" "--format=%h %gd %gs" "--date=raw" args ref)))
+      "reflog" "show" "--format=%h%x00%aN%x00%gd%x00%gs" "--date=raw" args ref)))
 
 (defvar magit-reflog-labels
   '(("commit"      . magit-reflog-commit)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -411,6 +411,7 @@ the upstream isn't ahead of the current branch) show."
                (?w "buffer and save defaults" magit-log-save-default-arguments)
                "Margin"
                (?L "toggle visibility" magit-toggle-margin)
+               (?l "cycle style"       magit-cycle-margin-style)
                (?d "toggle details"    magit-toggle-margin-details))
     :max-action-columns 1))
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -40,7 +40,7 @@
 (defvar magit-refs-indent-cherry-lines)
 (defvar magit-refs-margin)
 (defvar magit-refs-show-commit-count)
-(defvar magit-show-margin)
+(defvar magit-buffer-margin)
 (defvar magit-status-margin)
 (defvar magit-status-sections-hook)
 
@@ -99,18 +99,22 @@ Only considered when moving past the last entry with
   :group 'magit-log
   :type 'boolean)
 
-(defcustom magit-log-margin '(t 18 age)
+(defcustom magit-log-margin '(t age magit-log-margin-width t 18)
   "Format of the margin in `magit-log-mode' buffers.
 
-The value has the form (INIT NAME DATE-STYLE).
+The value has the form (INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH).
 
 If INIT is non-nil, then the margin is shown initially.
-If NAME is an integer, then the name of the author is shown
-  using an area of that width.  Otherwise it must be nil.
-DATE-STYLE can be `age', in which case the age of the commit
-is shown.  If it is `age-abbreviated', then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be a
-format-string suitable for `format-time-string'."
+STYLE controls how to format the committer date.  It can be one
+  of `age' (to show the age of the commit), `age-abbreviated' (to
+  abbreviate the time unit to a character), or a string (suitable
+  for `format-time-string') to show the actual date.
+WIDTH controls the width of the margin.  This exists for forward
+  compatibility and currently the value should not be changed.
+AUTHOR controls whether the name of the author is also shown by
+  default.
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+  is shown, then this specifies how much space is used to do so."
   :package-version '(magit . "2.9.0")
   :group 'magit-log
   :group 'magit-margin
@@ -173,18 +177,25 @@ be nil, in which case no usage information is shown."
                  (const :tag "nowhere")))
 
 (defcustom magit-log-select-margin
-  (list t 18 (nth 2 magit-log-margin))
+  (list (nth 0 magit-log-margin)
+        (nth 1 magit-log-margin)
+        'magit-log-margin-width t
+        (nth 4 magit-log-margin))
   "Format of the margin in `magit-log-select-mode' buffers.
 
-The value has the form (INIT NAME DATE-STYLE).
+The value has the form (INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH).
 
 If INIT is non-nil, then the margin is shown initially.
-If NAME is an integer, then the name of the author is shown
-  using an area of that width.  Otherwise it must be nil.
-DATE-STYLE can be `age', in which case the age of the commit
-is shown.  If it is `age-abbreviated', then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be a
-format-string suitable for `format-time-string'."
+STYLE controls how to format the committer date.  It can be one
+  of `age' (to show the age of the commit), `age-abbreviated' (to
+  abbreviate the time unit to a character), or a string (suitable
+  for `format-time-string') to show the actual date.
+WIDTH controls the width of the margin.  This exists for forward
+  compatibility and currently the value should not be changed.
+AUTHOR controls whether the name of the author is also shown by
+  default.
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+  is shown, then this specifies how much space is used to do so."
   :package-version '(magit . "2.9.0")
   :group 'magit-log
   :group 'magit-margin
@@ -204,18 +215,25 @@ format-string suitable for `format-time-string'."
   :type 'hook)
 
 (defcustom magit-cherry-margin
-  (list t 18 (nth 2 magit-log-margin))
+  (list (nth 0 magit-log-margin)
+        (nth 1 magit-log-margin)
+        'magit-log-margin-width t
+        (nth 4 magit-log-margin))
   "Format of the margin in `magit-cherry-mode' buffers.
 
-The value has the form (INIT NAME DATE-STYLE).
+The value has the form (INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH).
 
 If INIT is non-nil, then the margin is shown initially.
-If NAME is an integer, then the name of the author is shown
-  using an area of that width.  Otherwise it must be nil.
-DATE-STYLE can be `age', in which case the age of the commit
-is shown.  If it is `age-abbreviated', then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be a
-format-string suitable for `format-time-string'."
+STYLE controls how to format the committer date.  It can be one
+  of `age' (to show the age of the commit), `age-abbreviated' (to
+  abbreviate the time unit to a character), or a string (suitable
+  for `format-time-string') to show the actual date.
+WIDTH controls the width of the margin.  This exists for forward
+  compatibility and currently the value should not be changed.
+AUTHOR controls whether the name of the author is also shown by
+  default.
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+  is shown, then this specifies how much space is used to do so."
   :package-version '(magit . "2.9.0")
   :group 'magit-log
   :group 'magit-margin
@@ -234,18 +252,25 @@ format-string suitable for `format-time-string'."
   :type '(repeat (string :tag "Argument")))
 
 (defcustom magit-reflog-margin
-  (list t nil (nth 2 magit-log-margin))
+  (list (nth 0 magit-log-margin)
+        (nth 1 magit-log-margin)
+        'magit-log-margin-width nil
+        (nth 4 magit-log-margin))
   "Format of the margin in `magit-reflog-mode' buffers.
 
-The value has the form (INIT NAME DATE-STYLE).
+The value has the form (INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH).
 
 If INIT is non-nil, then the margin is shown initially.
-If NAME is an integer, then the name of the author is shown
-  using an area of that width.  Otherwise it must be nil.
-DATE-STYLE can be `age', in which case the age of the commit
-is shown.  If it is `age-abbreviated', then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be a
-format-string suitable for `format-time-string'."
+STYLE controls how to format the committer date.  It can be one
+  of `age' (to show the age of the commit), `age-abbreviated' (to
+  abbreviate the time unit to a character), or a string (suitable
+  for `format-time-string') to show the actual date.
+WIDTH controls the width of the margin.  This exists for forward
+  compatibility and currently the value should not be changed.
+AUTHOR controls whether the name of the author is also shown by
+  default.
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+  is shown, then this specifies how much space is used to do so."
   :package-version '(magit . "2.9.0")
   :group 'magit-log
   :group 'magit-margin
@@ -1001,7 +1026,7 @@ Do not add this to a hook variable."
             (backward-char)
             (magit-log-format-margin author date)))
         (when (and (eq style 'cherry)
-                   magit-show-margin)
+                   (magit-buffer-margin-p))
           (save-excursion
             (backward-char)
             (apply #'magit-log-format-margin
@@ -1124,17 +1149,19 @@ If there is no blob buffer in the same frame, then do nothing."
 ;;; Log Margin
 
 (defun magit-log-format-margin (author date)
-  (when (magit-margin-get :option)
-    (magit-make-margin-overlay
-     (concat (-when-let (width (magit-margin-get :person))
-               (concat (propertize (truncate-string-to-width
-                                    (or author "")
-                                    width
-                                    nil ?\s (make-string 1 magit-ellipsis))
-                                   'face 'magit-log-author)
-                       " "))
-             (propertize
-              (let ((style (magit-margin-get :style)))
+  (-when-let (option (magit-margin-option))
+    (-let [(_ style width details details-width)
+           (or magit-buffer-margin
+               (symbol-value option))]
+      (magit-make-margin-overlay
+       (concat (and details
+                    (concat (propertize (truncate-string-to-width
+                                         (or author "")
+                                         details-width
+                                         nil ?\s (make-string 1 magit-ellipsis))
+                                        'face 'magit-log-author)
+                            " "))
+               (propertize
                 (if (stringp style)
                     (format-time-string
                      style
@@ -1142,9 +1169,22 @@ If there is no blob buffer in the same frame, then do nothing."
                   (-let* ((abbr (eq style 'age-abbreviated))
                           ((cnt unit) (magit--age date abbr)))
                     (format (format (if abbr "%%2i%%-%ic" "%%2i %%-%is")
-                                    (1- (magit-margin-get :age-width)))
-                            cnt unit))))
-              'face 'magit-log-date)))))
+                                    (- width (if details (1+ details-width) 0)))
+                            cnt unit)))
+                'face 'magit-log-date))))))
+
+(defun magit-log-margin-width (style details details-width)
+  (+ (if details (1+ details-width) 0)
+     (if (stringp style)
+         (length (format-time-string style))
+       (+ 2 ; two digits
+          1 ; trailing space
+          (if (eq style 'age-abbreviated)
+              1  ; single character
+            (+ 1 ; gap after digits
+               (apply #'max (--map (max (length (nth 1 it))
+                                        (length (nth 2 it)))
+                                   magit--age-spec))))))))
 
 ;;; Select Mode
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1552,7 +1552,7 @@ all others with \"-\"."
                               (magit-margin-get :age-width)))))))
       (setq magit-show-margin width)
       (when (and enable magit-set-buffer-margin-refresh)
-        (magit-refresh))
+        (magit-refresh-buffer))
       (dolist (window (get-buffer-window-list nil nil 0))
         (with-selected-window window
           (set-window-margins nil (car (window-margins)) width)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -405,11 +405,14 @@ the upstream isn't ahead of the current branch) show."
                (?d "Show refnames"       "--decorate"))
     :options  ((?n "Limit number of commits" "-n")
                (?o "Order commits by"        "++order=" magit-log-select-order))
-    :actions  ((?g "Refresh"       magit-log-refresh)
-               (?t "Toggle margin" magit-toggle-margin)
-               (?s "Set defaults"  magit-log-set-default-arguments) nil
-               (?w "Save defaults" magit-log-save-default-arguments))
-    :max-action-columns 2))
+    :actions  ("Refresh"
+               (?g "buffer"                   magit-log-refresh)
+               (?s "buffer and set defaults"  magit-log-set-default-arguments)
+               (?w "buffer and save defaults" magit-log-save-default-arguments)
+               "Margin"
+               (?L "toggle visibility" magit-toggle-margin)
+               (?d "toggle details"    magit-toggle-margin-details))
+    :max-action-columns 1))
 
 (magit-define-popup-keys-deferred 'magit-log-popup)
 (magit-define-popup-keys-deferred 'magit-log-mode-refresh-popup)
@@ -1273,7 +1276,7 @@ commit as argument."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map magit-mode-map)
     (define-key map "q" 'magit-log-bury-buffer)
-    (define-key map "L" 'magit-toggle-margin)
+    (define-key map "L" 'magit-margin-popup)
     map)
   "Keymap for `magit-cherry-mode'.")
 
@@ -1325,7 +1328,7 @@ Type \\[magit-cherry-pick-popup] to apply the commit at point.
 (defvar magit-reflog-mode-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map magit-log-mode-map)
-    (define-key map "L" 'magit-toggle-margin)
+    (define-key map "L" 'magit-margin-popup)
     map)
   "Keymap for `magit-reflog-mode'.")
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -264,7 +264,7 @@ format-string suitable for `format-time-string'."
   :package-version '(magit . "2.9.0")
   :group 'magit-log
   :group 'magit-margin
-  :type 'magit-log-margin--custom-type
+  :type magit-log-margin--custom-type
   :initialize 'magit-custom-initialize-reset
   :set-after '(magit-log-margin)
   :set (apply-partially #'magit-margin-set-variable 'magit-reflog-mode))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -190,7 +190,8 @@ be nil, in which case no usage information is shown."
                  (const :tag "in both places" both)
                  (const :tag "nowhere")))
 
-(defcustom magit-log-select-margin '(t 18 (nth 2 magit-log-margin))
+(defcustom magit-log-select-margin
+  (list t 18 (nth 2 magit-log-margin))
   "Format of the margin in `magit-log-select-mode' buffers.
 
 The value has the form (INIT NAME DATE-STYLE).
@@ -220,7 +221,8 @@ format-string suitable for `format-time-string'."
   :group 'magit-log
   :type 'hook)
 
-(defcustom magit-cherry-margin '(t 18 (nth 2 magit-log-margin))
+(defcustom magit-cherry-margin
+  (list t 18 (nth 2 magit-log-margin))
   "Format of the margin in `magit-cherry-mode' buffers.
 
 The value has the form (INIT NAME DATE-STYLE).
@@ -249,7 +251,8 @@ format-string suitable for `format-time-string'."
   :group 'magit-commands
   :type '(repeat (string :tag "Argument")))
 
-(defcustom magit-reflog-margin '(t nil (nth 2 magit-log-margin))
+(defcustom magit-reflog-margin
+  (list t nil (nth 2 magit-log-margin))
   "Format of the margin in `magit-reflog-mode' buffers.
 
 The value has the form (INIT NAME DATE-STYLE).

--- a/lisp/magit-margin.el
+++ b/lisp/magit-margin.el
@@ -57,6 +57,14 @@ does not carry to other options."
 
 ;;; Commands
 
+(magit-define-popup magit-margin-popup
+  "Popup console for changing appearance of the margin."
+  'magit-commands nil nil
+  :actions '("Margin"
+             (?L "toggle visibility" magit-toggle-margin)
+             (?d "toggle details"    magit-toggle-margin-details))
+  :max-action-columns 1)
+
 (defun magit-toggle-margin ()
   "Show or hide the Magit margin."
   (interactive)
@@ -64,6 +72,15 @@ does not carry to other options."
     (user-error "Magit margin isn't supported in this buffer"))
   (setcar magit-buffer-margin (not (magit-buffer-margin-p)))
   (magit-set-buffer-margin))
+
+(defun magit-toggle-margin-details ()
+  "Show or hide details in the Magit margin."
+  (interactive)
+  (unless (magit-margin-option)
+    (user-error "Magit margin isn't supported in this buffer"))
+  (setf (nth 3 magit-buffer-margin)
+        (not (nth 3 magit-buffer-margin)))
+  (magit-set-buffer-margin nil t))
 
 ;;; Core
 

--- a/lisp/magit-margin.el
+++ b/lisp/magit-margin.el
@@ -1,0 +1,216 @@
+;;; magit-margin.el --- margins in Magit buffers  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2010-2016  The Magit Project Contributors
+;;
+;; You should have received a copy of the AUTHORS.md file which
+;; lists all contributors.  If not, see http://magit.vc/authors.
+
+;; Author: Jonas Bernoulli <jonas@bernoul.li>
+;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
+
+;; Magit is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; Magit is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+;; License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Magit.  If not, see http://www.gnu.org/licenses.
+
+;;; Commentary:
+
+;; This library implements support for showing additional information
+;; in the margins of Magit buffers.  Currently this is only used for
+;; commits, for which the author name and optionally committer date or
+;; age are shown.
+
+;;; Code:
+
+(require 'dash)
+
+(require 'magit-section)
+(require 'magit-mode)
+
+(defgroup magit-margin nil
+  "Information Magit displays in the margin.
+
+If you want to change the DATE-STYLE of all `magit-*-margin'
+options to the same value, you can do so by only customizing
+`magit-log-margin' *before* `magit' is loaded.  If you do so,
+then the respective value for the other options will default
+to what you have set for `magit-log-margin'."
+  :group 'magit-log)
+
+(defvar-local magit-set-buffer-margin-refresh nil)
+
+(defvar-local magit-show-margin nil)
+(put 'magit-show-margin 'permanent-local t)
+
+(defvar-local magit-margin-age-width nil)
+(put 'magit-margin-age-width 'permanent-local t)
+
+(defvar magit--age-spec)
+
+;;; Commands
+
+(defun magit-toggle-margin ()
+  "Show or hide the Magit margin."
+  (interactive)
+  (unless (derived-mode-p 'magit-log-mode 'magit-status-mode
+                          'magit-refs-mode 'magit-cherry-mode)
+    (user-error "Magit margin isn't supported in this buffer"))
+  (magit-set-buffer-margin (not (cdr (window-margins)))))
+
+;;; Core
+
+(defun magit-margin-get (prop)
+  (pcase prop
+    (:age-width magit-margin-age-width)
+    (:option (pcase major-mode
+               (`magit-cherry-mode     'magit-cherry-margin)
+               (`magit-log-mode        'magit-log-margin)
+               (`magit-log-select-mode 'magit-log-select-margin)
+               (`magit-reflog-mode     'magit-reflog-margin)
+               (`magit-refs-mode       'magit-refs-margin)
+               (`magit-stashes-mode    'magit-stashes-margin)
+               (`magit-status-mode     'magit-status-margin)))
+    (_ (nth (pcase prop
+              (:initially 0)
+              (:person    1)
+              (:style     2))
+            (symbol-value (magit-margin-get :option))))))
+
+(defun magit-maybe-show-margin ()
+  "Maybe show the margin, depending on the major-mode and an option."
+  (cond ((local-variable-p 'magit-show-margin)
+         (magit-set-buffer-margin magit-show-margin))
+        ((magit-margin-get :option)
+         (magit-set-buffer-margin (magit-margin-get :initially)))))
+
+(defun magit-set-buffer-margin (enable)
+  (let ((style (magit-margin-get :style)))
+    (setq magit-margin-age-width
+          (+ 1 ; gap between committer and time
+             ;;; width of unit
+             (if (eq style 'age-abbreviated)
+                 1  ; single character
+               (+ 1 ; gap between count and unit
+                  (apply #'max (--map (max (length (nth 1 it))
+                                           (length (nth 2 it)))
+                                      magit--age-spec))))))
+    (let ((width (and enable
+                      (+ (-if-let (width (magit-margin-get :person))
+                             (1+ width)
+                           0)
+                         (if (stringp style)
+                             (length (format-time-string style))
+                           (+ 2 ; count width
+                              (magit-margin-get :age-width)))))))
+      (setq magit-show-margin width)
+      (when (and enable magit-set-buffer-margin-refresh)
+        (magit-refresh-buffer))
+      (dolist (window (get-buffer-window-list nil nil 0))
+        (with-selected-window window
+          (set-window-margins nil (car (window-margins)) width)
+          (if enable
+              (add-hook  'window-configuration-change-hook
+                         'magit-set-buffer-margin-1 nil t)
+            (remove-hook 'window-configuration-change-hook
+                         'magit-set-buffer-margin-1 t)))))))
+
+(defun magit-set-buffer-margin-1 ()
+  (-when-let (window (get-buffer-window))
+    (with-selected-window window
+      (set-window-margins nil (car (window-margins)) magit-show-margin))))
+
+(defun magit-make-margin-overlay (&optional string previous-line)
+  (if previous-line
+      (save-excursion
+        (forward-line -1)
+        (magit-make-margin-overlay string))
+    ;; Don't put the overlay on the complete line to work around #1880.
+    (let ((o (make-overlay (1+ (line-beginning-position))
+                           (line-end-position)
+                           nil t)))
+      (overlay-put o 'evaporate t)
+      (overlay-put o 'before-string
+                   (propertize "o" 'display
+                               (list (list 'margin 'right-margin)
+                                     (or string " ")))))))
+
+(defun magit-maybe-make-margin-overlay ()
+  (when (or (magit-section-match
+             '(unpulled unpushed recent stashes local cherries)
+             magit-insert-section--current)
+            (and (eq major-mode 'magit-refs-mode)
+                 (magit-section-match
+                  '(remote commit)
+                  magit-insert-section--current)))
+    (magit-make-margin-overlay nil t)))
+
+;;; Custom Support
+
+(defun magit-margin-set-variable (mode symbol value)
+  (set-default symbol value)
+  (message "Updating margins in %s buffers..." mode)
+  (dolist (buffer (buffer-list))
+    (with-current-buffer buffer
+      (when (eq major-mode mode)
+        (magit-set-buffer-margin magit-show-margin)
+        (magit-refresh))))
+  (message "Updating margins in %s buffers...done" mode))
+
+(defconst magit-log-margin--custom-type
+  '(list (boolean :tag "Show initially")
+         (integer :tag "Show author name using width")
+         (choice  :tag "Show committer"
+                  (string :tag "date using format" "%Y-%m-%d %H:%M ")
+                  (const  :tag "date's age" age)
+                  (const  :tag "date's age (abbreviated)" age-abbreviated))))
+
+;;; Time Utilities
+
+(defvar magit--age-spec
+  `((?Y "year"   "years"   ,(round (* 60 60 24 365.2425)))
+    (?M "month"  "months"  ,(round (* 60 60 24 30.436875)))
+    (?w "week"   "weeks"   ,(* 60 60 24 7))
+    (?d "day"    "days"    ,(* 60 60 24))
+    (?h "hour"   "hours"   ,(* 60 60))
+    (?m "minute" "minutes" 60)
+    (?s "second" "seconds" 1))
+  "Time units used when formatting relative commit ages.
+
+The value is a list of time units, beginning with the longest.
+Each element has the form (CHAR UNIT UNITS SECONDS).  UNIT is the
+time unit, UNITS is the plural of that unit.  CHAR is a character
+abbreviation.  And SECONDS is the number of seconds in one UNIT.
+
+This is defined as a variable to make it possible to use time
+units for a language other than English.  It is not defined
+as an option, because most other parts of Magit are always in
+English.")
+
+(defun magit--age (date &optional abbreviate)
+  (cl-labels ((fn (age spec)
+                  (-let [(char unit units weight) (car spec)]
+                    (let ((cnt (round (/ age weight 1.0))))
+                      (if (or (not (cdr spec))
+                              (>= (/ age weight) 1))
+                          (list cnt (cond (abbreviate char)
+                                          ((= cnt 1) unit)
+                                          (t units)))
+                        (fn age (cdr spec)))))))
+    (fn (abs (- (float-time) (string-to-number date)))
+        magit--age-spec)))
+
+;;; magit-margin.el ends soon
+(provide 'magit-margin)
+;; Local Variables:
+;; coding: utf-8
+;; indent-tabs-mode: nil
+;; End:
+;;; magit-margin.el ends here

--- a/lisp/magit-margin.el
+++ b/lisp/magit-margin.el
@@ -62,6 +62,7 @@ does not carry to other options."
   'magit-commands nil nil
   :actions '("Margin"
              (?L "toggle visibility" magit-toggle-margin)
+             (?l "cycle style"       magit-cycle-margin-style)
              (?d "toggle details"    magit-toggle-margin-details))
   :max-action-columns 1)
 
@@ -72,6 +73,21 @@ does not carry to other options."
     (user-error "Magit margin isn't supported in this buffer"))
   (setcar magit-buffer-margin (not (magit-buffer-margin-p)))
   (magit-set-buffer-margin))
+
+(defun magit-cycle-margin-style ()
+  "Cycle style used for the Magit margin."
+  (interactive)
+  (unless (magit-margin-option)
+    (user-error "Magit margin isn't supported in this buffer"))
+  ;; This is only suitable for commit margins (there are not others).
+  (setf (cadr magit-buffer-margin)
+        (pcase (cadr magit-buffer-margin)
+          (`age 'age-abbreviated)
+          (`age-abbreviated
+           (let ((default (cadr (symbol-value (magit-margin-option)))))
+             (if (stringp default) default "%Y-%m-%d %H:%M ")))
+          (_ 'age)))
+  (magit-set-buffer-margin nil t))
 
 (defun magit-toggle-margin-details ()
   "Show or hide details in the Magit margin."

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -59,13 +59,13 @@
 
 (defcustom magit-mode-setup-hook
   '(magit-maybe-save-repository-buffers
-    magit-maybe-show-margin)
+    magit-set-buffer-margin)
   "Hook run by `magit-mode-setup'."
   :package-version '(magit . "2.3.0")
   :group 'magit-modes
   :type 'hook
   :options '(magit-maybe-save-repository-buffers
-             magit-maybe-show-margin))
+             magit-set-buffer-margin))
 
 (defcustom magit-pre-refresh-hook '(magit-maybe-save-repository-buffers)
   "Hook run before refreshing in `magit-refresh'.

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -31,7 +31,8 @@
 
 ;;; Options
 
-(defcustom magit-stashes-margin '(t nil (nth 2 magit-log-margin))
+(defcustom magit-stashes-margin
+  (list t nil (nth 2 magit-log-margin))
   "Format of the margin in `magit-stashes-mode' buffers.
 
 The value has the form (INIT NAME DATE-STYLE).

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -333,7 +333,7 @@ instead of \"Stashes:\"."
     (magit-insert-section (stashes ref (not magit-status-expand-stashes))
       (magit-insert-heading heading)
       (magit-git-wash (apply-partially 'magit-log-wash-log 'stash)
-        "reflog" "--format=%gd %at %gs" ref))))
+        "reflog" "--format=%gd%x00%aN%x00%at%x00%gs" ref))))
 
 ;;; List Stashes
 
@@ -354,7 +354,7 @@ instead of \"Stashes:\"."
                               "Stashes:"
                             (format "Stashes [%s]:" ref)))
     (magit-git-wash (apply-partially 'magit-log-wash-log 'stash)
-      "reflog" "--format=%gd %at %gs" ref)))
+      "reflog" "--format=%gd%x00%aN%x00%at%x00%gs" ref)))
 
 ;;; Show Stash
 

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -32,18 +32,25 @@
 ;;; Options
 
 (defcustom magit-stashes-margin
-  (list t nil (nth 2 magit-log-margin))
+  (list (nth 0 magit-log-margin)
+        (nth 1 magit-log-margin)
+        'magit-log-margin-width nil
+        (nth 4 magit-log-margin))
   "Format of the margin in `magit-stashes-mode' buffers.
 
-The value has the form (INIT NAME DATE-STYLE).
+The value has the form (INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH).
 
 If INIT is non-nil, then the margin is shown initially.
-If NAME is an integer, then the name of the author is shown
-  using an area of that width.  Otherwise it must be nil.
-DATE-STYLE can be `age', in which case the age of the commit
-is shown.  If it is `age-abbreviated', then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be a
-format-string suitable for `format-time-string'."
+STYLE controls how to format the committer date.  It can be one
+  of `age' (to show the age of the commit), `age-abbreviated' (to
+  abbreviate the time unit to a character), or a string (suitable
+  for `format-time-string') to show the actual date.
+WIDTH controls the width of the margin.  This exists for forward
+  compatibility and currently the value should not be changed.
+AUTHOR controls whether the name of the author is also shown by
+  default.
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+  is shown, then this specifies how much space is used to do so."
   :package-version '(magit . "2.9.0")
   :group 'magit-refs
   :group 'magit-margin

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -532,41 +532,6 @@ Unless optional argument KEEP-EMPTY-LINES is t, trim all empty lines."
       (insert-file-contents file)
       (split-string (buffer-string) "\n" (not keep-empty-lines)))))
 
-;;; Time Utilities
-
-(defvar magit--age-spec
-  `((?Y "year"   "years"   ,(round (* 60 60 24 365.2425)))
-    (?M "month"  "months"  ,(round (* 60 60 24 30.436875)))
-    (?w "week"   "weeks"   ,(* 60 60 24 7))
-    (?d "day"    "days"    ,(* 60 60 24))
-    (?h "hour"   "hours"   ,(* 60 60))
-    (?m "minute" "minutes" 60)
-    (?s "second" "seconds" 1))
-  "Time units used when formatting relative commit ages.
-
-The value is a list of time units, beginning with the longest.
-Each element has the form (CHAR UNIT UNITS SECONDS).  UNIT is the
-time unit, UNITS is the plural of that unit.  CHAR is a character
-abbreviation.  And SECONDS is the number of seconds in one UNIT.
-
-This is defined as a variable to make it possible to use time
-units for a language other than English.  It is not defined
-as an option, because most other parts of Magit are always in
-English.")
-
-(defun magit--age (date &optional abbreviate)
-  (cl-labels ((fn (age spec)
-                  (-let [(char unit units weight) (car spec)]
-                    (let ((cnt (round (/ age weight 1.0))))
-                      (if (or (not (cdr spec))
-                              (>= (/ age weight) 1))
-                          (list cnt (cond (abbreviate char)
-                                          ((= cnt 1) unit)
-                                          (t units)))
-                        (fn age (cdr spec)))))))
-    (fn (abs (- (float-time) (string-to-number date)))
-        magit--age-spec)))
-
 ;;; Kludges
 
 (defun magit-file-accessible-directory-p (filename)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -980,7 +980,7 @@ If there is no blob buffer in the same frame, then do nothing."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map magit-mode-map)
     (define-key map "\C-y" 'magit-refs-set-show-commit-count)
-    (define-key map "L"    'magit-toggle-margin)
+    (define-key map "L"    'magit-margin-popup)
     map)
   "Keymap for `magit-refs-mode'.")
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -148,18 +148,25 @@ The functions which respect this option are
   :type 'boolean)
 
 (defcustom magit-status-margin
-  (list nil nil (nth 2 magit-log-margin))
+  (list nil
+        (nth 1 magit-log-margin)
+        'magit-log-margin-width nil
+        (nth 4 magit-log-margin))
   "Format of the margin in `magit-status-mode' buffers.
 
-The value has the form (INIT NAME DATE-STYLE).
+The value has the form (INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH).
 
 If INIT is non-nil, then the margin is shown initially.
-If NAME is an integer, then the name of the author is shown
-  using an area of that width.  Otherwise it must be nil.
-DATE-STYLE can be `age', in which case the age of the commit
-is shown.  If it is `age-abbreviated', then the time unit is
-abbreviated to a single character.  DATE-STYLE can also be a
-format-string suitable for `format-time-string'."
+STYLE controls how to format the committer date.  It can be one
+  of `age' (to show the age of the commit), `age-abbreviated' (to
+  abbreviate the time unit to a character), or a string (suitable
+  for `format-time-string') to show the actual date.
+WIDTH controls the width of the margin.  This exists for forward
+  compatibility and currently the value should not be changed.
+AUTHOR controls whether the name of the author is also shown by
+  default.
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+  is shown, then this specifies how much space is used to do so."
   :package-version '(magit . "2.9.0")
   :group 'magit-status
   :group 'magit-margin
@@ -210,20 +217,25 @@ To change the value in an existing buffer use the command
 (put 'magit-refs-show-commit-count 'permanent-local t)
 
 (defcustom magit-refs-margin
-  (list nil 18 (nth 2 magit-log-margin))
+  (list nil
+        (nth 1 magit-log-margin)
+        'magit-log-margin-width nil
+        (nth 4 magit-log-margin))
   "Format of the margin in `magit-refs-mode' buffers.
 
-The value has the form (INIT NAME DATE-STYLE TAGS).
+The value has the form (INIT STYLE WIDTH AUTHOR AUTHOR-WIDTH).
 
 If INIT is non-nil, then the margin is shown initially.
-If NAME is an integer, then the name of the author is shown
-  using an area of that width.  Otherwise it must be nil.
-DATE-STYLE can be `age', in which case the age of the commit
-date is shown.  If it is `age-abbreviated', then the time
-unit is abbreviated to a single character.  DATE-STYLE can
-also be a format-string suitable for `format-time-string'.
-If TAGS is non-nil, then the margin shows information not
-only about branches, but also about tags."
+STYLE controls how to format the committer date.  It can be one
+  of `age' (to show the age of the commit), `age-abbreviated' (to
+  abbreviate the time unit to a character), or a string (suitable
+  for `format-time-string') to show the actual date.
+WIDTH controls the width of the margin.  This exists for forward
+  compatibility and currently the value should not be changed.
+AUTHOR controls whether the name of the author is also shown by
+  default.
+AUTHOR-WIDTH has to be an integer.  When the name of the author
+  is shown, then this specifies how much space is used to do so."
   :package-version '(magit . "2.9.0")
   :group 'magit-refs
   :group 'magit-margin
@@ -1044,7 +1056,7 @@ Refs are compared with a branch read form the user."
   (magit-mode-setup #'magit-refs-mode ref args))
 
 (defun magit-refs-refresh-buffer (&rest _ignore)
-  (setq magit-set-buffer-margin-refresh (not magit-show-margin))
+  (setq magit-set-buffer-margin-refresh (not (magit-buffer-margin-p)))
   (unless (magit-rev-verify (or (car magit-refresh-args) "HEAD"))
     (setq magit-refs-show-commit-count nil))
   (magit-insert-section (branchbuf)
@@ -1260,7 +1272,7 @@ different, but only if you have customized the option
                                       (and behind (format "behind %s" behind))))
                              (t "")))
                   "")))))
-    (when magit-show-margin
+    (when (magit-buffer-margin-p)
       (magit-refs-format-margin branch))
     (magit-refs-insert-cherry-commits head branch section)))
 
@@ -1308,7 +1320,7 @@ different, but only if you have customized the option
                             `((?n . ,(propertize tag 'face 'magit-tag))
                               (?c . ,(or mark count ""))
                               (?m . ,(or message "")))))
-              (when (and (car magit-buffer-margin)
+              (when (and (magit-buffer-margin-p)
                          magit-refs-margin-for-tags)
                 (magit-refs-format-margin (concat tag "^{commit}")))
               (magit-refs-insert-cherry-commits head tag section)))))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -208,7 +208,7 @@ To change the value in an existing buffer use the command
 (put 'magit-refs-show-commit-count 'safe-local-variable 'symbolp)
 (put 'magit-refs-show-commit-count 'permanent-local t)
 
-(defcustom magit-refs-margin '(nil 18 (nth 2 magit-log-margin) nil)
+(defcustom magit-refs-margin '(nil 18 (nth 2 magit-log-margin))
   "Format of the margin in `magit-refs-mode' buffers.
 
 The value has the form (INIT NAME DATE-STYLE TAGS).
@@ -226,17 +226,20 @@ only about branches, but also about tags."
   :group 'magit-refs
   :group 'magit-margin
   :safe (lambda (val) (memq val '(all branch nil)))
-  :type '(list (boolean :tag "Show initially")
-               (integer :tag "Show author name using width")
-               (choice  :tag "Show committer"
-                        (string :tag "date using format" "%Y-%m-%d %H:%m ")
-                        (const  :tag "date's age" age)
-                        (const  :tag "date's age (abbreviated)"
-                                age-abbreviated))
-               (boolean :tag "Show for tags too"))
+  :type magit-log-margin--custom-type
   :initialize 'magit-custom-initialize-reset
   :set-after '(magit-log-margin)
   :set (apply-partially #'magit-margin-set-variable 'magit-refs-mode))
+
+(defcustom magit-refs-margin-for-tags nil
+  "Whether to show information about tags in the margin.
+
+This is disabled by default because it is slow if there are many
+tags."
+  :package-version '(magit . "2.9.0")
+  :group 'magit-refs
+  :group 'magit-margin
+  :type 'boolean)
 
 (defcustom magit-visit-ref-behavior nil
   "Control how `magit-visit-ref' behaves in `magit-refs-mode' buffers.
@@ -1303,8 +1306,8 @@ different, but only if you have customized the option
                             `((?n . ,(propertize tag 'face 'magit-tag))
                               (?c . ,(or mark count ""))
                               (?m . ,(or message "")))))
-              (when (and magit-show-margin
-                         (nth 3 magit-refs-margin))
+              (when (and (car magit-buffer-margin)
+                         magit-refs-margin-for-tags)
                 (magit-refs-format-margin (concat tag "^{commit}")))
               (magit-refs-insert-cherry-commits head tag section)))))
       (insert ?\n))))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -147,7 +147,8 @@ The functions which respect this option are
   :group 'magit-status
   :type 'boolean)
 
-(defcustom magit-status-margin '(nil nil (nth 2 magit-log-margin))
+(defcustom magit-status-margin
+  (list nil nil (nth 2 magit-log-margin))
   "Format of the margin in `magit-status-mode' buffers.
 
 The value has the form (INIT NAME DATE-STYLE).
@@ -208,7 +209,8 @@ To change the value in an existing buffer use the command
 (put 'magit-refs-show-commit-count 'safe-local-variable 'symbolp)
 (put 'magit-refs-show-commit-count 'permanent-local t)
 
-(defcustom magit-refs-margin '(nil 18 (nth 2 magit-log-margin))
+(defcustom magit-refs-margin
+  (list nil 18 (nth 2 magit-log-margin))
   "Format of the margin in `magit-refs-mode' buffers.
 
 The value has the form (INIT NAME DATE-STYLE TAGS).


### PR DESCRIPTION
This is the second part. The first part happened directly on `master`, mostly in 186c3d6ccbca78386cb0faa69164b3396bb38ae6 and in response to #2792.

* Generalize margin support as described in 3881bbb2540e07c6f75ef3c675b38bca023f2649.
* Add commands to toggle margin details and cycle the margin style.

This changes the form of margin options again, but better do that now after five days and before the release than later when more than a handful of users have already adapted.