### PR TITLE
git-commit-setup: improve check before inserting newline

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -426,8 +426,7 @@ already using it, then you probably shouldn't start doing so."
     (setq save-place nil))
   (save-excursion
     (goto-char (point-min))
-    (when (= (line-beginning-position)
-             (line-end-position))
+    (when (looking-at "\\`\\(\\'\\|\n[^\n]\\)")
       (open-line 1)))
   (run-hooks 'git-commit-setup-hook)
   (set-buffer-modified-p nil))


### PR DESCRIPTION
git-commit-setup always inserts a hardcoded newline after the
beginning of a new commit message and this is very annoying when
committing with --signoff because you get by default 3 empty lines
before the "Signed-off-by:" and you have to manually remove that
hardcoded line to conform to general git log style.

This happens because `git commit` also inserts a newline (only if
--signoff is used) so in that case a redundant newline is created
(thanks tarsius for figuring this out!).

So improve the check before inserting the newline to not insert if
--signoff is used, but keep old behaviour when the flag is absent.

Signed-off-by: Ioan-Adrian Ratiu <adi@adirat.com>