### PR TITLE
fix show signature

### DIFF
--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -61,5 +61,8 @@ Fixes since v2.10.3
 * Parsing the log buffer failed if the log displayed a ref that
   contained parentheses in its name.  #3028
 
+* Parsing the `git show' and `git log' output for a signed commit
+  failed with the Git variable `log.showSignature' enabled.  #3061
+
 This release also contains other minor improvements, bug fixes, typo
 fixes, and documentation fixes.

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -108,6 +108,7 @@ this."
 
 (defcustom magit-git-global-arguments
   `("--no-pager" "--literal-pathspecs" "-c" "core.preloadindex=true"
+    "-c" "log.showSignature=false"
     ,@(and (eq system-type 'windows-nt)
            (list "-c" "i18n.logOutputEncoding=UTF-8")))
   "Global Git arguments.


### PR DESCRIPTION
 Fix commit messages which are over written with signature, when
using `log.signatureEnabled=true`. #3061
