### PR TITLE
Fix magit-version if magit.el is a symlink

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -877,14 +877,16 @@ Git, and Emacs in the echo area."
         debug)
     (unless (and toplib
                  (equal (file-name-nondirectory toplib) "magit.el"))
-      (setq toplib (locate-library "magit.el")))
+      (setq toplib (locate-library "magit.el"))
+      (setq toplib (and toplib (file-chase-links toplib))))
     (push toplib debug)
     (when toplib
       (let* ((topdir (file-name-directory toplib))
              (gitdir (expand-file-name
                       ".git" (file-name-directory
                               (directory-file-name topdir))))
-             (static (locate-library "magit-version.el" nil (list topdir))))
+             (static (locate-library "magit-version.el" nil (list topdir)))
+             (static (and static (file-chase-links static))))
         (or (progn
               (push 'repo debug)
               (when (and (file-exists-p gitdir)


### PR DESCRIPTION
I've written a package manager to replace `package.el`, and one of the
things it does differently is that instead of copying a package's
files to build it, it symlinks them. That is, the `build/magit` folder
is added to the `load-path`, and `build/magit/magit.el` is a symlink
to `repos/magit/lisp/magit.el`, where `repos/magit` is the Git repository
for `magit`.

Unfortunately, `magit-version` doesn't know how to work with
symlinks—that is, it expects the `.git` directory to live in
`build/magit`, when in fact it lives in `repos/magit`. Would there be
any unforeseen consequences to making `magit-version` resolve
symlinks?