### PR TITLE
Fix git-commit to honor 'enable-local-variables'

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -407,7 +407,7 @@ already using it, then you probably shouldn't start doing so."
                                                (regexp-quote buffer-file-name)
                                                "\\'")
                                        git-commit-major-mode))))
-      (normal-mode)))
+      (normal-mode t)))
   (setq with-editor-show-usage nil)
   (with-editor-mode 1)
   (add-hook 'with-editor-finish-query-functions


### PR DESCRIPTION
Hello, I hope the commit message is clear what I mean: I work on a
project that has `.dir-locals.el` file with unsafe variables, so every
time I make a commit, I get a standard message about local variables
that "may not be safe", etc.

This happens because `normal-mode` sets `enable-local-variables` to `t`
when it is called without arguments.

I called `normal-mode` with `t` argument since any non-nil value suits,
although you can guess from the docstring that `find-file` should
probably be a string, so using `t` is like violating the documented
thing; is that OK?