### PR TITLE
magit-completing-read: add default to choices if necessary

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -320,7 +320,11 @@ that this wrapper makes the following changes:
 The use of another completing function and/or wrapper obviously
 results in additional differences."
   (let ((reply (funcall magit-completing-read-function
-                        (concat prompt ": ") collection predicate
+                        (concat prompt ": ")
+                        (if (and def (not (member def collection)))
+                            (cons def collection)
+                          collection)
+                        predicate
                         require-match initial-input hist def)))
     (if (string= reply "")
         (if require-match

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -57,16 +57,22 @@
 (defcustom magit-completing-read-function 'magit-builtin-completing-read
   "Function to be called when requesting input from the user.
 
-For Helm users, the simplest way to get Helm completion is to
-turn on `helm-mode' and leave this option set to the default
-value.  However, if you prefer to not use `helm-mode' but still
-want Magit to use Helm for completion, you can set this option to
-`helm--completing-read-default'."
+If you have enabled `ivy-mode' or `helm-mode', then you don't
+have to customize this option; `magit-builtin-completing-read'
+will work just fine.  However, if you use Ido completion, then
+you do have to use `magit-ido-completion-read', because Ido is
+less well behaved than the former, more modern alternatives.
+
+If you would like to use Ivy or Helm completion with Magit but
+not enable the respective modes globally, then customize this
+option to use `ivy-completing-read'
+or `helm--completing-read-default'."
   :group 'magit-essentials
   :type '(radio (function-item magit-builtin-completing-read)
                 (function-item magit-ido-completing-read)
+                (function-item ivy-completing-read)
                 (function-item helm--completing-read-default)
-                (function :tag "Other")))
+                (function :tag "Other function")))
 
 (defcustom magit-no-confirm-default nil
   "A list of commands which should just use the default choice.


### PR DESCRIPTION
Until now, we did not bother adding the default choice to the list of
all choices, because we assumed that doing so was not necessary.

But it turned out that while it is possible to use such a default by
simply confirming it, `completing-read` does not actually added to the
list of all choices.  It therefore won't be shown when the user uses
TAB to list the choices and manually typing the default and then
exiting with RET also won't work.

Additionally `ivy-completing-read` was recently changed to completely
ignore a default that isn't a member of the choices, making a fix more
pressing.

This commit simply prepends the default to the list of choices, if it
is not a `member` yet.  Doing this is much simpler than adjusting each
and every caller of `magit-completing-read`, but it may in some cases
be weird for the default to be listed first, when the other choices
are sorted alphabetically.