### PR TITLE
magit-push-popup: add --follow-tags switch

### DIFF
--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -424,6 +424,7 @@ removed after restarting Emacs."
               (?F "Force"            "--force")
               (?h "Disable hooks"    "--no-verify")
               (?d "Dry run"          "--dry-run")
+              (?t "Follow tags"      "--follow-tags")
               ,@(and (not magit-push-current-set-remote-if-missing)
                      '((?u "Set upstream"  "--set-upstream"))))
   :actions '("Configure"


### PR DESCRIPTION
`--follow-tags` has been in git since 1.8.3 (https://github.com/git/git/commit/c2aba15), and seems like a useful option. No problem if it doesn't make sense to add it here, but I thought it would be nice.

The `?t` switch seems mnemonic to me, but I'm open to it being anything.

I didn't add any release notes because I'm guessing this wouldn't go out in the next patch release (2.10.1).

Any feedback is welcome!