### PR TITLE
Use absolute path for magit-emacs-Q-command load file

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -484,7 +484,8 @@ ACTION is a member of option `magit-slow-confirm'."
                               (file-name-directory (locate-library lib)))
                             '("magit" "magit-popup" "with-editor"
                               "git-commit" "dash"))))
-                "-l" "magit")
+                ;; Avoid Emacs bug#16406 by using full path.
+                "-l" ,(file-name-sans-extension (locate-library "magit")))
               " ")))
     (message "Uncustomized Magit command saved to kill-ring, %s"
              "please run it in a terminal.")


### PR DESCRIPTION
This matches the absolute paths for library directories.