### PR TITLE
Improvements to magit-version

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1343,11 +1343,13 @@ the actual git binary, which are also placed on ~$PATH~, and using one
 of these wrappers instead of the binary would degrade performance
 horribly.
 
-If Magit doesn't find the correct executable then you *can* work around
-that by setting ~magit-git-executable~ to an absolute path.  But note
-that doing so is a kludge.  It is better to make sure the order in the
-environment variable ~$PATH~ is correct, and that Emacs is started with
-that environment in effect.  If you have to connect from Windows to a
+If Magit doesn't find the correct executable then you *can* work
+around that by setting ~magit-git-executable~ to an absolute path.
+But note that doing so is a kludge.  It is better to make sure the
+order in the environment variable ~$PATH~ is correct, and that Emacs
+is started with that environment in effect.  The command
+~magit-debug-git-executable~ can be useful to find out where Emacs is
+searching for git.  If you have to connect from Windows to a
 non-Windows machine, then you must change the value to "git".
 
 - User Option: magit-git-executable
@@ -1355,6 +1357,10 @@ non-Windows machine, then you must change the value to "git".
   The git executable used by Magit, either the full path to the
   executable or the string "git" to let Emacs find the executable
   itself, using the standard mechanism for doing such things.
+
+- Key: M-x magit-debug-git-executable, magit-debug-git-executable
+
+  Display a buffer with information about ~magit-git-executable~.
 
 *** Global Git Arguments
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -312,9 +312,12 @@ add a section in the respective process buffer."
                       (setq msg (with-temp-buffer
                                   (insert-file-contents log)
                                   (goto-char (point-max))
-                                  (and (re-search-backward
-                                        magit-process-error-message-re nil t)
-                                       (match-string 1))))
+                                  (cond
+                                   ((functionp magit-git-debug)
+                                    (funcall magit-git-debug (buffer-string)))
+                                   ((re-search-backward
+                                     magit-process-error-message-re nil t)
+                                    (match-string 1)))))
                       (let ((magit-git-debug nil))
                         (with-current-buffer (magit-process-buffer t)
                           (magit-process-insert-section default-directory

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -958,6 +958,38 @@ and Emacs to it."
         (message "Cannot determine Magit's version %S" debug)))
     magit-version))
 
+(defun magit-debug-git-executable ()
+  "Display a buffer with information about `magit-git-executable'."
+  (interactive)
+  (with-current-buffer (get-buffer-create "*magit-git-debug*")
+    (pop-to-buffer (current-buffer))
+    (erase-buffer)
+    (insert (format "magit-git-executable: %S" magit-git-executable)
+            (unless (file-name-absolute-p magit-git-executable)
+              (format " [%S]" (executable-find magit-git-executable)))
+            (format " (%s)\n"
+                    (let* ((errmsg nil)
+                           (magit-git-debug (lambda (err) (setq errmsg err))))
+                      (or (magit-git-version t) errmsg))))
+    (insert (format "exec-path: %S\n" exec-path))
+    (--when-let (cl-set-difference
+                 (-filter #'file-exists-p (remq nil (parse-colon-path
+                                                     (getenv "PATH"))))
+                 (-filter #'file-exists-p (remq nil exec-path))
+                 :test #'file-equal-p)
+      (insert (format "  entries in PATH, but not in exec-path: %S\n" it)))
+    (dolist (execdir exec-path)
+      (insert (format "  %s (%s)\n" execdir (car (file-attributes execdir))))
+      (when (file-directory-p execdir)
+        (dolist (exec (directory-files
+                       execdir t (concat
+                                  "\\`git" (regexp-opt exec-suffixes) "\\'")))
+          (insert (format "    %s (%s)\n" exec
+                          (let* ((magit-git-executable exec)
+                                 (errmsg nil)
+                                 (magit-git-debug (lambda (err) (setq errmsg err))))
+                            (or (magit-git-version t) errmsg)))))))))
+
 ;;; (Asserts)
 
 (defun magit-startup-asserts ()

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -940,7 +940,12 @@ and Emacs to it."
         (when print-dest
           (princ (format "Magit %s, Git %s, Emacs %s, %s"
                          (or magit-version "(unknown)")
-                         (or (magit-git-version t) "(unknown)")
+                         (or (let ((magit-git-debug
+                                    (lambda (err)
+                                      (display-warning '(magit git)
+                                                       err :error))))
+                               (magit-git-version t))
+                             "(unknown)")
                          emacs-version
                          system-type)
                  print-dest))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -878,11 +878,13 @@ above."
 Use the function by the same name instead of this variable.")
 
 ;;;###autoload
-(defun magit-version ()
+(defun magit-version (&optional print-dest)
   "Return the version of Magit currently in use.
-When called interactive also show the used versions of Magit,
-Git, and Emacs in the echo area."
-  (interactive)
+If optional argument PRINT-DEST is non-nil output
+stream (interactively, the echo area, or the current buffer with
+a prefix argument), also print the used versions of Magit, Git,
+and Emacs to it."
+  (interactive (list (if current-prefix-arg (current-buffer) t)))
   (let ((magit-git-global-arguments nil)
         (toplib (or load-file-name buffer-file-name))
         debug)
@@ -935,12 +937,13 @@ Git, and Emacs in the echo area."
                                     dirname)
                   (setq magit-version (match-string 1 dirname))))))))
     (if (stringp magit-version)
-        (when (called-interactively-p 'any)
-          (message "Magit %s, Git %s, Emacs %s, %s"
-                   (or magit-version "(unknown)")
-                   (or (magit-git-version t) "(unknown)")
-                   emacs-version
-                   system-type))
+        (when print-dest
+          (princ (format "Magit %s, Git %s, Emacs %s, %s"
+                         (or magit-version "(unknown)")
+                         (or (magit-git-version t) "(unknown)")
+                         emacs-version
+                         system-type)
+                 print-dest))
       (setq debug (reverse debug))
       (setq magit-version 'error)
       (when magit-version


### PR DESCRIPTION
From recent stackexchange questions, I think our `magit-version` command is not sufficiently foolproof for a troubleshooting tool.

http://emacs.stackexchange.com/questions/31913/how-to-direct-m-m-xs-output-to-the-current-buffer-rather-than-to-the-ec
http://emacs.stackexchange.com/questions/31868/magit-version-post-installation-does-not-look-as-in-the-manual