### PR TITLE
Discard highlight-overlays

### DIFF
--- a/Documentation/RelNotes/2.9.0.txt
+++ b/Documentation/RelNotes/2.9.0.txt
@@ -400,6 +400,9 @@ Fixes since v2.8.0
 * The status header about the upstream did not take
   `branch.NAME.rebase' into account.  e65f15d0
 
+* Highlighting overlays could not be garbage collected until after a
+  refresh.  #2888
+
 This release also contains typofixes, documentation updates,
 code clean-ups, and other small bug fixes and improvements.
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -845,7 +845,8 @@ evaluated its BODY.  Admittedly that's a bit of a hack."
             (deactivate-mark nil)
             (selection (magit-region-sections)))
         (mapc #'delete-overlay magit-section-highlight-overlays)
-        (setq magit-section-unhighlight-sections
+        (setq magit-section-highlight-overlays nil
+              magit-section-unhighlight-sections
               magit-section-highlighted-sections
               magit-section-highlighted-sections nil)
         (unless (eq section magit-root-section)


### PR DESCRIPTION
Set `magit-section-highlight-overlays' to nil in addition to mapping
delete-overlay over it to remove all references to those overlays.
Otherwise `magit-section-highlight-overlays' grows unbounded, since `delete-overlay' only causes overlays to be unlinked form the buffer, they don't actually cease to exist. When we remove all references they should (hopefully) be garbage collected.