### PR TITLE
Cmd line completion (#3004)

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -600,9 +600,10 @@ Run Git in the top-level directory of the current repository.
 With a prefix argument run the command in the root of the current
 repository, otherwise in `default-directory'."
   (interactive (magit-read-shell-command "Shell command (pwd: %s)"))
-  (setq args (split-string args))
   (let ((default-directory directory))
-    (apply #'magit-start-process (car args) nil (cdr args)))
+    (start-file-process-shell-command
+     "magit-shell-command"
+     (magit-process-buffer 'nodisplay) args))
   (magit-process-buffer))
 
 ;;;###autoload

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -627,9 +627,13 @@ Run the command in the top-level directory of the current repository.
                  (or (magit-toplevel)
                      (user-error "Not inside a Git repository"))
                default-directory)))
-    (list (magit-read-string (format prompt (abbreviate-file-name dir))
-                             nil 'magit-git-command-history)
-          dir)))
+    (list
+     (replace-regexp-in-string
+      "\\`git " ""
+      (read-shell-command
+       (format (concat prompt ": ") (abbreviate-file-name dir))
+       "git " 'magit-git-command-history))
+     dir)))
 
 ;;; Revision Stack
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -600,10 +600,9 @@ Run Git in the top-level directory of the current repository.
 With a prefix argument run the command in the root of the current
 repository, otherwise in `default-directory'."
   (interactive (magit-read-shell-command "Shell command (pwd: %s)"))
+  (setq args (split-string args))
   (let ((default-directory directory))
-    (start-file-process-shell-command
-     "magit-shell-command"
-     (magit-process-buffer 'nodisplay) args))
+    (apply #'magit-start-process (car args) nil (cdr args)))
   (magit-process-buffer))
 
 ;;;###autoload

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -577,13 +577,13 @@ defaulting to the tag at point.
   "Execute a Git subcommand asynchronously, displaying the output.
 With a prefix argument run Git in the root of the current
 repository, otherwise in `default-directory'."
-  (interactive (magit-read-shell-command "Git subcommand (pwd: %s)"))
+  (interactive (magit-read-shell-command "Git subcommand (pwd: %s)" nil "git "))
   (let ((magit-git-global-arguments
          ;; A human will want globbing by default.
          (remove "--literal-pathspecs"
                  magit-git-global-arguments))
         (default-directory directory))
-    (magit-run-git-async (split-string args)))
+    (magit-run-git-async (cdr (split-string args))))
   (magit-process-buffer))
 
 ;;;###autoload
@@ -591,7 +591,7 @@ repository, otherwise in `default-directory'."
   "Execute a Git subcommand asynchronously, displaying the output.
 Run Git in the top-level directory of the current repository.
 \n(fn)" ; arguments are for internal use
-  (interactive (magit-read-shell-command "Git subcommand (pwd: %s)" t))
+  (interactive (magit-read-shell-command "Git subcommand (pwd: %s)" t "git "))
   (magit-git-command args directory))
 
 ;;;###autoload
@@ -613,17 +613,15 @@ Run the command in the top-level directory of the current repository.
   (interactive (magit-read-shell-command "Shell command (pwd: %s)" t))
   (magit-shell-command args directory))
 
-(defun magit-read-shell-command (prompt &optional root)
+(defun magit-read-shell-command (prompt &optional root initial-input)
   (let ((dir (if (or root current-prefix-arg)
                  (or (magit-toplevel)
                      (user-error "Not inside a Git repository"))
                default-directory)))
     (list
-     (replace-regexp-in-string
-      "\\`git " ""
-      (read-shell-command
+     (read-shell-command
        (format (concat prompt ": ") (abbreviate-file-name dir))
-       "git " 'magit-git-command-history))
+       initial-input 'magit-git-command-history)
      dir)))
 
 ;;; Revision Stack

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -578,17 +578,12 @@ defaulting to the tag at point.
 With a prefix argument run Git in the root of the current
 repository, otherwise in `default-directory'."
   (interactive (magit-read-shell-command "Git subcommand (pwd: %s)"))
-  (require 'eshell)
-  (with-temp-buffer
-    (insert args)
-    (setq args (mapcar 'eval (eshell-parse-arguments (point-min)
-                                                     (point-max))))
-    (setq default-directory directory)
-    (let ((magit-git-global-arguments
-           ;; A human will want globbing by default.
-           (remove "--literal-pathspecs"
-                   magit-git-global-arguments)))
-     (magit-run-git-async args)))
+  (let ((magit-git-global-arguments
+         ;; A human will want globbing by default.
+         (remove "--literal-pathspecs"
+                 magit-git-global-arguments))
+        (default-directory directory))
+    (magit-run-git-async (split-string args)))
   (magit-process-buffer))
 
 ;;;###autoload
@@ -605,12 +600,8 @@ Run Git in the top-level directory of the current repository.
 With a prefix argument run the command in the root of the current
 repository, otherwise in `default-directory'."
   (interactive (magit-read-shell-command "Shell command (pwd: %s)"))
-  (require 'eshell)
-  (with-temp-buffer
-    (insert args)
-    (setq args (mapcar 'eval (eshell-parse-arguments (point-min)
-                                                     (point-max))))
-    (setq default-directory directory)
+  (setq args (split-string args))
+  (let ((default-directory directory))
     (apply #'magit-start-process (car args) nil (cdr args)))
   (magit-process-buffer))
 


### PR DESCRIPTION
#3004

Now only the git commands (`magit-git-command` and `magit-git-command-topdir`) use "git " as initial input.
The usage of `eshell-parse-arguments` have been removed.
Completion works with both bash-completion and pcml-git.
This is a first shot where we can discuss around.
Some thoughts:
I have no problems entering manually "git" at prompt, after all it is only three characters + the space, as I said I found myself often entering "git" when using `magit-git-command` and failing.
I have no problems also using `C-u` for `magit-shell-command` and `magit-git-command` so perhaps the topdir commands could be removed.
Git help shell commands are not working, perhaps they could be handled specially for emacs, calling man or info with emacs functions ?