### PR TITLE
Use magit-get instead of magit-git-string

### DIFF
--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -381,11 +381,11 @@ current branch.  The description is taken from the Git variable
 `branch.<NAME>.description'; if that is undefined then no header
 line is inserted at all."
   (let ((branch (magit-get-current-branch)))
-    (--when-let (magit-git-lines
-                 "config" (format "branch.%s.description" branch))
+    (-when-let* ((desc (magit-get "branch" branch "description"))
+                 (desc-lines (split-string desc "\n")))
       (magit-insert-section (branchdesc branch t)
-        (magit-insert-heading branch ": " (car it))
-        (insert (mapconcat 'identity (cdr it) "\n"))
+        (magit-insert-heading branch ": " (car desc-lines))
+        (insert (mapconcat 'identity (cdr desc-lines) "\n"))
         (insert "\n\n")))))
 
 (defun magit-insert-local-branches ()

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -373,8 +373,7 @@ detached `HEAD'."
   "Insert a header line about branch usually pulled into current branch."
   (when pull
     (magit-insert-section (branch pull)
-      (let ((rebase (magit-git-string "config"
-                                      (format "branch.%s.rebase" branch))))
+      (let ((rebase (magit-get "branch" branch "rebase")))
         (pcase rebase
           ("true")
           ("false" (setq rebase nil))


### PR DESCRIPTION
Just noticed these while checking the git calls for #2909. This shaves off another call to `git config` during refresh, doesn't make a noticeable change in speed.

Before: `Refreshing magit...done (0.450s, cached 46/73)`
After: `Refreshing magit...done (0.449s, cached 48/74)`
