### PR TITLE
magit-{init,status}: compare toplevels by truename

### DIFF
--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -117,6 +117,11 @@ Fixes since v2.10.3
   not into its own upstream branch, then the user was not offered to
   force the deletion, causing it to fail.  #3107
 
+* With `find-file-visit-truename' set to a non-nil value, the commands
+  `magit-status' and `magit-init' failed to detect when their
+  directory argument was a symlink that resolved to the output of
+  `magit-toplevel'.  #3115
+
 This release also contains the fixes described in the v2.10.{1,2,3}
 release notes, as well as other minor improvements, bug fixes, typo
 fixes, and documentation fixes.

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -151,7 +151,7 @@ Non-interactively DIRECTORY is (re-)initialized unconditionally."
                       (read-directory-name "Create repository in: ")))))
      (-when-let (toplevel (magit-toplevel directory))
        (setq toplevel (expand-file-name toplevel))
-       (unless (y-or-n-p (if (string-equal toplevel directory)
+       (unless (y-or-n-p (if (file-equal-p toplevel directory)
                              (format "Reinitialize existing repository %s? "
                                      directory)
                            (format "%s is a repository.  Create another in %s? "
@@ -177,7 +177,7 @@ then offer to initialize it as a new repository."
   (if directory
       (let ((toplevel (magit-toplevel directory)))
         (setq directory (file-name-as-directory (expand-file-name directory)))
-        (if (and toplevel (string-equal directory toplevel))
+        (if (and toplevel (file-equal-p directory toplevel))
             (magit-status-internal directory)
           (when (y-or-n-p
                  (if toplevel


### PR DESCRIPTION
##### Changes

This allows user input, whether read interactively or from `magit-repository-directories`, involving symlinked files to be compared to the result of `magit-toplevel` with `find-file-visit-truename` enabled. Otherwise, `magit-status` in particular fails to show the status corresponding to a symlinked directory in `magit-repository-directories`, and instead asks the user to create a new repository.

##### Background

My personal need for this arises from configuring `magit-repository-directories` to list a single directory containing symlinks to all other repositories in my filesystem. This saves me from having to maintain the list in my `user-init-file`. I only noticed the `magit-status` issue after recently enabling `find-file-visit-truename`. Though I can't imagine how the introduction of `file-equal-p` might affect anything else, an alternative solution in my configuration would be to advise `magit-list-repos` to return truenames.