### PR TITLE
magit-show-commit: when in a log buffer, use log's file restriction

### DIFF
--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -46,6 +46,9 @@ Changes since v2.10.3
 
 * Added `magit-file-checkout' to `magit-reset-popup'.  #3052
 
+* When a revision is shown from a log buffer, the revision buffer now
+  inherits the file restriction of the log buffer.  #3056
+
 Fixes since v2.10.3
 -------------------
 

--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -49,6 +49,8 @@ Changes since v2.10.3
 * When a revision is shown from a log buffer, the revision buffer now
   inherits the file restriction of the log buffer.  #3056
 
+* Add new command `magit-revision-toggle-file-filter'.  #3062
+
 Fixes since v2.10.3
 -------------------
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2473,6 +2473,15 @@ without having to using one of the diff popups.
   the committer image, accordingly.  Either the car or the cdr may
   be nil.
 
+- Key: M-x magit-revision-toggle-file-filter, magit-revision-toggle-file-filter
+
+  This command toggles the file restriction of the current revision
+  buffer.  It is particularly useful when you display a revision from
+  a log buffer that is restricted to a file or files.  In this case,
+  the revision buffer is also restricted to these files, and this
+  command allows you to quickly switch between viewing all the changes
+  in the commit and the restricted subset.
+
 ** Ediffing
 
 This section describes how to enter Ediff from Magit buffers.  For

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -3379,6 +3379,19 @@ the committer image, accordingly.  Either the car or the cdr may
 be nil.
 @end defopt
 
+@table @asis
+@kindex M-x magit-revision-toggle-file-filter
+@cindex magit-revision-toggle-file-filter
+@item @kbd{M-x magit-revision-toggle-file-filter} @tie{}@tie{}@tie{}@tie{}(@code{magit-revision-toggle-file-filter})
+
+This command toggles the file restriction of the current revision
+buffer.  It is particularly useful when you display a revision from
+a log buffer that is restricted to a file or files.  In this case,
+the revision buffer is also restricted to these files, and this
+command allows you to quickly switch between viewing all the changes
+in the commit and the restricted subset.
+@end table
+
 @node Ediffing
 @section Ediffing
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1938,6 +1938,24 @@ or a ref which is not a branch, then it inserts nothing."
                (if magit-revision-use-gravatar-kludge slice2 slice1)
                (if magit-revision-use-gravatar-kludge slice1 slice2)))))))
 
+(defvar-local magit-revision-files nil)
+
+(defun magit-revision-toggle-file-filter ()
+  "Toggle the file restriction of the current revision buffer."
+  (interactive)
+  (with-current-buffer (or (and (derived-mode-p 'magit-revision-mode)
+                                (current-buffer))
+                           (magit-mode-get-buffer 'magit-revision-mode)
+                           (user-error "No revision buffer found"))
+    (let ((files (nth 3 magit-refresh-args)))
+      (unless (or magit-revision-files files)
+        (user-error "No file filter to toggle"))
+      (setf (nth 3 magit-refresh-args) (if (not files)
+                                           magit-revision-files
+                                         (setq magit-revision-files files)
+                                         nil))
+      (magit-refresh))))
+
 ;;; Diff Sections
 
 (defvar magit-unstaged-section-map

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -894,6 +894,12 @@ be committed."
 
 (defvar-local magit-buffer-revision-hash nil)
 
+(defun magit-show-commit--arguments ()
+  (-let [(args diff-files) (magit-diff-arguments)]
+    (list args (if (derived-mode-p 'magit-log-mode)
+                   (nth 2 magit-refresh-args)
+                 diff-files))))
+
 ;;;###autoload
 (defun magit-show-commit (rev &optional args files module)
   "Visit the revision at point in another buffer.
@@ -908,7 +914,7 @@ for a revision."
                        (magit-tag-at-point))))
      (nconc (cons (or (and (not current-prefix-arg) atpoint)
                       (magit-read-branch-or-commit "Show commit" atpoint))
-                  (magit-diff-arguments))
+                  (magit-show-commit--arguments))
             (and mcommit (list (magit-section-parent-value
                                 (magit-current-section)))))))
   (require 'magit)
@@ -1353,7 +1359,7 @@ commit or stash at point, then prompt for a commit."
                               (`scroll-down (point-max)))))))
           (let ((magit-display-buffer-noselect t))
             (if (eq cmd 'magit-show-commit)
-                (apply #'magit-show-commit rev (magit-diff-arguments))
+                (apply #'magit-show-commit rev (magit-show-commit--arguments))
               (funcall cmd rev))))
       (call-interactively #'magit-show-commit))))
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1756,8 +1756,8 @@ Staging and applying changes is documented in info node
                             " " rev
                             (pcase (length files)
                               (0)
-                              (1 (concat " in file " (car files)))
-                              (_ (concat " in files "
+                              (1 (concat " limited to file " (car files)))
+                              (_ (concat " limited to files "
                                          (mapconcat #'identity files ", ")))))
                     'face 'magit-header-line))
   (setq magit-buffer-revision-hash (magit-rev-parse rev))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1103,13 +1103,14 @@ If there is no revision buffer in the same frame, then do nothing."
       (setq magit--update-revision-buffer (list commit buffer))
       (run-with-idle-timer
        magit-update-other-window-delay nil
-       (lambda ()
-         (-let [(rev buf) magit--update-revision-buffer]
-           (setq magit--update-revision-buffer nil)
-           (when (buffer-live-p buf)
-             (let ((magit-display-buffer-noselect t))
-               (apply #'magit-show-commit rev (magit-diff-arguments)))))
-         (setq magit--update-revision-buffer nil))))))
+       (let ((args (magit-show-commit--arguments)))
+         (lambda ()
+           (-let [(rev buf) magit--update-revision-buffer]
+             (setq magit--update-revision-buffer nil)
+             (when (buffer-live-p buf)
+               (let ((magit-display-buffer-noselect t))
+                 (apply #'magit-show-commit rev args))))
+           (setq magit--update-revision-buffer nil)))))))
 
 (defvar magit--update-blob-buffer nil)
 


### PR DESCRIPTION
```
All calls to magit-show-commit take the file restriction from
magit-diff-arguments.  But when a call is made from a log buffer, the
user is viewing the revision in the context of the log, so the log's
file restriction is more relevant than the diff's [*].

Adjust magit-show-commit calls to respect the log's file restriction
if the current buffer is a log buffer.  Leave calls to
magit-show-commit in git-rebase.el and magit-blame.el unchanged
because these aren't designed to be executed from a log buffer.

Closes #3056

[*] This patch assumes that all users would prefer the log's file
    restriction over the diff's in this situation, but of course we
    can add an option to revert to the previous behavior if this turns
    out not to be the case.
```

Re: #3056 
