### PR TITLE
Fix magit-version if magit.el is a symlink, part ii

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -877,8 +877,8 @@ Git, and Emacs in the echo area."
         debug)
     (unless (and toplib
                  (equal (file-name-nondirectory toplib) "magit.el"))
-      (setq toplib (locate-library "magit.el"))
-      (setq toplib (and toplib (file-chase-links toplib))))
+      (setq toplib (locate-library "magit.el")))
+    (setq toplib (and toplib (file-chase-links toplib)))
     (push toplib debug)
     (when toplib
       (let* ((topdir (file-name-directory toplib))


### PR DESCRIPTION
I didn't quite catch all the possible cases in the control flow when I submitted #2967, so I recently ran into another problem with symlinks. This pull request makes it so that symlinks are *definitely* resolved properly by `magit-version`.