### PR TITLE
magit-clone: improve suggested directory name

### DIFF
--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -64,6 +64,9 @@ Changes since v2.10.3
   Depending on the context, this will abort a merge, a rebase, a
   patch application, a cherry-pick, a revert, or a bisect.  #3017
 
+* The command `magit-clone' now suggests a directory name that more
+  closely follows `git clone' when no directory is given.  #3079
+
 Fixes since v2.10.3
 -------------------
 

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -58,7 +58,7 @@ Then show the status buffer for the new repository."
    (let  ((url (magit-read-string-ns "Clone repository")))
      (list url (read-directory-name
                 "Clone to: " nil nil nil
-                (and (string-match "\\([^./]+\\)\\(\\.git\\)?$" url)
+                (and (string-match "\\([^/:]+?\\)\\(/?\\.git\\)?$" url)
                      (match-string 1 url))))))
   (setq directory (file-name-as-directory (expand-file-name directory)))
   (magit-run-git-async "clone" repository


### PR DESCRIPTION
```
Extract the directory name by taking the tail of the url up to the
first slash or colon, not the first slash or period.

This makes magit-clone's default directory name match the behavior of
"git clone <url>" in two places where it did not:

  1. https://[...]/foo.bar.git => "foo.bar" (instead of "bar")

  2. host.xz:foo/.git => "foo" (instead of "git")

Fixes #3079.
```
