### PR TITLE
log: use NUL to delimit refs

### DIFF
--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -54,5 +54,8 @@ Fixes since v2.10.3
 * Adding an untracked subdirectory as a submodule failed if a remote
   was not configured for the subdirectory repository.  #3047
 
+* Parsing the log buffer failed if the log displayed a ref that
+  contained parentheses in its name.  #3028
+
 This release also contains other minor improvements, bug fixes, typo
 fixes, and documentation fixes.

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -172,7 +172,7 @@ bisect run'."
       (magit-insert-heading "Bisect Rest:")
       (magit-git-wash (apply-partially 'magit-log-wash-log 'bisect-vis)
         "bisect" "visualize" "git" "log"
-        "--format=%h%d %s" "--decorate=full"
+        "--format=%h%d%x00%s" "--decorate=full"
         (and magit-bisect-show-graph "--graph")))))
 
 (defun magit-insert-bisect-log ()

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1838,7 +1838,7 @@ or a ref which is not a branch, then it inserts nothing."
   (magit-insert-section (headers)
     ;; Before v2.2.0, "%D" was not supported.
     (--when-let (magit-rev-format "%d" rev "--decorate=full")
-      (insert (magit-format-ref-labels (substring it 2 -1)) ?\s))
+      (insert (magit-format-ref-labels it) ?\s))
     (insert (propertize (magit-rev-parse (concat rev "^{commit}"))
                         'face 'magit-hash))
     (magit-insert-heading)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1261,8 +1261,15 @@ Return a list of two integers: (A>B B>A)."
                   'face (if (equal ref head) 'magit-branch-current face)))))
 
 (defun magit-format-ref-labels (string)
+  ;; To support Git <2.2.0, we remove the surrounding parentheses here
+  ;; rather than specifying that STRING should be generated with Git's
+  ;; "%D" placeholder.
+  (setq string (->> string
+                    (replace-regexp-in-string "\\`\\s-*(" "")
+                    (replace-regexp-in-string ")\\s-*\\'" "")))
   (save-match-data
-    (let ((regexp "\\(, \\|tag: \\| -> \\|[()]\\)") head names)
+    (let ((regexp "\\(, \\|tag: \\| -> \\)")
+          head names)
       (if (and (derived-mode-p 'magit-log-mode)
                (member "--simplify-by-decoration" (cadr magit-refresh-args)))
           (let ((branches (magit-list-local-branch-names))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -828,7 +828,7 @@ Do not add this to a hook variable."
          (remove "--literal-pathspecs" magit-git-global-arguments)))
     (magit-git-wash (apply-partially #'magit-log-wash-log 'log)
       "log"
-      (format "--format=%%h%s%%x00%s[%%aN][%%at]%%s%s"
+      (format "--format=%%h%s%%x00%s%%x00%%aN%%x00%%at%%x00%%s%s"
               (if (member "--decorate" args) "%d" "")
               (if (member "--show-signature" args)
                   (progn (setq args (remove "--show-signature" args)) "%G?")
@@ -865,9 +865,9 @@ Do not add this to a hook variable."
           "\\(?4:[-_/|\\*o. ]*\\)"                 ; graph
           "\\(?1:[0-9a-fA-F]+\\)"                  ; sha1
           "\\(?3:[^\0]+)\\)?\0"                    ; refs
-          "\\(?7:[BGUXYREN]\\)?"                   ; gpg
-          "\\[\\(?5:[^]]*\\)\\]"                   ; author
-          "\\[\\(?6:[^]]*\\)\\]"                   ; date
+          "\\(?7:[BGUXYREN]\\)?\0"                 ; gpg
+          "\\(?5:[^\0]*\\)\0"                      ; author
+          "\\(?6:[^\0]+\\)\0"                      ; date
           "\\(?2:.*\\)$"))                         ; msg
 
 (defconst magit-log-cherry-re

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -828,7 +828,7 @@ Do not add this to a hook variable."
          (remove "--literal-pathspecs" magit-git-global-arguments)))
     (magit-git-wash (apply-partially #'magit-log-wash-log 'log)
       "log"
-      (format "--format=%%h%s %s[%%aN][%%at]%%s%s"
+      (format "--format=%%h%s%%x00%s[%%aN][%%at]%%s%s"
               (if (member "--decorate" args) "%d" "")
               (if (member "--show-signature" args)
                   (progn (setq args (remove "--show-signature" args)) "%G?")
@@ -863,8 +863,8 @@ Do not add this to a hook variable."
 (defconst magit-log-heading-re
   (concat "^"
           "\\(?4:[-_/|\\*o. ]*\\)"                 ; graph
-          "\\(?1:[0-9a-fA-F]+\\) "                 ; sha1
-          "\\(?:\\(?3:([^()]+)\\) \\)?"            ; refs
+          "\\(?1:[0-9a-fA-F]+\\)"                  ; sha1
+          "\\(?3:[^\0]+)\\)?\0"                    ; refs
           "\\(?7:[BGUXYREN]\\)?"                   ; gpg
           "\\[\\(?5:[^]]*\\)\\]"                   ; author
           "\\[\\(?6:[^]]*\\)\\]"                   ; date
@@ -885,8 +885,8 @@ Do not add this to a hook variable."
 (defconst magit-log-bisect-vis-re
   (concat "^"
           "\\(?4:[-_/|\\*o. ]*\\)"                 ; graph
-          "\\(?1:[0-9a-fA-F]+\\) "                 ; sha1
-          "\\(?:\\(?3:([^()]+)\\) \\)?"            ; refs
+          "\\(?1:[0-9a-fA-F]+\\)"                  ; sha1
+          "\\(?3:[^\0]+)\\)?\0"                    ; refs
           "\\(?2:.*\\)$"))                         ; msg
 
 (defconst magit-log-bisect-log-re


### PR DESCRIPTION
Please see commit messages.

Fixes #3028.