### PR TITLE
Use completion in magit-subtree.el

### DIFF
--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -67,6 +67,9 @@ Changes since v2.10.3
 * The command `magit-clone' now suggests a directory name that more
   closely follows `git clone' when no directory is given.  #3079
 
+* The commands `magit-subtree-add', `magit-subtree-pull', and
+  `magit-subtree-push' now offer more completion candidates.  #3081
+
 Fixes since v2.10.3
 -------------------
 

--- a/lisp/magit-subtree.el
+++ b/lisp/magit-subtree.el
@@ -90,10 +90,12 @@
 ;;;###autoload
 (defun magit-subtree-add (prefix repository ref args)
   "Add REF from REPOSITORY as a new subtree at PREFIX."
-  (interactive (list (magit-subtree-prefix "Add subtree")
-                     (magit-read-string-ns "Repository")
-                     (magit-read-string-ns "Ref")
-                     (magit-subtree-args)))
+  (interactive
+   (cons (magit-subtree-prefix "Add subtree")
+         (let ((remote (magit-read-remote-or-url "From repository")))
+           (list remote
+                 (magit-read-refspec "Ref" remote)
+                 (magit-subtree-args)))))
   (magit-git-subtree "add" prefix args repository ref))
 
 ;;;###autoload
@@ -115,17 +117,19 @@
 ;;;###autoload
 (defun magit-subtree-pull (prefix repository ref args)
   "Pull REF from REPOSITORY into the PREFIX subtree."
-  (interactive (list (magit-subtree-prefix "Pull into subtree")
-                     (magit-read-string-ns "From repository")
-                     (magit-read-string-ns "Ref")
-                     (magit-subtree-args)))
+  (interactive
+   (cons (magit-subtree-prefix "Pull into subtree")
+         (let ((remote (magit-read-remote-or-url "From repository")))
+           (list remote
+                 (magit-read-refspec "Ref" remote)
+                 (magit-subtree-args)))))
   (magit-git-subtree "pull" prefix args repository ref))
 
 ;;;###autoload
 (defun magit-subtree-push (prefix repository ref args)
   "Extract the history of the subtree PREFIX and push it to REF on REPOSITORY."
   (interactive (list (magit-subtree-prefix "Push subtree")
-                     (magit-read-string-ns "To repository")
+                     (magit-read-remote-or-url "To repository")
                      (magit-read-string-ns "To reference")
                      (magit-subtree-args)))
   (magit-git-subtree "push" prefix args repository ref))

--- a/lisp/magit-subtree.el
+++ b/lisp/magit-subtree.el
@@ -88,13 +88,13 @@
   (magit-run-git-async "subtree" subcmd (concat "--prefix=" prefix) args))
 
 ;;;###autoload
-(defun magit-subtree-add (prefix repository commit args)
-  "Add COMMIT from REPOSITORY as a new subtree at PREFIX."
+(defun magit-subtree-add (prefix repository ref args)
+  "Add REF from REPOSITORY as a new subtree at PREFIX."
   (interactive (list (magit-subtree-prefix "Add subtree")
                      (magit-read-string-ns "Repository")
-                     (magit-read-string-ns "Commit")
+                     (magit-read-string-ns "Ref")
                      (magit-subtree-args)))
-  (magit-git-subtree "add" prefix args repository commit))
+  (magit-git-subtree "add" prefix args repository ref))
 
 ;;;###autoload
 (defun magit-subtree-add-commit (prefix commit args)
@@ -113,13 +113,13 @@
   (magit-git-subtree "merge" prefix args commit))
 
 ;;;###autoload
-(defun magit-subtree-pull (prefix repository commit args)
-  "Pull COMMIT from REPOSITORY into the PREFIX subtree."
+(defun magit-subtree-pull (prefix repository ref args)
+  "Pull REF from REPOSITORY into the PREFIX subtree."
   (interactive (list (magit-subtree-prefix "Pull into subtree")
                      (magit-read-string-ns "From repository")
-                     (magit-read-string-ns "Commit")
+                     (magit-read-string-ns "Ref")
                      (magit-subtree-args)))
-  (magit-git-subtree "pull" prefix args repository commit))
+  (magit-git-subtree "pull" prefix args repository ref))
 
 ;;;###autoload
 (defun magit-subtree-push (prefix repository ref args)


### PR DESCRIPTION
* lisp/magit-subtree.el (magit-subtree-add): Complete repo and branch
(magit-subtree-pull): Complete repo and branch
(magit-subtree-push): Complete repo

This could probably be taken farther, but this was as far as I was comfortable with. 