### PR TITLE
magit-log-wash-rev: correct reflog comment

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -972,8 +972,9 @@ Do not add this to a hook variable."
                             magit-log-bisect-vis-re
                           magit-log-heading-re)))
       (magit-delete-line)
-      ;; `git reflog show' output sometimes ends with an incomplete
-      ;; element (which has no basis in the data stored in the file).
+      ;; If the reflog entries have been pruned, the output of `git
+      ;; reflog show' includes a partial line that refers to the hash
+      ;; of the youngest expired reflog entry.
       (when (and (eq style 'reflog) (not date))
         (cl-return-from magit-log-wash-rev t))
       (magit-insert-section section (commit hash)


### PR DESCRIPTION
```
The comment added in d430d856 (magit-log-wash-rev: work around `git
reflog show' bug, 2016-12-01) states that the partial trailing line
"has no basis in the data stored in the file".  However, as far as I
can tell, this partial line occurs if some reflog entries have been
expired (e.g., by 'git gc').  The reported hash on this partial line
seems to always correspond to the "old hash" field of the oldest
reflog entry.  That is, this hash is the first field of the first
entry in the corresponding .git/logs/refs/ file.

Update the comment to reflect this.

See also 81a6241e (magit-log-reflog-re: Allow for partial line,
2015-04-11).
```