### PR TITLE
Add new function `git-rebase-noop` to add a noop action at point

### DIFF
--- a/Documentation/RelNotes/2.10.2.txt
+++ b/Documentation/RelNotes/2.10.2.txt
@@ -1,6 +1,13 @@
 Magit v2.10.2 Release Notes (unreleased)
 ========================================
 
+Changes since v2.10.1
+---------------------
+
+* The new command `git-rebase-noop' adds a noop action during a
+  rebase.  It can be used to make git perform a rebase even if none
+  of the commits are selected.  #2991
+
 Fixes since v2.10.1
 -------------------
 


### PR DESCRIPTION
If you do a rebase and drop all the commits in the file, git will do nothing, because the file is considered empty (everything is commented). If you really do want to remove all the commits, you have to insert a `noop` action which prevents the file from being empty. It has no other purpose.

This commit lets the user add such a `noop` action. Currently, you have to switch to a different mode (e.g. text-mode), disable the read only mode, add `noop` manually and switch back.