### PR TITLE
Order of ref completions

### DIFF
--- a/Documentation/RelNotes/2.10.4.txt
+++ b/Documentation/RelNotes/2.10.4.txt
@@ -10,6 +10,9 @@ Changes since v2.10.3
   behavior is still to fetch after adding a remote (i.e., the switch
   is enabled by default).  #2997
 
+* Added option `magit-list-refs-sortby' to allow more control over the
+  order of refs in prompts.  #2872
+
 Fixes since v2.10.3
 -------------------
 

--- a/Documentation/RelNotes/2.10.4.txt
+++ b/Documentation/RelNotes/2.10.4.txt
@@ -13,6 +13,12 @@ Changes since v2.10.3
 * Added option `magit-list-refs-sortby' to allow more control over the
   order of refs in prompts.  #2872
 
+* The Magit wrappers around the default Emacs completion functions now
+  override the default behavior of alphabetically sorting choices when
+  displaying them in the "*Completions*" buffer.  In repositories with
+  many release tags, the new behavior prevents completion prompts from
+  being dominated by version tags instead of branch names.  #2925
+
 Fixes since v2.10.3
 -------------------
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1191,6 +1191,14 @@ More frameworks will be supported in the future.
   comes with a supposed drop-in replacement ~ido-completing-read~, but
   that has too many deficits to serve our needs.
 
+- User Option: magit-list-refs-sortby
+
+  For many commands that read a ref or refs from the user, the value
+  of this option can be used to control the order of the refs.  Valid
+  values include any key accepted by the ~--sort~ flag of ~git
+  for-each-ref~.  By default, refs are sorted alphabetically by their
+  full name (e.g., "refs/heads/master").
+
 By default many commands that could potentially lead to data loss have
 to be confirmed.  This includes many very common commands, so this
 can become annoying quickly.  Many of these actions can be undone,

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -1648,6 +1648,15 @@ comes with a supposed drop-in replacement @code{ido-completing-read}, but
 that has too many deficits to serve our needs.
 @end defun
 
+@defopt magit-list-refs-sortby
+
+For many commands that read a ref or refs from the user, the value
+of this option can be used to control the order of the refs.  Valid
+values include any key accepted by the @code{--sort} flag of @code{git
+  for-each-ref}.  By default, refs are sorted alphabetically by their
+full name (e.g., "refs/heads/master").
+@end defopt
+
 By default many commands that could potentially lead to data loss have
 to be confirmed.  This includes many very common commands, so this
 can become annoying quickly.  Many of these actions can be undone,

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1002,12 +1002,20 @@ where COMMITS is the number of commits in TAG but not in REV."
 (defvar magit-list-refs-namespaces
   '("refs/heads" "refs/remotes" "refs/tags" "refs/pull"))
 
-(defun magit-list-refs (&rest args)
-  (magit-git-lines "for-each-ref" "--format=%(refname)"
-                   (or args magit-list-refs-namespaces)))
+(defun magit-list-refs (&optional namespaces format)
+  "Return list of references.
+
+When NAMESPACES is non-nil, list refs from these namespaces
+rather than those from `magit-list-refs-namespaces'.
+
+FORMAT is passed to the `--format' flag of `git for-each-ref' and
+defaults to \"%(refname)\"."
+  (magit-git-lines "for-each-ref"
+                   (concat "--format=" (or format "%(refname)"))
+                   (or namespaces magit-list-refs-namespaces)))
 
 (defun magit-list-branches ()
-  (magit-list-refs "refs/heads" "refs/remotes"))
+  (magit-list-refs (list "refs/heads" "refs/remotes")))
 
 (defun magit-list-local-branches ()
   (magit-list-refs "refs/heads"))
@@ -1035,12 +1043,11 @@ where COMMITS is the number of commits in TAG but not in REV."
               (member it (magit-list-unmerged-branches upstream)))
             (magit-list-local-branch-names)))
 
-(defun magit-list-refnames (&rest args)
-  (magit-git-lines "for-each-ref" "--format=%(refname:short)"
-                   (or args magit-list-refs-namespaces)))
+(defun magit-list-refnames (&optional namespaces)
+  (magit-list-refs namespaces "%(refname:short)"))
 
 (defun magit-list-branch-names ()
-  (magit-list-refnames "refs/heads" "refs/remotes"))
+  (magit-list-refnames (list "refs/heads" "refs/remotes")))
 
 (defun magit-list-local-branch-names ()
   (magit-list-refnames "refs/heads"))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -43,8 +43,6 @@
 
 (defvar magit-tramp-process-environment nil)
 
-(require 'crm)
-
 ;;; Options
 
 ;; For now this is shared between `magit-process' and `magit-git'.
@@ -1394,21 +1392,10 @@ Return a list of two integers: (A>B B>A)."
        (magit-get-current-branch))))
 
 (defun magit-read-range (prompt &optional default)
-  (let* ((choose-completion-string-functions
-          '(crm--choose-completion-string))
-         (minibuffer-completion-table #'crm--collection-fn)
-         (minibuffer-completion-confirm t)
-         (crm-completion-table (magit-list-refnames))
-         (crm-separator "\\.\\.\\.?")
-         (input (read-from-minibuffer
-                 (concat prompt (and default (format " (%s)" default)) ": ")
-                 nil crm-local-completion-map
-                 nil 'magit-revision-history
-                 default)))
-    (when (string-equal input "")
-      (or (setq input default)
-          (user-error "Nothing selected")))
-    input))
+  (magit-completing-read-multiple prompt
+                                  (magit-list-refnames)
+                                  "\\.\\.\\.?"
+                                  default 'magit-revision-history))
 
 (defun magit-read-remote-branch
     (prompt &optional remote default local-branch require-match)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -559,27 +559,18 @@ buffer."
 
 (defun magit-log-read-revs (&optional use-current)
   (or (and use-current (--when-let (magit-get-current-branch) (list it)))
-      (let* ((choose-completion-string-functions
-              '(crm--choose-completion-string))
-             (minibuffer-completion-table #'crm--collection-fn)
-             (minibuffer-completion-confirm t)
-             (crm-completion-table
-              `(,@(and (file-exists-p (magit-git-dir "FETCH_HEAD"))
-                       (list "FETCH_HEAD"))
-                ,@(magit-list-refnames)))
-             (crm-separator "\\(\\.\\.\\.?\\|[, ]\\)")
-             (default (or (magit-branch-or-commit-at-point)
-                          (unless use-current
-                            (magit-get-previous-branch))))
-             (input (read-from-minibuffer
-                     (format "Log rev,s%s: "
-                             (if default (format " (%s)" default) ""))
-                     nil magit-log-read-revs-map
-                     nil 'magit-revision-history default)))
-        (when (string-equal input "")
-          (or (setq input default)
-              (user-error "Nothing selected")))
-        (split-string input "[, ]" t))))
+      (let ((collection `(,@(and (file-exists-p (magit-git-dir "FETCH_HEAD"))
+                                 (list "FETCH_HEAD"))
+                          ,@(magit-list-refnames))))
+        (split-string
+         (magit-completing-read-multiple "Log rev,s" collection
+                                         "\\(\\.\\.\\.?\\|[, ]\\)"
+                                         (or (magit-branch-or-commit-at-point)
+                                             (unless use-current
+                                               (magit-get-previous-branch)))
+                                         'magit-revision-history
+                                         magit-log-read-revs-map)
+         "[, ]" t))))
 
 ;;;###autoload
 (defun magit-log-current (revs &optional args files)

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -579,9 +579,10 @@ only available for the part before the colon, or when no colon
 is used."
   (interactive
    (list (magit-read-remote "Push to remote")
-         (completing-read-multiple
-          "Push refspec,s: "
-          (cons "HEAD" (magit-list-local-branch-names)))
+         (split-string (magit-completing-read-multiple
+                        "Push refspec,s"
+                        (cons "HEAD" (magit-list-local-branch-names)))
+                       crm-default-separator t)
          (magit-push-arguments)))
   (run-hooks 'magit-credential-hook)
   (magit-run-git-async "push" "-v" args remote refspecs))

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -344,6 +344,8 @@ results in additional differences."
                      predicate require-match
                      initial-input hist def)))
 
+(defvar helm-completion-in-region-default-sort-fn)
+
 (defun magit-completing-read-multiple
   (prompt choices &optional sep default hist keymap)
   "Read multiple items from CHOICES, separated by SEP.
@@ -364,6 +366,7 @@ into a list."
           '(crm--choose-completion-string))
          (minibuffer-completion-table #'crm--collection-fn)
          (minibuffer-completion-confirm t)
+         (helm-completion-in-region-default-sort-fn nil)
          (input
           (cl-letf (((symbol-function 'completion-pcm--all-completions)
                      #'magit-completion-pcm--all-completions))

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -328,11 +328,18 @@ results in additional differences."
           nil)
       reply)))
 
+(defun magit--completion-table (collection)
+  (lambda (string pred action)
+    (if (eq action 'metadata)
+        '(metadata (display-sort-function . identity))
+      (complete-with-action action collection string pred))))
+
 (defun magit-builtin-completing-read
   (prompt choices &optional predicate require-match initial-input hist def)
   "Magit wrapper for standard `completing-read' function."
   (completing-read (magit-prompt-with-default prompt def)
-                   choices predicate require-match
+                   (magit--completion-table choices)
+                   predicate require-match
                    initial-input hist def))
 
 (defun magit-completing-read-multiple
@@ -350,7 +357,7 @@ When KEYMAP is nil, it defaults to `crm-local-completion-map'.
 Unlike `completing-read-multiple', the return value is not split
 into a list."
   (let* ((crm-separator (or sep crm-default-separator))
-         (crm-completion-table choices)
+         (crm-completion-table (magit--completion-table choices))
          (choose-completion-string-functions
           '(crm--choose-completion-string))
          (minibuffer-completion-table #'crm--collection-fn)


### PR DESCRIPTION
This PR makes the following changes:

  * Allow the sorting key of `magit-list-refs` and friends to be
    customized.

  * Prevent the default Emacs completion from alphabetically sorting
    the collection items before displaying them to the user.  There's
    still a remaining issue with the `crm` completion functions and
    global `helm-mode` or global `ivy-mode` that this PR doesn't
    address.

Please see the commit messages.

Re: #2872, #2925
