### PR TITLE
magit-commit-popup: add custom reader for --reuse-message

### DIFF
--- a/Documentation/RelNotes/2.11.0.txt
+++ b/Documentation/RelNotes/2.11.0.txt
@@ -85,6 +85,10 @@ Changes since v2.10.3
   `magit-run-git', not just during the status buffer refresh.  This
   should make staging and unstaging slightly faster.  #3096
 
+* When reading a value for the `--reuse-message' option, the popup
+  `magit-commit-popup' now prompts with all ref names, offering
+  `ORIG_HEAD' as the default if it exists.  #3110
+
 Fixes since v2.10.3
 -------------------
 

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -105,7 +105,8 @@ an error while using those is harder to recover from."
                (?R "Claim authorship and reset author date" "--reset-author"))
     :options  ((?A "Override the author"  "--author=")
                (?S "Sign using gpg"       "--gpg-sign=" magit-read-gpg-secret-key)
-               (?C "Reuse commit message" "--reuse-message="))
+               (?C "Reuse commit message" "--reuse-message="
+                   magit-read-reuse-message))
     :actions  ((?c "Commit"         magit-commit)
                (?e "Extend"         magit-commit-extend)
                (?f "Fixup"          magit-commit-fixup)
@@ -141,6 +142,13 @@ an error while using those is harder to recover from."
                         prompt keys nil nil nil 'magit-gpg-secret-key-hist
                         (car (or magit-gpg-secret-key-hist keys)))
                        " "))))
+
+(defun magit-read-reuse-message (prompt &optional default)
+  (magit-completing-read prompt (magit-list-refnames)
+                         nil nil nil 'magit-revision-history
+                         (or default
+                             (and (magit-rev-verify "ORIG_HEAD")
+                                  "ORIG_HEAD"))))
 
 ;;; Commands
 


### PR DESCRIPTION
```
As mentioned in git-reset's manpage, ORIG_HEAD can be useful for
undoing a commit and reusing its message (though there are of course
other ways to do this).  Define a reader for the --reuse-message
option that offers ORIG_HEAD as the default value when it exists.

Also, prompt with all ref names.  If these aren't useful for the given
situation, the user can ignore them and enter an arbitrary value.
```

Closes #3110.

------------------------------------------------------------------------

I went back and forth on whether it's useful to include all ref names,
so I also have another version that uses `magit-read-string-ns`.
Thoughts?
