### PR TITLE
Add `&' on a file to open it with dired-do-async-shell-command

### DIFF
--- a/Documentation/RelNotes/2.10.3.txt
+++ b/Documentation/RelNotes/2.10.3.txt
@@ -4,5 +4,9 @@ Magit v2.10.3 Release Notes (unreleased)
 Changes since v2.10.2
 ---------------------
 
+* The new command `magit-do-async-shell-command' opens file at point
+  with `dired-do-async-shell-command'.  "&" is now bound to this
+  command.  #2992
+
 Fixes since v2.10.2
 -------------------

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1432,6 +1432,7 @@ is set in `magit-mode-setup'."
     (define-key map "C" 'magit-commit-add-log)
     (define-key map "s" 'magit-stage)
     (define-key map "u" 'magit-unstage)
+    (define-key map "&" 'magit-do-async-shell-command)
     map)
   "Keymap for `file' sections.")
 

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -130,6 +130,17 @@ is no file at point then instead visit `default-directory'."
                                         file))
                              (concat default-directory "/."))))
 
+;;;###autoload
+(defun magit-do-async-shell-command (file)
+  "Open FILE with `dired-do-async-shell-command'.
+Interactively, open the file at point."
+  (interactive (list (or (magit-file-at-point)
+                         (completing-read "Act on file: "
+                                          (magit-list-files)))))
+  (dired-do-async-shell-command
+   (dired-read-shell-command "& on %s: " current-prefix-arg (list file))
+   nil (list file)))
+
 ;;; Clean
 
 ;;;###autoload


### PR DESCRIPTION
Emacs is not good at opening every possible kind of file. For those rare cases, it's always good to be able to launch an external command.