### PR TITLE
Don't add default to prompt for helm and ivy completion; and avoid completion misconfiguration

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -320,7 +320,11 @@ that this wrapper makes the following changes:
 The use of another completing function and/or wrapper obviously
 results in additional differences."
   (let ((reply (funcall magit-completing-read-function
-                        (concat prompt ": ") collection predicate
+                        (concat prompt ": ")
+                        (if (and def (not (member def collection)))
+                            (cons def collection)
+                          collection)
+                        predicate
                         require-match initial-input hist def)))
     (if (string= reply "")
         (if require-match


### PR DESCRIPTION
I think we should merge this now (after verifying that the helm change is appropriate). 

But in the long run we should probably phase out the `magit-completion-read-function` option, or at least move the kludges that are currently duplicated in all the magit specific functions into `magit-completing-read`, so that the upstream completion functions can be used directly instead of our wrappers. But that requires a transition plan and testing, and I don't have time for that right now. If someone else wants to do it, please go ahead. Otherwise we should merge this soon.

Re #3088.