### PR TITLE
Properly initialize hook options

### DIFF
--- a/Documentation/RelNotes/2.9.1.txt
+++ b/Documentation/RelNotes/2.9.1.txt
@@ -10,6 +10,9 @@ Changes since v2.9.0
 Fixes since v2.9.0
 ------------------
 
+* Customizations of hooks were ignored, if the `custom-set-variables'
+  form was evaluated before the Magit libraries were loaded.  #2902
+
 * When creating a commit, `magit-display-buffer-fullcolumn-most-v1'
   filled the entire frame, hiding the commit message buffer.  #2891
 

--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -113,6 +113,7 @@
 
 (require 'dash)
 (require 'log-edit)
+(require 'magit-utils nil t)
 (require 'ring)
 (require 'server)
 (require 'with-editor)
@@ -162,12 +163,6 @@ The major mode configured here is turned on by the minor mode
   :type '(choice (function-item text-mode)
                  (const :tag "No major mode")))
 
-(unless (find-lisp-object-file-name 'git-commit-setup-hook 'defvar)
-  (add-hook 'git-commit-setup-hook 'with-editor-usage-message)
-  (add-hook 'git-commit-setup-hook 'git-commit-propertize-diff)
-  (add-hook 'git-commit-setup-hook 'git-commit-turn-on-auto-fill)
-  (add-hook 'git-commit-setup-hook 'git-commit-setup-changelog-support)
-  (add-hook 'git-commit-setup-hook 'git-commit-save-message))
 (defcustom git-commit-setup-hook
   '(git-commit-save-message
     git-commit-setup-changelog-support
@@ -177,6 +172,7 @@ The major mode configured here is turned on by the minor mode
   "Hook run at the end of `git-commit-setup'."
   :group 'git-commit
   :type 'hook
+  :get (and (featurep 'magit-utils) 'magit-hook-custom-get)
   :options '(git-commit-save-message
              git-commit-setup-changelog-support
              git-commit-turn-on-auto-fill

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -79,13 +79,12 @@ and then turned on again when turning off the latter."
   :group 'magit-blame
   :type '(choice (const :tag "No lighter" "") string))
 
-(unless (find-lisp-object-file-name 'magit-blame-goto-chunk-hook 'defvar)
-  (add-hook 'magit-blame-goto-chunk-hook 'magit-blame-maybe-update-revision-buffer))
 (defcustom magit-blame-goto-chunk-hook '(magit-blame-maybe-update-revision-buffer)
   "Hook run by `magit-blame-next-chunk' and `magit-blame-previous-chunk'."
   :package-version '(magit . "2.1.0")
   :group 'magit-blame
   :type 'hook
+  :get 'magit-hook-custom-get
   :options '(magit-blame-maybe-update-revision-buffer))
 
 (defface magit-blame-heading

--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -39,9 +39,6 @@
   "Ediff support for Magit."
   :group 'magit-extensions)
 
-(unless (find-lisp-object-file-name 'magit-ediff-quit-hook 'defvar)
-  (add-hook 'magit-ediff-quit-hook 'magit-ediff-restore-previous-winconf)
-  (add-hook 'magit-ediff-quit-hook 'magit-ediff-cleanup-auxiliary-buffers))
 (defcustom magit-ediff-quit-hook
   '(magit-ediff-cleanup-auxiliary-buffers
     magit-ediff-restore-previous-winconf)
@@ -53,6 +50,7 @@ invoked using Magit."
   :package-version '(magit . "2.2.0")
   :group 'magit-ediff
   :type 'hook
+  :get 'magit-hook-custom-get
   :options '(magit-ediff-cleanup-auxiliary-buffers
              magit-ediff-restore-previous-winconf))
 

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -112,22 +112,20 @@ which in turn uses the function specified here."
                 (function-item display-buffer)
                 (function :tag "Function")))
 
-(unless (find-lisp-object-file-name 'magit-pre-display-buffer-hook 'defvar)
-  (add-hook 'magit-pre-display-buffer-hook 'magit-save-window-configuration))
 (defcustom magit-pre-display-buffer-hook '(magit-save-window-configuration)
   "Hook run by `magit-display-buffer' before displaying the buffer."
   :package-version '(magit . "2.3.0")
   :group 'magit-modes
   :type 'hook
+  :get 'magit-hook-custom-get
   :options '(magit-save-window-configuration))
 
-(unless (find-lisp-object-file-name 'magit-post-display-buffer-hook 'defvar)
-  (add-hook 'magit-post-display-buffer-hook 'magit-maybe-set-dedicated))
 (defcustom magit-post-display-buffer-hook '(magit-maybe-set-dedicated)
   "Hook run by `magit-display-buffer' after displaying the buffer."
   :package-version '(magit . "2.3.0")
   :group 'magit-modes
   :type 'hook
+  :get 'magit-hook-custom-get
   :options '(magit-maybe-set-dedicated))
 
 (defcustom magit-generate-buffer-name-function

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -27,13 +27,12 @@
 
 ;;; Options
 
-(unless (find-lisp-object-file-name 'magit-submodule-list-mode-hook 'defvar)
-  (add-hook 'magit-submodule-list-mode-hook 'hl-line-mode))
 (defcustom magit-submodule-list-mode-hook '(hl-line-mode)
   "Hook run after entering Magit-Submodule-List mode."
   :package-version '(magit . "2.9.0")
   :group 'magit-modes
   :type 'hook
+  :get 'magit-hook-custom-get
   :options '(hl-line-mode))
 
 (defcustom magit-submodule-list-columns

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -464,13 +464,12 @@ depth directly."
   :group 'magit
   :type 'integer)
 
-(unless (find-lisp-object-file-name 'magit-repolist-mode-hook 'defvar)
-  (add-hook 'magit-repolist-mode-hook 'hl-line-mode))
 (defcustom magit-repolist-mode-hook '(hl-line-mode)
   "Hook run after entering Magit-Repolist mode."
   :package-version '(magit . "2.9.0")
   :group 'magit-modes
   :type 'hook
+  :get 'magit-hook-custom-get
   :options '(hl-line-mode))
 
 (defcustom magit-repolist-columns


### PR DESCRIPTION
magit-hook-custom-get: new function used to initialize hook options

Fixes #2902.

I did some rudimentary testing using 

```lisp
;;; Preparations

;; Don't (package-initialize)
(add-to-list 'load-path "~/.emacs.d/lib/dash")
(add-to-list 'load-path "~/.emacs.d/lib/with-editor")
(add-to-list 'load-path "~/.emacs.d/lib/magit/lisp")

;;; Variant 1: no customizations

;;; Variant 2: using Custom

;; (custom-set-variables
;;  '(git-commit-setup-hook
;;    (quote
;;     (git-commit-save-message git-commit-setup-changelog-support git-commit-turn-on-auto-fill git-commit-turn-on-flyspell git-commit-propertize-diff with-editor-usage-message)))
;;  '(package-selected-packages (quote (magit))))

;;; Variant 3: using add-hook

;; (add-hook 'git-commit-setup-hook 'git-commit-turn-on-flyspell)

;;; Test

(require 'git-commit)
(pp-eval-expression '(mapcar 'list git-commit-setup-hook))
```