### PR TITLE
magit-ref-fullname: support revision suffixes

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -849,7 +849,15 @@ string \"true\", otherwise return nil."
          (substring it 5))))
 
 (defun magit-ref-fullname (name)
-  (magit-rev-parse "--symbolic-full-name" name))
+  "Return fully qualified refname for NAME.
+If NAME is ambiguous, return nil.  NAME may include suffixes such
+as \"^1\" and \"~3\".  "
+  (save-match-data
+    (if (string-match "\\`\\([^^~]+\\)\\(.*\\)" name)
+        (--when-let (magit-rev-parse "--symbolic-full-name"
+                                     (match-string 1 name))
+          (concat it (match-string 2 name)))
+      (error "`name' has an unrecognized format"))))
 
 (defun magit-ref-ambiguous-p (name)
   (not (magit-ref-fullname name)))


### PR DESCRIPTION
```
magit-ref-ambiguous-p uses magit-ref-fullname to check if a ref is
ambiguous, but this results in some non-ambiguous names being
considered ambiguous because "git rev-parse --symbolic-full-name"
doesn't handle names like master~1.

We had the same problem before the introduction of
magit-ref-ambiguous-p (7026b9bd) because we used magit-ref-fullname
directly to check whether a ref was ambiguous.  However, we only used
this in a couple of places, and it looks like the only problematic
case (i.e. where we passed a ref with a ^ or ~ suffix) was in
magit-get-shortname (which led to an unnecessary "tags/" prefix for
unambiguous tags).

As of 622c9941 (Merge branch 'km/show-ambig' [#3101], 2017-06-10), we
rely on the magit-ref-fullname check (through magit-ref-ambiguous-p)
more heavily, so the unnecessary disambiguation is more widespread and
annoying.

Instead of handling this in magit-ref-fullname, we could change
magit-ref-ambiguous-p to strip the suffix in the name before passing
it to magit-ref-fullname, but we handle it at this level to
future-proof against magit-ref-fullname callers that might pass a
revision with a suffix.

```

Fixes #3106.
