### PR TITLE
git-commit-filename-regexp: autoload

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -369,6 +369,7 @@ already using it, then you probably shouldn't start doing so."
 
 ;;; Hooks
 
+;;;###autoload
 (defconst git-commit-filename-regexp "/\\(\
 \\(\\(COMMIT\\|NOTES\\|PULLREQ\\|TAG\\)_EDIT\\|MERGE_\\|\\)MSG\
 \\|BRANCH_DESCRIPTION\\)\\'")
@@ -390,6 +391,7 @@ already using it, then you probably shouldn't start doing so."
        (string-match-p git-commit-filename-regexp buffer-file-name)
        (git-commit-setup)))
 
+;;;###autoload
 (defun git-commit-setup ()
   ;; cygwin git will pass a cygwin path (/cygdrive/c/foo/.git/...),
   ;; try to handle this in window-nt Emacs.


### PR DESCRIPTION
This will allow users to register `git-commit-mode` with `auto-mode-alist` without having to enable `global-git-commit-mode` and thus eagerly load the whole `git-commit.el` package.

The motivation for this change was [this Q&A](https://emacs.stackexchange.com/q/32676/15748). If the proposed addition of an autoload cookie is not acceptable/desirable, I would be grateful for any suggestions addressing the points in the linked question.