### PR TITLE
Doc fix: magit-diff whitespace highlighting variable names

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2359,9 +2359,10 @@ without having to using one of the diff popups.
 
   Specify where to highlight whitespace errors.
 
-  See ~magit-highlight-trailing-whitespace~,
-  ~magit-highlight-indentation~.  The symbol ~t~ means in all diffs,
-  ~status~ means only in the status buffer, and nil means nowhere.
+  See ~magit-diff-highlight-trailing~,
+  ~magit-diff-highlight-indentation~.  The symbol ~t~ means in all
+  diffs, ~status~ means only in the status buffer, and nil means
+  nowhere.
 
 - User Option: magit-diff-highlight-trailing
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -3259,9 +3259,10 @@ Whether to show word-granularity differences within diff hunks.
 
 Specify where to highlight whitespace errors.
 
-See @code{magit-highlight-trailing-whitespace},
-@code{magit-highlight-indentation}.  The symbol @code{t} means in all diffs,
-@code{status} means only in the status buffer, and nil means nowhere.
+See @code{magit-diff-highlight-trailing},
+@code{magit-diff-highlight-indentation}.  The symbol @code{t} means in all
+diffs, @code{status} means only in the status buffer, and nil means
+nowhere.
 @end defopt
 
 @defopt magit-diff-highlight-trailing

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -169,9 +169,10 @@ t      show fine differences for the current diff hunk only.
 
 (defcustom magit-diff-paint-whitespace t
   "Specify where to highlight whitespace errors.
-See `magit-highlight-trailing-whitespace',
-`magit-highlight-indentation'.  The symbol t means in all diffs,
-`status' means only in the status buffer, and nil means nowhere."
+See `magit-diff-highlight-trailing',
+`magit-diff-highlight-indentation'.  The symbol t means in all
+diffs, `status' means only in the status buffer, and nil means
+nowhere."
   :group 'magit-diff
   :safe (lambda (val) (memq val '(t nil status)))
   :type '(choice (const :tag "Always" t)


### PR DESCRIPTION
Update documentation with new whitespace highlighting variable names introduced in ea668709.