### PR TITLE
Fix parsing of bisect script with args.

### DIFF
--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -129,7 +129,7 @@ bisect run'."
                  (cons (read-shell-command "Bisect shell command: ") args)))
   (when (and bad good)
     (magit-bisect-start bad good))
-  (magit-git-bisect "run" (list cmdline)))
+  (magit-git-bisect "run" (list shell-file-name shell-command-switch cmdline)))
 
 (defun magit-git-bisect (subcommand &optional args no-assert)
   (unless (or no-assert (magit-bisect-in-progress-p))

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -126,7 +126,12 @@ begun.  In that case it behaves like `git bisect start; git
 bisect run'."
   (interactive (let ((args (and (not (magit-bisect-in-progress-p))
                                 (magit-bisect-start-read-args))))
-                 (cons (read-shell-command "Bisect shell command: ") args)))
+                 (lexical-let* ((raw-cmdline (read-shell-command "Bisect shell command: "))
+                                (parsed-cmdline (with-temp-buffer
+                                                  (insert raw-cmdline)
+                                                  (mapcar 'eval (eshell-parse-arguments (point-min)
+                                                                                        (point-max))))))
+                               (cons parsed-cmdline args))))
   (when (and bad good)
     (magit-bisect-start bad good))
   (magit-git-bisect "run" (list cmdline)))

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -126,12 +126,7 @@ begun.  In that case it behaves like `git bisect start; git
 bisect run'."
   (interactive (let ((args (and (not (magit-bisect-in-progress-p))
                                 (magit-bisect-start-read-args))))
-                 (lexical-let* ((raw-cmdline (read-shell-command "Bisect shell command: "))
-                                (parsed-cmdline (with-temp-buffer
-                                                  (insert raw-cmdline)
-                                                  (mapcar 'eval (eshell-parse-arguments (point-min)
-                                                                                        (point-max))))))
-                               (cons parsed-cmdline args))))
+                 (cons (read-shell-command "Bisect shell command: ") args)))
   (when (and bad good)
     (magit-bisect-start bad good))
   (magit-git-bisect "run" (list cmdline)))


### PR DESCRIPTION
I'm a Clojure programmer and not familiar with elisp, so this fix is cobbled together by copious amounts of Google and borrowing from the existing `magit-git-command`. I expect there's a better way to implement this patch.

When running a script with bisect, I've found it doesn't parse the arguments. I've demonstrated this with a shell script "ls -l":

    #!/bin/bash
    
    echo "This isn't 'ls' with the '-l' option. Its a shell script *named* 'ls -l'."
    exit 1

and with a quick bisect:

    Head:     2230857 Reset Package-Requires for Melpa
    Tag:      2.10.2 (1)
    
    2230857f69d5a919579fdc7cf8222fdb64621949 is the first bad commit
    running ls -l
    This isn't 'ls' with the '-l' option. Its a shell script *named* 'ls -l'.
    2230857f69d5a919579fdc7cf8222fdb64621949 is the first bad commit
    commit 2230857f69d5a919579fdc7cf8222fdb64621949
    Author: Jonas Bernoulli <jonas@bernoul.li>
    Date:   Tue Feb 14 12:47:53 2017 +0100
        Reset Package-Requires for Melpa
    :040000 040000 11c1e4d64ecb29040270110e21ea1c6818022700 4134365de16ea9508252c49700854f381b76895e M	lisp
    bisect run success
    
    Bisect Rest (1)
    2230857 * @ bad Reset Package-Requires for Melpa
    
    Bisect Log (3)
    git bisect start 'master' 'master~~'
    b9078ee bad Add v2.10.3 release notes stub
    ade30b0 good Release version 2.10.2
    
    git bisect bad 2230857f69d5a919579fdc7cf8222fdb64621949
    2230857 bad Reset Package-Requires for Melpa
    
    2230857f69d5a919579fdc7cf8222fdb64621949 is the first bad commit
    
    Untracked files (7)
    lisp/AUTHORS.md
    lisp/COPYING
    lisp/dir
    lisp/magit-pkg.el
    lisp/magit.info
    lisp/magit.info-1
    lisp/magit.info-2

but when on this branch:    

    Head:     2230857 Reset Package-Requires for Melpa
    Tag:      2.10.2 (1)
    
    b9078ee215822abe19c2f4cacb12b3e11ee413cc is the first bad commit
    running ls -l
    total 136
    -rw-r--r--   1 matt  staff    600 Feb 23 22:21 CONTRIBUTING.md
    -rw-r--r--   1 matt  staff  35068 Feb 23 22:36 COPYING
    drwxr-xr-x   9 matt  staff    306 Feb 23 22:21 Documentation
    -rw-r--r--   1 matt  staff   2465 Feb 23 22:21 ISSUE_TEMPLATE
    -rw-r--r--   1 matt  staff   7424 Feb 23 22:21 Makefile
    -rw-r--r--   1 matt  staff   4856 Feb 23 22:21 README.md
    -rw-r--r--   1 matt  staff   4417 Feb 23 23:10 default.mk
    drwxr-xr-x  46 matt  staff   1564 Feb 23 23:28 lisp
    drwxr-xr-x   3 matt  staff    102 Feb 23 22:21 t
    b9078ee215822abe19c2f4cacb12b3e11ee413cc is the first bad commit
    commit b9078ee215822abe19c2f4cacb12b3e11ee413cc
    Author: Jonas Bernoulli <jonas@bernoul.li>
    Date:   Tue Feb 14 12:48:49 2017 +0100
        Add v2.10.3 release notes stub
    :040000 040000 b0d438f8d495191e20f93c35ac8a4f83fc5fc270 df3b760e76dc60946873c421356fdb2fc517a027 M	Documentation
    bisect run success
    
    Bisect Rest (1)
    b9078ee * origin/master origin/HEAD master bad Add v2.10.3 release notes stub
    
    Bisect Log (3)
    git bisect start 'master' 'master~~'
    b9078ee bad Add v2.10.3 release notes stub
    ade30b0 good Release version 2.10.2
    
    git bisect good 2230857f69d5a919579fdc7cf8222fdb64621949
    2230857 good Reset Package-Requires for Melpa
    
    b9078ee215822abe19c2f4cacb12b3e11ee413cc is the first bad commit
    
    Untracked files (7)
    lisp/AUTHORS.md
    lisp/COPYING
    lisp/dir
    lisp/magit-pkg.el
    lisp/magit.info
    lisp/magit.info-1
    lisp/magit.info-2
    