### PR TITLE
Kill Ediff Registry buffer

### DIFF
--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -486,6 +486,7 @@ stash that were staged."
     (ediff-kill-buffer-carefully ediff-error-buffer)
     (ediff-kill-buffer-carefully ediff-msg-buffer)
     (ediff-kill-buffer-carefully ediff-debug-buffer)
+    (ediff-kill-buffer-carefully ediff-registry-buffer)
     (when (boundp 'ediff-patch-diagnostics)
       (ediff-kill-buffer-carefully ediff-patch-diagnostics))
     (cond ((and (ediff-window-display-p)


### PR DESCRIPTION
The [Ediff Registry](https://www.gnu.org/software/emacs/manual/html_node/ediff/Registry-of-Ediff-Sessions.html) buffer is the only remaining Ediff-related buffer that Magit does not clean up.