### PR TITLE
magit-remote-add-set-remote.pushDefault: doc correction

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -4600,10 +4600,9 @@ Also see [[man:git-remote]]
   remote.
 
   If ~ask~, then always ask.  If ~ask-if-unset~, then ask, but only if the
-  variable isn't set already.  If ~nil~, then don't ever set.  If the
-  value is a string, then set without asking, provided the name of the
-  name of the added remote is equal to that string and the variable
-  isn't already set.
+  variable isn't set already.  If ~nil~, then don't ever set.  If the value
+  is a string, then set without asking, provided that the name of the added
+  remote is equal to that string and the variable isn't already set.
 
 ** Fetching
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -6336,10 +6336,9 @@ Whether to set the value of @code{remote.pushDefault} after adding a
 remote.
 
 If @code{ask}, then always ask.  If @code{ask-if-unset}, then ask, but only if the
-variable isn't set already.  If @code{nil}, then don't ever set.  If the
-value is a string, then set without asking, provided the name of the
-name of the added remote is equal to that string and the variable
-isn't already set.
+variable isn't set already.  If @code{nil}, then don't ever set.  If the value
+is a string, then set without asking, provided that the name of the added
+remote is equal to that string and the variable isn't already set.
 @end defopt
 
 @node Fetching

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -90,9 +90,9 @@ Then show the status buffer for the new repository."
 
 If `ask', then always ask.  If `ask-if-unset', then ask, but only
 if the variable isn't set already.  If nil, then don't ever set.
-If the value is a string, then set without asking, provided the
-name of the name of the added remote is equal to that string and
-the variable isn't already set."
+If the value is a string, then set without asking, provided that
+the name of the added remote is equal to that string and the
+variable isn't already set."
   :package-version '(magit . "2.4.0")
   :group 'magit-commands
   :type '(choice (const  :tag "ask if unset" ask-if-unset)


### PR DESCRIPTION
Added "that" between "provided" and "the name of".
Removed the duplicate words "the name of".

The corrections were made in the
magit-remote-add-set-remote.pushDefault
variables docstring and in it's magit.org documentation.