### PR TITLE
magit-log-buffer-file: fix `-L` arg when region is active

### DIFF
--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -70,6 +70,9 @@ Changes since v2.10.3
 * The commands `magit-subtree-add', `magit-subtree-pull', and
   `magit-subtree-push' now offer more completion candidates.  #3081
 
+* The log buffer now shows the line range restriction (i.e. `-L'
+  argument) in its header.  #3075
+
 Fixes since v2.10.3
 -------------------
 

--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -101,6 +101,9 @@ Fixes since v2.10.3
 * The command `magit-show-commit' mistakenly displayed a tag's commit
   when point was on a branch with the same name.  #3098
 
+* The command `magit-log-buffer-file' miscalculated line numbers from
+  the region.  #3075
+
 This release also contains the fixes described in the v2.10.{1,2,3}
 release notes, as well as other minor improvements, bug fixes, typo
 fixes, and documentation fixes.

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -634,11 +634,17 @@ completion candidates."
   "Show log for the blob or file visited in the current buffer.
 With a prefix argument or when `--follow' is part of
 `magit-log-arguments', then follow renames."
-  (interactive (if (region-active-p)
-                   (list current-prefix-arg
-                         (1- (line-number-at-pos (region-beginning)))
-                         (1- (line-number-at-pos (region-end))))
-                 (list current-prefix-arg)))
+  (interactive
+   (cons current-prefix-arg
+         (and (region-active-p)
+              (list (line-number-at-pos (region-beginning))
+                    (line-number-at-pos
+                     (let ((end (region-end)))
+                       (if (char-after end)
+                           end
+                         ;; Ensure that we don't get the line number
+                         ;; of a trailing newline.
+                         (1- end))))))))
   (require 'magit)
   (-if-let (file (magit-file-relative-name))
       (magit-mode-setup-internal

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -637,14 +637,16 @@ With a prefix argument or when `--follow' is part of
   (interactive
    (cons current-prefix-arg
          (and (region-active-p)
-              (list (line-number-at-pos (region-beginning))
-                    (line-number-at-pos
-                     (let ((end (region-end)))
-                       (if (char-after end)
-                           end
-                         ;; Ensure that we don't get the line number
-                         ;; of a trailing newline.
-                         (1- end))))))))
+              (save-restriction
+                (widen)
+                (list (line-number-at-pos (region-beginning))
+                      (line-number-at-pos
+                       (let ((end (region-end)))
+                         (if (char-after end)
+                             end
+                           ;; Ensure that we don't get the line number
+                           ;; of a trailing newline.
+                           (1- end)))))))))
   (require 'magit)
   (-if-let (file (magit-file-relative-name))
       (magit-mode-setup-internal

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -806,7 +806,10 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
         (propertize
          (concat " Commits in " (mapconcat 'identity revs  " ")
                  (and files (concat " touching "
-                                    (mapconcat 'identity files " "))))
+                                    (mapconcat 'identity files " ")))
+                 (--some (and (string-prefix-p "-L" it)
+                              (concat " " it))
+                         args))
          'face 'magit-header-line))
   (unless (= (length files) 1)
     (setq args (remove "--follow" args)))


### PR DESCRIPTION
Previously, the line numbers passed to `git log`'s `-L` arg were calculated by subtracting 1 from
`line-number-at-pos` for `region-beginning` and `region-end`, which was incorrect in some cases.

e.g. calling `mark-whole-buffer` in a file with a single line with a trailing newline would call
`git log -L0,1:file`, instead of the expected `git log -L1,1:file`.

Additionally, if the active region does not include a trailing newline, the end of the range passed
to `-L` would also be off by 1. (e.g. in a 1-line file with no trailing newline, it would call `git
log -L0,0:file`)

This fix changes `magit-log-buffer-file` to calculate `-L` as a range starting at `the line number
at the start of the region`, and ending at `the line number at start + total lines in the region -
1`.

This appears to fix the problem, at least in all cases I've tried.

I can add regression tests if necessary--I wanted to make sure this is an OK approach first.

I'd also love if `magit-log-refresh-buffer` would update the header line with the line range passed to `-L`, similar to how limiting the log to a list of files updates the header to ` touching <files>`. I think it should work OK to check `args` for `(string-match-p "^-L")`, parse the value if present, and update the header appropriately, but is there a better way?