### PR TITLE
While committing, diff from inside gitdir if necessary

### DIFF
--- a/Documentation/RelNotes/2.10.1.txt
+++ b/Documentation/RelNotes/2.10.1.txt
@@ -8,6 +8,12 @@ Fixes since v2.10.0
   when asked to confirm the deletion of these stashes resulted in a
   type error.  #2917
 
+* When committing inside a repository that was created using `git
+  init --separate-git-dir', the diff buffer was empty, instead of
+  showing the changes about to be committed.  For some reason that
+  git command, unlike other commands that do essentially the same
+  thing, does not set `core.worktree', which confused Magit.  #2955
+
 * In the repository list buffer, the columns that are supposed to list
   unpushed and unpulled commit counts, were blank.  #2960
 

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -331,6 +331,7 @@ depending on the value of option `magit-commit-squash-confirm'."
     (condition-case nil
         (let ((magit-inhibit-save-previous-winconf 'unset)
               (magit-display-buffer-noselect t)
+              (magit-toplevel--force-fallback-to-gitdir t)
               (inhibit-quit nil))
           (message "Diffing changes to be committed (C-g to abort diffing)")
           (funcall fn (car (magit-diff-arguments))))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -395,6 +395,8 @@ absolute path is returned."
         (setq it (file-name-as-directory (magit-expand-git-file-name it)))
         (if path (expand-file-name (convert-standard-filename path) it) it)))))
 
+(defvar magit-toplevel--force-fallback-to-gitdir nil)
+
 (defun magit-toplevel (&optional directory)
   "Return the absolute path to the toplevel of the current repository.
 
@@ -459,14 +461,22 @@ returning the truename."
             (let* ((link (expand-file-name "gitdir" gitdir))
                    (wtree (and (file-exists-p link)
                                (magit-file-line link))))
-              (if (and wtree
-                       ;; Ignore .git/gitdir files that result from a
-                       ;; Git bug.  See #2364.
-                       (not (equal wtree ".git")))
-                  ;; Return the linked working tree.
-                  (file-name-directory wtree)
+              (cond
+               ((and wtree
+                     ;; Ignore .git/gitdir files that result from a
+                     ;; Git bug.  See #2364.
+                     (not (equal wtree ".git")))
+                ;; Return the linked working tree.
+                (file-name-directory wtree))
+               (magit-toplevel--force-fallback-to-gitdir
+                ;; `git init --separate-git-dir' doesn't set `core.worktree'.
+                ;; Commands that have to work under such conditions and that
+                ;; also do work properly when run in the gitdir, should bind
+                ;; this variable.  See #2955.
+                gitdir)
+               (t
                 ;; Step outside the control directory to enter the working tree.
-                (file-name-directory (directory-file-name gitdir))))))))))
+                (file-name-directory (directory-file-name gitdir)))))))))))
 
 (defmacro magit-with-toplevel (&rest body)
   (declare (indent defun) (debug (body)))


### PR DESCRIPTION
```
If a repository is created using `git init --separate-git-dir', then
that does not set `core.worktree' (unlike what `git submodule' does).

When committing inside such a repository `magit-commit-diff' is run
inside the gitdir, and there is no way to prevent that.  Luckily `git
diff' also works inside the gitdir, but because many other commands
don't, we always run everything in the working tree.

This is fairly deeply ingrained, so we have to add a kludge to
`magit-toplevel', that causes it to return the gitdir instead,
and that is triggered by dynamically binding the new variable
`magit-toplevel--force-fallback-to-gitdir' to a non-nil value.

And `magit-commit-diff' now does so to fix #2955.
```

Fixes #2955.