### PR TITLE
Remember arguments used in refs buffer and allow updating  them without prefix arg

### DIFF
--- a/Documentation/RelNotes/2.11.1.txt
+++ b/Documentation/RelNotes/2.11.1.txt
@@ -18,6 +18,12 @@ Changes since v2.11.0
     (define-key magit-mode-map [remap previous-line] 'magit-previous-line)
     (define-key magit-mode-map [remap next-line] 'magit-next-line)
 
+* The command `magit-refs-popup' now remembers arguments and they are
+  displayed in the header-line of `magit-refs-mode' buffers.  The popup
+  command still invokes the default action by default when invoked from
+  another buffer, but when invoked from a `magit-refs-mode' buffer it
+  now shows the popup.  #2898
+
 Fixes since v2.11.0
 -------------------
 

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -242,7 +242,10 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
                   magit-show-refs))
   :default-action 'magit-show-refs-head
   :max-action-columns 1
-  :use-prefix 'popup)
+  :use-prefix (lambda ()
+                (if (derived-mode-p 'magit-refs-mode)
+                    (if current-prefix-arg 'popup 'default)
+                  'popup)))
 
 (defun magit-read-ref-sort (prompt initial-input)
   (magit-completing-read prompt

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -213,10 +213,15 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
   (setq-local bookmark-make-record-function
               #'magit-bookmark--refs-make-record))
 
-(defun magit-refs-refresh-buffer (&rest _ignore)
+(defun magit-refs-refresh-buffer (ref &optional args)
   (setq magit-set-buffer-margin-refresh (not (magit-buffer-margin-p)))
-  (unless (magit-rev-verify (or (car magit-refresh-args) "HEAD"))
+  (unless ref
+    (setq ref "HEAD"))
+  (unless (magit-rev-verify ref)
     (setq magit-refs-show-commit-count nil))
+  (setq header-line-format
+        (propertize (format " %s %s" ref (mapconcat #'identity args " "))
+                    'face 'magit-header-line))
   (magit-insert-section (branchbuf)
     (run-hooks 'magit-refs-sections-hook)))
 

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -222,36 +222,55 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
 
 ;;; Commands
 
-;;;###autoload (autoload 'magit-show-refs-popup "magit" nil t)
-(magit-define-popup magit-show-refs-popup
-  "Popup console for `magit-show-refs'."
-  :man-page "git-branch"
-  :switches '((?m "Merged to HEAD"            "--merged")
-              (?M "Merged to master"          "--merged=master")
-              (?n "Not merged to HEAD"        "--no-merged")
-              (?N "Not merged to master"      "--no-merged=master"))
-  :options  '((?c "Contains"   "--contains="  magit-read-branch-or-commit)
-              (?m "Merged"     "--merged="    magit-read-branch-or-commit)
-              (?n "Not merged" "--no-merged=" magit-read-branch-or-commit)
-              (?s "Sort"       "--sort="      magit-read-ref-sort))
-  :actions  '((?y "Show refs, comparing them with HEAD"
-                  magit-show-refs-head)
-              (?c "Show refs, comparing them with current branch"
-                  magit-show-refs-current)
-              (?o "Show refs, comparing them with other branch"
-                  magit-show-refs))
-  :default-action 'magit-show-refs-head
-  :max-action-columns 1
-  :use-prefix (lambda ()
-                (if (derived-mode-p 'magit-refs-mode)
-                    (if current-prefix-arg 'popup 'default)
-                  'popup)))
+(defcustom magit-show-refs-arguments nil
+  "The arguments used in `magit-refs-mode' buffers."
+  :group 'magit-git-arguments
+  :group 'magit-refs
+  :type '(repeat (string :tag "Argument")))
+
+(defvar magit-show-refs-popup
+  (list
+   :variable 'magit-show-refs-arguments
+   :man-page "git-branch"
+   :switches '((?m "Merged to HEAD"            "--merged")
+               (?M "Merged to master"          "--merged=master")
+               (?n "Not merged to HEAD"        "--no-merged")
+               (?N "Not merged to master"      "--no-merged=master"))
+   :options  '((?c "Contains"   "--contains="  magit-read-branch-or-commit)
+               (?m "Merged"     "--merged="    magit-read-branch-or-commit)
+               (?n "Not merged" "--no-merged=" magit-read-branch-or-commit)
+               (?s "Sort"       "--sort="      magit-read-ref-sort))
+   :actions  '((?y "Show refs, comparing them with HEAD"
+                   magit-show-refs-head)
+               (?c "Show refs, comparing them with current branch"
+                   magit-show-refs-current)
+               (?o "Show refs, comparing them with other branch"
+                   magit-show-refs))
+   :default-action 'magit-show-refs-head
+   :max-action-columns 1
+   :use-prefix (lambda ()
+                 (if (derived-mode-p 'magit-refs-mode)
+                     (if current-prefix-arg 'popup 'default)
+                   'popup))))
+
+(magit-define-popup-keys-deferred 'magit-show-refs-popup)
 
 (defun magit-read-ref-sort (prompt initial-input)
   (magit-completing-read prompt
                          '("-committerdate" "-authordate"
                            "committerdate" "authordate")
                          nil nil initial-input))
+
+(defun magit-show-refs-arguments ()
+  (if (eq magit-current-popup 'magit-show-refs-popup)
+      magit-current-popup-args
+    magit-show-refs-arguments))
+
+;;;###autoload
+(defun magit-show-refs-popup (&optional arg)
+  "Popup console for `magit-show-refs'."
+  (interactive "P")
+  (magit-invoke-popup 'magit-show-refs-popup nil arg))
 
 ;;;###autoload
 (defun magit-show-refs-head (&optional args)

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -261,16 +261,28 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
                            "committerdate" "authordate")
                          nil nil initial-input))
 
+(defun magit-show-refs-get-buffer-args ()
+  (cond ((and magit-use-sticky-arguments
+              (derived-mode-p 'magit-refs-mode))
+         (cadr magit-refresh-args))
+        ((and (eq magit-use-sticky-arguments t)
+              (--when-let (magit-mode-get-buffer 'magit-refs-mode)
+                (with-current-buffer it
+                  (cadr magit-refresh-args)))))
+        (t
+         (default-value 'magit-show-refs-arguments))))
+
 (defun magit-show-refs-arguments ()
   (if (eq magit-current-popup 'magit-show-refs-popup)
       magit-current-popup-args
-    magit-show-refs-arguments))
+    (magit-show-refs-get-buffer-args)))
 
 ;;;###autoload
 (defun magit-show-refs-popup (&optional arg)
   "Popup console for `magit-show-refs'."
   (interactive "P")
-  (magit-invoke-popup 'magit-show-refs-popup nil arg))
+  (let ((magit-show-refs-arguments (magit-show-refs-get-buffer-args)))
+    (magit-invoke-popup 'magit-show-refs-popup nil arg)))
 
 ;;;###autoload
 (defun magit-show-refs-head (&optional args)

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -241,6 +241,7 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
               (?o "Show refs, comparing them with other branch"
                   magit-show-refs))
   :default-action 'magit-show-refs-head
+  :max-action-columns 1
   :use-prefix 'popup)
 
 (defun magit-read-ref-sort (prompt initial-input)


### PR DESCRIPTION
* Like for diff and log buffers
  * [ ] Remember the arguments, allow setting locally and globally.
  * [ ] Show arguments in header.
  * Useful for #2872.
* [ ] Always show popup when `y` is pressed in refs buffer, don't require prefix argument.
  * Despite #2894, and unlike for diff and log, there *probably* won't be a show-new and a refresh variant.
  * Maybe rename to `magit-list-references`.

The current implementation on this branch was created before I realized that the arguments are not being remembered (and how much work it would be to do that), and is therefore not suitable for merge.