### PR TITLE
Use start-file-process-shell-command in magit-start-process.

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -490,9 +490,9 @@ Magit status buffer."
                  (process-environment (append (magit-cygwin-env-vars)
                                               process-environment))
                  (default-process-coding-system (magit--process-coding-system)))
-             (apply #'start-file-process
-                    (file-name-nondirectory program)
-                    process-buf program args))))
+             (start-file-process-shell-command
+              (file-name-nondirectory program)
+              process-buf (mapconcat 'identity (cons program args) " ")))))
     (with-editor-set-process-filter process #'magit-process-filter)
     (set-process-sentinel process #'magit-process-sentinel)
     (set-process-buffer   process process-buf)


### PR DESCRIPTION
* lisp/magit-process.el (magit-start-process): Do it.

Redirections, pipes and generally complex commands are not supported in `magit-shell-command` because `magit-start-process` use `(apply #'start-process args)` which assume that `(car args)` is a command where the rest of args are applied, for example the cmd line "echo foo > test.txt" will never redirect "foo" to the file test.txt but instead echo "foo > test.txt" as a string.
This PR is using `start-file-process-shell-command` which fix it.

