### PR TITLE
Autoload ido-enter-magit-status

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -95,6 +95,7 @@ blame to center around the line point is on."
 
 ;;; Emacs Tools
 
+;;;###autoload
 (defun ido-enter-magit-status ()
   "Drop into `magit-status' from file switching.
 


### PR DESCRIPTION
Do you mind to make `ido-enter-magit-status` available right away?
