### PR TITLE
Record the working tree for separated git directories

### DIFF
--- a/Documentation/RelNotes/2.10.2.txt
+++ b/Documentation/RelNotes/2.10.2.txt
@@ -12,3 +12,6 @@ Fixes since v2.10.1
 * magit-abbrev-length mishandled two edge cases, returning 0 when
   called within an empty repository or outside of a repository.
   077740f5
+
+* A bug fix in the last release broke the visit-file functionality in
+  diff buffers displayed while committing.  #2988

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -417,6 +417,7 @@ current when this function was called (if it is a Magit buffer
 and still alive), as well as the respective Magit status buffer.
 
 See `magit-start-process' and `with-editor' for more information."
+  (magit--record-separated-gitdir)
   (magit-with-editor (magit-run-git-async args)))
 
 (defun magit-run-git-sequencer (&rest args)


### PR DESCRIPTION
I'm not sure if this is the direction we should go, but it's the best
I've come up with so far.  If we do want to go with someting along
these lines, I should think more carefully about the last paragraph of
the commit message.

#2955

-----------------

```
magit-toplevel needs to determine the working tree from inside .git/
when a buffer is visiting COMMIT_EDITMSG or various other files.  To
do this, it uses the following logic:

 1) file is in .git/modules/<module>/: set working tree to the output
    of "git rev-parse --show-toplevel"

 2) file is in .git/worktrees/<wtree>/: set working tree to the path
    in .git/worktrees/<wtree>/gitdir, minus the trailing "/.git"

 3) file is in .git: set working tree to the parent directory

This, however, fails when a repository was set up by passing
--separate-git-dir to "git init" or "git clone".  (It follows step 3,
returning an unrelated parent directory.)  In Git version 2.8.4 and
lower, core.worktree was set when --separate-git-dir was used, so "git
rev-parse --show-toplevel" (step 1) would also work for separated git
directories.  However, it turns out that Git was not intentionally
setting core.worktree here intentional [*].

The most visible consequence of magit-toplevel failing to return the
working tree for separated gitdirs was that an empty diff buffer was
displayed while committing (issue #2955).  9e0e2a24 (While committing,
diff from inside gitdir if necessary, 2017-01-17) worked around this
by introducing a defvar that could be let-bound to instruct
magit-toplevel to return the gitdir instead.  This resulted in the
diff buffer correctly showing staged changes because "git diff
--cached" works fine from the gitdir, but it broke
magit-diff-visit-file in these buffers (issue #2981) because the
default directory was the git directory rather than the top-level of
the working tree.  This approach also didn't consider other cases
where magit-toplevel would fail inside a separated gitdir, such as
running git-rebase-show-commit in a git-rebase-todo buffer.

Instead, let's record the worktree -> gitdir mapping of separated
repositories before the git call in magit-run-git-with-editor.  When
magit-toplevel is called from a gitdir file (COMMIT_EDITMSG,
MERGE_MSG, git-rebase-todo, ...), it can look for a working tree
associated with the current git directory.  If one isn't found, it can
take the parent directory as the working tree, as usual.  This comes
at a price of a magit-toplevel and magit-git-dir call during editing
commands, but it seems unlikely that any solution could avoid these
calls.

This should cover all cases where Magit throws users into a buffer
inside the git directory.  If this is true, it should be unlikely that
magit-toplevel uses an invalid mapping.  A user would have to call a
command that involves magit-run-git-with-editor and then, before
finishing that process, go to another working tree that points to the
same git directory and again call a command that involves
magit-run-git-with-editor.  And the user would have had to set up
these working trees outside of the "git worktree" mechanism because
magit-toplevel handles "git worktree" directories fine.

Fixes #2955.
Re: #2981.

[*] https://public-inbox.org/git/87h94d8cwi.fsf@kyleam.com/T/#u
```
