### PR TITLE
magit-split-range: fix handling of "..@{upstream}"

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1298,7 +1298,7 @@ Return a list of two integers: (A>B B>A)."
   (when (string-match magit-range-re range)
     (let ((beg (or (match-string 1 range) "HEAD"))
           (end (or (match-string 3 range) "HEAD")))
-      (cons (if (string-equal (match-string 2) "...")
+      (cons (if (string-equal (match-string 2 range) "...")
                 (magit-git-string "merge-base" beg end)
               beg)
             end))))


### PR DESCRIPTION
Hi!

This solves a bug I have with `magit-ediff-dwim` in a diff buffer generated from the "Unpulled from" section of the status buffer. To reproduce:

```bash
git init origin; cd origin
echo "hello" > README; git add README; git commit -m "Add README"

git clone . ../local

echo "Hello world!" > README; git add README; git commit -m "Fix README"

cd ../local
git fetch
emacs
```

In Emacs:

- <kbd>M-x</kbd> magit-status
- On "Unpulled from origin/master (1)": <kbd>d d</kbd>
- On "modified  README": <kbd>e</kbd>

`magit-ediff-dwim` fails, saying `magit-split-range: Args out of range: #<buffer *magit-diff: local>, 0, 2`.

The problem seems to be that `(magit-split-range "..@{upstream}")` fails:

    Debugger entered--Lisp error: (args-out-of-range #<buffer *scratch*> 0 2)
      match-string(2)
      (string-equal (match-string 2) "...")
      (if (string-equal (match-string 2) "...") (magit-git-string "merge-base" beg end) beg)
      (cons (if (string-equal (match-string 2) "...") (magit-git-string "merge-base" beg end) beg) end)
      (let ((beg (or (match-string 1 range) "HEAD")) (end (or (match-string 3 range) "HEAD"))) (cons (if (string-equal (match-string 2) "...") (magit-git-string "merge-base" beg end) beg) end))
      (progn (let ((beg (or (match-string 1 range) "HEAD")) (end (or (match-string 3 range) "HEAD"))) (cons (if (string-equal (match-string 2) "...") (magit-git-string "merge-base" beg end) beg) end)))
      (if (string-match magit-range-re range) (progn (let ((beg (or (match-string 1 range) "HEAD")) (end (or (match-string 3 range) "HEAD"))) (cons (if (string-equal (match-string 2) "...") (magit-git-string "merge-base" beg end) beg) end))))
      magit-split-range("..@{upstream}")
      eval((magit-split-range "..@{upstream}") nil)
      elisp--eval-last-sexp(nil)
      eval-last-sexp(nil)
      funcall-interactively(eval-last-sexp nil)
      call-interactively(eval-last-sexp nil nil)
      command-execute(eval-last-sexp)

With this patch `(magit-split-range "..@{upstream}")` now returns `("HEAD" . "@{upstream}")`.
