### PR TITLE
[WIP] Use cache around magit-run-git calls

### DIFF
--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -81,6 +81,10 @@ Changes since v2.10.3
 * Text inside brackets in commit messages (including when shown in a
   log) are now highlighted using face `magit-keyword'.
 
+* Invocations of git are cached over the whole body of
+  `magit-run-git', not just during the status buffer refresh.  This
+  should make staging and unstaging slightly faster.  #3096
+
 Fixes since v2.10.3
 -------------------
 

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -913,7 +913,8 @@ Run hooks `magit-pre-refresh-hook' and `magit-post-refresh-hook'."
   (interactive)
   (unless inhibit-magit-refresh
     (let ((start (current-time))
-          (magit--refresh-cache (list (cons 0 0))))
+          (magit--refresh-cache (or magit--refresh-cache
+                                    (list (cons 0 0)))))
       (when magit-refresh-verbose
         (message "Refreshing magit..."))
       (magit-run-hook-with-benchmark 'magit-pre-refresh-hook)

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -290,8 +290,9 @@ as well as the current repository's status buffer are refreshed.
 
 Process output goes into a new section in the buffer returned by
 `magit-process-buffer'."
-  (magit-call-git args)
-  (magit-refresh))
+  (let ((magit--refresh-cache (list (cons 0 0))))
+    (magit-call-git args)
+    (magit-refresh)))
 
 (defvar magit-pre-call-git-hook nil)
 


### PR DESCRIPTION
Continued from #3094.

This initial revision is just the simplest thing possible: extend the refresh cache around `magit-run-git`. We might get in trouble if the git command we run changes something we cache, I'm not sure if that can happen though? The main savings seems to be the `rev-parse` calls, so we could filter the cache to keep just those if it's a problem.

Here's the diff of git calls for a single `magit-stage`.
```diff
--- count-master.txt	2017-06-01 00:10:11.951496805 -0400
+++ count-cache2.txt	2017-06-01 00:11:07.457862768 -0400
@@ -22,27 +22,13 @@
 git show --no-patch --format=%s master^{commit} --
 git rev-parse --verify master
 git config --list -z
-git rev-parse --show-cdup
-git rev-parse --show-toplevel
 git show --no-patch --format=%h %s current^{commit} --
 git symbolic-ref --short HEAD
 git rev-parse --verify HEAD
 git update-index --refresh
-git rev-parse --show-toplevel
-git rev-parse --show-cdup
-git rev-parse --show-cdup
-git rev-parse --show-toplevel
 git add -u -- README.md
-git config -z --get-all magit.extension
-git rev-parse --show-toplevel
 git rev-parse --show-cdup
-git rev-parse --show-cdup
-git rev-parse --show-toplevel
-git rev-parse --show-toplevel
-git rev-parse --show-cdup
-git rev-parse --show-cdup
-git rev-parse --show-toplevel
 git rev-parse --show-toplevel
 
 
-45 calls in 0.168s
+31 calls in 0.147s
```

Code I used to measure:
```elisp
(defvar git-call-list t)
(defun around-magit-process-file (fun program &optional infile buffer display &rest args)
  (when (listp git-call-list)
    (push (cons program (mapcar #'substring-no-properties
                                (cl-set-difference args magit-git-global-arguments :test #'equal)))
          git-call-list))
  (let ((tbeg (current-time))
        (tend nil))
    (prog1 (apply fun program infile buffer display args)
      (setq tend (current-time))
      (when (listp git-call-list)
        (push (float-time (time-subtract tend tbeg))
              (car git-call-list))))))
(advice-add 'magit-process-file :around #'around-magit-process-file)

(defun toggle-magit-git-counting (enable)
  (interactive (list (not (listp git-call-list))))
  (if enable
      (setq git-call-list ())
    (with-current-buffer (get-buffer-create "*magit calls*")
      (if git-call-list
          (let ((total-time 0.0))
            (pcase-dolist (`(,time . ,call) git-call-list)
              (insert (format "|%.3fs" time) "|" (mapconcat #'identity call " ") "\n")
              (cl-incf total-time time))
            (insert (format "\n\n%d calls in %.3fs\n"
                            (length git-call-list) total-time)))
        (erase-buffer))
      (pop-to-buffer (current-buffer))
      (setq git-call-list t)))
  (message "%sabled git counting" (if enable "en" "dis")))

(setq magit-refresh-verbose t)
(global-set-key [f12] 'toggle-magit-git-counting)
```