### PR TITLE
Make Shift-selection less surprising

### DIFF
--- a/Documentation/RelNotes/2.11.1.txt
+++ b/Documentation/RelNotes/2.11.1.txt
@@ -4,6 +4,20 @@ Magit v2.11.1 Release Notes (unreleased)
 Changes since v2.11.0
 ---------------------
 
+* Added new commands `magit-previous-line' and `magit-next-line' as
+  substitutes for `previous-line' and `next-line'.  Magit's selection
+  mechanism is based on the region but selects an area that is larger
+  than the region.  This causes shift selection to select two lines on
+  the first invocation when using the vanilla commands.  When invoked
+  inside the body of a hunk the new Magit-specific variants don't move
+  point on the first invocation and thereby they only selects a single
+  line.  Which inconsistency you prefer is a matter of preference.  #2912
+
+  To use the Magit-specific variants add this to your init file:
+
+    (define-key magit-mode-map [remap previous-line] 'magit-previous-line)
+    (define-key magit-mode-map [remap next-line] 'magit-next-line)
+
 Fixes since v2.11.0
 -------------------
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -295,6 +295,49 @@ With a prefix argument also expand it." heading)
                   (recenter 0)))
        (message ,(format "Section \"%s\" wasn't found" heading)))))
 
+;;;; Region
+
+(defun magit-turn-on-shift-select-mode-p ()
+  (and shift-select-mode
+       this-command-keys-shift-translated
+       (not mark-active)
+       (not (eq (car-safe transient-mark-mode) 'only))
+       (magit-section-match 'hunk)
+       (> (point) (magit-section-content (magit-current-section)))))
+
+(defun magit-previous-line (&optional _arg _try-vscroll)
+  "Like `previous-line' but with Magit-specific shift-selection.
+
+Magit's selection mechanism is based on the region but selects an
+area that is larger than the region.  This causes `previous-line'
+when invoked while holding the shift key to move up one line and
+thereby select two lines.  When invoked inside a hunk body this
+command does not move point on the first invocation and thereby
+it only selects a single line.  Which inconsistency you prefer
+is a matter of preference."
+  (declare (interactive-only
+            "use `forward-line' with negative argument instead."))
+  (interactive "p\np")
+  (if (magit-turn-on-shift-select-mode-p)
+      (push-mark-command t)
+    (call-interactively 'previous-line)))
+
+(defun magit-next-line (&optional _arg _try-vscroll)
+  "Like `next-line' but with Magit-specific shift-selection.
+
+Magit's selection mechanism is based on the region but selects
+an area that is larger than the region.  This causes `next-line'
+when invoked while holding the shift key to move down one line
+and thereby select two lines.  When invoked inside a hunk body
+this command does not move point on the first invocation and
+thereby it only selects a single line.  Which inconsistency you
+prefer is a matter of preference."
+  (declare (interactive-only forward-line))
+  (interactive "p\np")
+  (if (magit-turn-on-shift-select-mode-p)
+      (push-mark-command t)
+    (call-interactively 'next-line)))
+
 ;;;; Visibility
 
 (defun magit-section-show (section)


### PR DESCRIPTION
Normally `C-S-n`, sets the mark and then moves down one line, resulting in one line being selected by the region. The same thing happens in Magit (because we don't handle this specifically yet), but because Magit's "selection mechanism" is only *based* on the region, but actually spans a wider area, this keeps surprising users.

The selection begins at the beginning of the line on which the beginning of the region is and ends at the end of the line on which the end of the region is. The effect of this is that a single `C-S-n` selects *two* lines. The region is still the same, but the region is not visualized and so it looks like `C-S-n` works differently in Magit buffers.

For multi-section selections I think we should stick to that. Such a selection always contains at least two sections. Or we might want to start with a region that isn't a valid selection and therefore is visualized as such.

For hunk-internal regions I think we should change the behavior, so that it does something different and thereby looks like it does *not* do something different ;-) Here the first `C-S-n` should just set the mark but *not* move to the next line.

The current implementation on this branch just always does forgo the movement of the first `C-S-n`.