### PR TITLE
Remove org-export-ignore-headlines advice

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -641,43 +641,6 @@ and https://github.com/magit/magit/issues/2295."
           ;; `completion-pcm--all-completions' that shipped with Emacs 25.1.
           (nreverse poss))))))
 
-;;; Kludges for Org
-
-(eval-when-compile
-  (require 'org-element nil t)
-  (require 'ox-extra nil t))
-(declare-function org-element-adopt-elements  "org-element"
-                  (parent &rest children))
-(declare-function org-element-contents        "org-element" (element))
-(declare-function org-element-extract-element "org-element" (element))
-(declare-function org-element-map             "org-element"
-                  (data types fun &optional info
-                        first-match no-recursion with-affiliated))
-(declare-function org-element-type            "org-element" (element))
-
-(with-eval-after-load 'ox-extra ; see #2914
-  (defun org-extra--merge-sections (data _backend info)
-    (org-element-map data 'headline
-      (lambda (hl)
-        (let ((sections
-               (cl-loop
-                for el in (org-element-map (org-element-contents hl)
-                              '(headline section) #'identity info)
-                until (eq (org-element-type el) 'headline)
-                collect el)))
-          (when (and sections
-                     (> (length sections) 1))
-            (apply #'org-element-adopt-elements
-                   (car sections)
-                   (cl-mapcan (lambda (s) (org-element-contents s))
-                              (cdr sections)))
-            (mapc #'org-element-extract-element (cdr sections)))))
-      info))
-
-  (advice-add 'org-export-ignore-headlines :after
-              'org-extra--merge-sections
-              '((name . "org-export-ignore-headlines--merge-sections"))))
-
 ;;; Kludges for Incompatible Modes
 
 (defvar whitespace-mode)


### PR DESCRIPTION
```
org-extra--merge-sections was added to ox-extra.el in Org's
fef346798 (ox-extra: Merge sections from ignored headlines,
2017-05-03).

Re: #2914
```

@tarsius I'm opening this as a PR so that you can merge it whenever
you've updated your Org installation.
