### PR TITLE
Make it easier to work with outside contributors' pull-requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ install:
   - tar -xaf emacs-bin-${EMACS_VERSION}.tar.gz -C /
   - export EMACS=/tmp/emacs/bin/emacs
   - $CURL -O https://raw.githubusercontent.com/magnars/dash.el/master/dash.el
+  - $CURL -O https://raw.githubusercontent.com/tarsius/ghub/master/ghub.el
+  - $CURL -o let-alist.el https://elpa.gnu.org/packages/let-alist-1.0.5.el
   - $CURL -O https://raw.githubusercontent.com/magit/magit-popup/master/magit-popup.el
   - $CURL -O https://raw.githubusercontent.com/magit/with-editor/master/with-editor.el
-  - $EMACS -Q --batch -L . -f batch-byte-compile dash.el magit-popup.el with-editor.el
+  - $EMACS -Q --batch -L . -f batch-byte-compile dash.el ghub.el let-alist.el magit-popup.el with-editor.el
   - $EMACS --version
 script:
   - git config --global user.name "A U Thor"

--- a/Documentation/RelNotes/2.12.0.txt
+++ b/Documentation/RelNotes/2.12.0.txt
@@ -195,6 +195,11 @@ Changes since v2.11.0
   support Github, but other Git forges will be supported in the future.
   #3134
 
+* The command `magit-branch-delete' now offers to also delete the
+  corresponding remote after deleting a local branch that was created
+  with `magit-branch-pull-request' or magit-checkout-pull-request',
+  provided that remote has no other tracking branches.  #3134
+
 Fixes since v2.11.0
 -------------------
 

--- a/Documentation/RelNotes/2.12.0.txt
+++ b/Documentation/RelNotes/2.12.0.txt
@@ -186,6 +186,10 @@ Changes since v2.11.0
 
 * The command `magit-log-buffer-file' now also works in Dired buffers.
 
+* Added command `magit-browse-pull-request', which reads an open pull
+  request and then visits it in a browser.  For now this only supports
+  Github, but other Git forges will be supported in the future.  #3134
+
 Fixes since v2.11.0
 -------------------
 

--- a/Documentation/RelNotes/2.12.0.txt
+++ b/Documentation/RelNotes/2.12.0.txt
@@ -190,6 +190,11 @@ Changes since v2.11.0
   request and then visits it in a browser.  For now this only supports
   Github, but other Git forges will be supported in the future.  #3134
 
+* Added new commands `magit-checkout-pull-request' and
+  `magit-branch-pull-request' to the branch popup.  For now they only
+  support Github, but other Git forges will be supported in the future.
+  #3134
+
 Fixes since v2.11.0
 -------------------
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.11.0 (2.11.0-283-g2d82dc0e5+1)
+#+SUBTITLE: for version 2.11.0 (2.11.0-301-gce31549d7+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -22,7 +22,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+BEGIN_QUOTE
-This manual is for Magit version 2.11.0 (2.11.0-283-g2d82dc0e5+1).
+This manual is for Magit version 2.11.0 (2.11.0-301-gce31549d7+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@bernoul.li>
 
@@ -4042,6 +4042,94 @@ features are available from separate popups.
   matter, all commits between FROM and ~HEAD~ are moved to the new
   branch.  If FROM is not reachable from ~HEAD~ or is reachable from the
   source branch's upstream, then an error is raised.
+
+- Key: b p, magit-branch-pull-request
+
+  This command creates and configures a new branch from a Github
+  pull-request, creating and configuring a new remote if necessary.
+
+  The name of the local branch is the same as the name of the remote
+  branch that you are being asked to merge, unless the contributor
+  could not be bother to properly name the branch before opening the
+  pull-request.  The most likely such case is when you are being asked
+  to merge something like "fork/master" into "origin/master".  In such
+  cases the local branch will be named "pr-N", where ~N~ is the
+  pull-request number.
+
+  These variables are always set by this command:
+
+  - ~branch.<name>.pullRequest~ is set to the pull-request number.
+  - ~branch.<name>.description~ is set to the pull-request title.
+  - ~branch.<name>.rebase~ is set to ~true~ because there should be no
+    merge commits among the commits in a pull-request.
+
+  This command also configures the upstream and the push-remote of the
+  local branch that it creates.
+
+  The branch against which the pull-request was opened, is always used
+  as the upstream.  This makes it easy to see what commits you are
+  being asked to merge in the section titled something like "Unmerged
+  into origin/master".
+
+  Like for other commands that create a branch it depends on the
+  option ~magit-branch-prefer-remote-upstream~ whether the remote branch
+  itself or the respective local branch is used as the upstream, so
+  this section may also be titled e.g. "Unmerged into master".
+
+  When necessary and possible, then the remote pull-request branch is
+  configured to be used as the push-target.  This makes it easy to see
+  what further changes the contributor has made since you last
+  reviewed their changes in the section titled something like
+  "Unpulled from origin/new-feature" or "Unpulled from
+  fork/new-feature".
+
+  - If the pull-request branch is located in the upstream repository,
+    then it is not necessary to configure the push-target.
+
+    (If you have push access to the upstream repository, then it is
+    usually a good idea to configure that as the push-remote using
+    ~remote.pushDefault~.  However even if you are not using that
+    recommended setting, then it is still easy enough to set
+    ~branch.<name>.pushRemote~ while pushing using ~P p~.)
+
+  - If the pull-request branch is located inside a fork, then you
+    usually are able to push to that branch, because Github by default
+    allows the recipient of a pull-request to push to the remote
+    pull-request branch even if it is located in a fork.  The
+    contributor has to explicitly disable this.
+
+    - If you are not allowed to push to the pull-request branch on
+      the fork, then a branch by the same name located in the
+      upstream repository is configured as the push-target.
+
+    - A — sadly rather common — special case is when the contributor
+      didn't bother to use a dedicated branch for the pull-request.
+
+      The most likely such case is when you are being asked to merge
+      something like "fork/master" into "origin/master".  The special
+      push permission mentioned above is never granted for the branch
+      that is the repository's default branch, and that is almost
+      certainly be the case in this scenario.
+
+      To enable you to easily push somewhere anyway, the local branch
+      is named "pr-N" (where ~N~ is the pull-request number) and the
+      upstream repository is used as the push-remote.
+
+    - Finally, if you are allowed to push to the pull-request branch
+      and the contributor had the foresight to use a dedicated branch,
+      then the fork is configured as the push-remote.
+
+    The push-remote is configured using ~branch.<name>.pushRemote~, even
+    if the used value is identical to that of ~remote.pushDefault~, just
+    in case you change the value of the latter later on.  Additionally
+    the variable ~branch.<name>.pullRequestRemote~ is set to the fork
+    remote.
+
+- Key: b p, magit-checkout-pull-request
+
+  This command creates and configures a new branch from a pull
+  request, the same way ~magit-branch-pull-request~ does.  Additionally
+  it checks out the new branch.
 
 - Key: b x, magit-branch-reset
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.11.0 (2.11.0-301-gce31549d7+1)
+#+SUBTITLE: for version 2.11.0 (2.11.0-302-gac281d7f1+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -22,7 +22,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+BEGIN_QUOTE
-This manual is for Magit version 2.11.0 (2.11.0-301-gce31549d7+1).
+This manual is for Magit version 2.11.0 (2.11.0-302-gac281d7f1+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@bernoul.li>
 
@@ -1274,6 +1274,13 @@ telling Magit to ask fewer questions.
       confirm the deletion of a branch by accepting the default choice
       (or selecting another branch), but when a branch has not been
       merged yet, also make sure the user is aware of that.
+
+    - ~delete-pr-branch~ When deleting a branch that was created from a
+      pull request and if no other branches still exist on that
+      remote, then `magit-branch-delete' offers to delete the remote
+      as well.  This should be safe because it only happens if no
+      other refs exist in the remotes namespace, and you can recreate
+      the remote if necessary.
 
     - ~drop-stashes~ Dropping a stash is dangerous because Git stores
       stashes in the reflog.  Once a stash is removed, there is no
@@ -4124,6 +4131,17 @@ features are available from separate popups.
     in case you change the value of the latter later on.  Additionally
     the variable ~branch.<name>.pullRequestRemote~ is set to the fork
     remote.
+
+  When you later delete the local pull-request branch, then you are
+  offered to also delete the corresponding remote, provided it is not
+  the upstream remote and that the tracking branch that corresponds to
+  the deleted branch is the only remaining tracked branch.  If you
+  don't confirm, then only the tracking branch itself is deleted in
+  addition to the local branch.
+
+  Do not delete the tracking branch instead of the local branch.  The
+  cleanup mentioned in the previous paragraph is not performed if you
+  do that.
 
 - Key: b p, magit-checkout-pull-request
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.11.0 (2.11.0-283-g2d82dc0e5+1)
+@subtitle for version 2.11.0 (2.11.0-301-gce31549d7+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -52,7 +52,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @quotation
-This manual is for Magit version 2.11.0 (2.11.0-283-g2d82dc0e5+1).
+This manual is for Magit version 2.11.0 (2.11.0-301-gce31549d7+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@@bernoul.li>
 
@@ -5493,6 +5493,117 @@ The commit at the other end of the selection actually does not
 matter, all commits between FROM and @code{HEAD} are moved to the new
 branch.  If FROM is not reachable from @code{HEAD} or is reachable from the
 source branch's upstream, then an error is raised.
+
+@kindex b p
+@cindex magit-branch-pull-request
+@item @kbd{b p} @tie{}@tie{}@tie{}@tie{}(@code{magit-branch-pull-request})
+
+This command creates and configures a new branch from a Github
+pull-request, creating and configuring a new remote if necessary.
+
+The name of the local branch is the same as the name of the remote
+branch that you are being asked to merge, unless the contributor
+could not be bother to properly name the branch before opening the
+pull-request.  The most likely such case is when you are being asked
+to merge something like "fork/master" into "origin/master".  In such
+cases the local branch will be named "pr-N", where @code{N} is the
+pull-request number.
+
+These variables are always set by this command:
+
+@itemize
+@item
+@code{branch.<name>.pullRequest} is set to the pull-request number.
+
+@item
+@code{branch.<name>.description} is set to the pull-request title.
+
+@item
+@code{branch.<name>.rebase} is set to @code{true} because there should be no
+merge commits among the commits in a pull-request.
+@end itemize
+
+This command also configures the upstream and the push-remote of the
+local branch that it creates.
+
+The branch against which the pull-request was opened, is always used
+as the upstream.  This makes it easy to see what commits you are
+being asked to merge in the section titled something like "Unmerged
+into origin/master".
+
+Like for other commands that create a branch it depends on the
+option @code{magit-branch-prefer-remote-upstream} whether the remote branch
+itself or the respective local branch is used as the upstream, so
+this section may also be titled e.g. "Unmerged into master".
+
+When necessary and possible, then the remote pull-request branch is
+configured to be used as the push-target.  This makes it easy to see
+what further changes the contributor has made since you last
+reviewed their changes in the section titled something like
+"Unpulled from origin/new-feature" or "Unpulled from
+fork/new-feature".
+
+@itemize
+@item
+If the pull-request branch is located in the upstream repository,
+then it is not necessary to configure the push-target.
+
+(If you have push access to the upstream repository, then it is
+usually a good idea to configure that as the push-remote using
+@code{remote.pushDefault}.  However even if you are not using that
+recommended setting, then it is still easy enough to set
+@code{branch.<name>.pushRemote} while pushing using @code{P p}.)
+
+
+@item
+If the pull-request branch is located inside a fork, then you
+usually are able to push to that branch, because Github by default
+allows the recipient of a pull-request to push to the remote
+pull-request branch even if it is located in a fork.  The
+contributor has to explicitly disable this.
+
+@itemize
+@item
+If you are not allowed to push to the pull-request branch on
+the fork, then a branch by the same name located in the
+upstream repository is configured as the push-target.
+
+
+@item
+A — sadly rather common — special case is when the contributor
+didn't bother to use a dedicated branch for the pull-request.
+
+The most likely such case is when you are being asked to merge
+something like "fork/master" into "origin/master".  The special
+push permission mentioned above is never granted for the branch
+that is the repository's default branch, and that is almost
+certainly be the case in this scenario.
+
+To enable you to easily push somewhere anyway, the local branch
+is named "pr-N" (where @code{N} is the pull-request number) and the
+upstream repository is used as the push-remote.
+
+
+@item
+Finally, if you are allowed to push to the pull-request branch
+and the contributor had the foresight to use a dedicated branch,
+then the fork is configured as the push-remote.
+@end itemize
+
+The push-remote is configured using @code{branch.<name>.pushRemote}, even
+if the used value is identical to that of @code{remote.pushDefault}, just
+in case you change the value of the latter later on.  Additionally
+the variable @code{branch.<name>.pullRequestRemote} is set to the fork
+remote.
+@end itemize
+
+@kindex b p
+@cindex magit-checkout-pull-request
+@item @kbd{b p} @tie{}@tie{}@tie{}@tie{}(@code{magit-checkout-pull-request})
+
+This command creates and configures a new branch from a pull
+request, the same way @code{magit-branch-pull-request} does.  Additionally
+it checks out the new branch.
 
 @kindex b x
 @cindex magit-branch-reset

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.11.0 (2.11.0-301-gce31549d7+1)
+@subtitle for version 2.11.0 (2.11.0-302-gac281d7f1+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -52,7 +52,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @quotation
-This manual is for Magit version 2.11.0 (2.11.0-301-gce31549d7+1).
+This manual is for Magit version 2.11.0 (2.11.0-302-gac281d7f1+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@@bernoul.li>
 
@@ -1803,6 +1803,15 @@ And even then the reflog is gone.  The user always has to
 confirm the deletion of a branch by accepting the default choice
 (or selecting another branch), but when a branch has not been
 merged yet, also make sure the user is aware of that.
+
+
+@item
+@code{delete-pr-branch} When deleting a branch that was created from a
+pull request and if no other branches still exist on that
+remote, then `magit-branch-delete' offers to delete the remote
+as well.  This should be safe because it only happens if no
+other refs exist in the remotes namespace, and you can recreate
+the remote if necessary.
 
 
 @item
@@ -5596,6 +5605,17 @@ in case you change the value of the latter later on.  Additionally
 the variable @code{branch.<name>.pullRequestRemote} is set to the fork
 remote.
 @end itemize
+
+When you later delete the local pull-request branch, then you are
+offered to also delete the corresponding remote, provided it is not
+the upstream remote and that the tracking branch that corresponds to
+the deleted branch is the only remaining tracked branch.  If you
+don't confirm, then only the tracking branch itself is deleted in
+addition to the local branch.
+
+Do not delete the tracking branch instead of the local branch.  The
+cleanup mentioned in the previous paragraph is not performed if you
+do that.
 
 @kindex b p
 @cindex magit-checkout-pull-request

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ define set_package_requires
     (let ((s (read (buffer-substring (point) (line-end-position)))))
       (--when-let (assq (quote async)       s) (setcdr it (list async-version)))
       (--when-let (assq (quote dash)        s) (setcdr it (list dash-version)))
+      (--when-let (assq (quote ghub)        s) (setcdr it (list ghub-version)))
       (--when-let (assq (quote with-editor) s) (setcdr it (list with-editor-version)))
       (--when-let (assq (quote git-commit)  s) (setcdr it (list git-commit-version)))
       (delete-region (point) (line-end-position))
@@ -209,6 +210,7 @@ bump-versions-1:
 	@$(BATCH) --eval "(progn\
         (setq async-version \"$(ASYNC_VERSION)\")\
         (setq dash-version \"$(DASH_VERSION)\")\
+        (setq ghub-version \"$(GHUB_VERSION)\")\
         (setq with-editor-version \"$(WITH_EDITOR_VERSION)\")\
         (setq git-commit-version \"$(GIT_COMMIT_VERSION)\")\
         $$set_package_requires)"
@@ -217,6 +219,7 @@ bump-snapshots:
 	@$(BATCH) --eval "(progn\
         (setq async-version \"$(ASYNC_MELPA_SNAPSHOT)\")\
         (setq dash-version \"$(DASH_MELPA_SNAPSHOT)\")\
+        (setq ghub-version \"$(GHUB_SNAPSHOT)\")\
         (setq with-editor-version \"$(WITH_EDITOR_MELPA_SNAPSHOT)\")\
         (setq git-commit-version \"$(GIT_COMMIT_MELPA_SNAPSHOT)\")\
         $$set_package_requires)"

--- a/default.mk
+++ b/default.mk
@@ -62,6 +62,7 @@ ELS += magit.el
 ELS += magit-status.el
 ELS += magit-refs.el
 ELS += magit-files.el
+ELS += magit-collab.el
 ELS += magit-branch.el
 ELS += magit-worktree.el
 ELS += magit-notes.el
@@ -89,12 +90,14 @@ VERSION ?= $(shell test -e $(TOP).git && git describe --tags --abbrev=0)
 
 ASYNC_VERSION       = 1.9.2
 DASH_VERSION        = 2.13.0
+GHUB_VERSION        = 2.0.0
 MAGIT_POPUP_VERSION = 2.13.0
 WITH_EDITOR_VERSION = 2.6.0
 GIT_COMMIT_VERSION  = 2.10.3
 
 ASYNC_MELPA_SNAPSHOT       = 20170823
 DASH_MELPA_SNAPSHOT        = 20170810
+GHUB_SNAPSHOT              = 20171207
 MAGIT_POPUP_MELPA_SNAPSHOT = 20171121
 WITH_EDITOR_MELPA_SNAPSHOT = 20170817
 GIT_COMMIT_MELPA_SNAPSHOT  = 20170823
@@ -120,6 +123,13 @@ ifeq "$(DASH_DIR)" ""
   DASH_DIR = $(TOP)../dash
 endif
 
+GHUB_DIR ?= $(shell \
+  find -L $(ELPA_DIR) -maxdepth 1 -regex '.*/ghub-[.0-9]*' 2> /dev/null | \
+  sort | tail -n 1)
+ifeq "$(GHUB_DIR)" ""
+  GHUB_DIR = $(TOP)../ghub
+endif
+
 MAGIT_POPUP_DIR ?= $(shell \
   find -L $(ELPA_DIR) -maxdepth 1 -regex '.*/magit-popup-[.0-9]*' 2> /dev/null | \
   sort | tail -n 1)
@@ -143,10 +153,12 @@ LOAD_PATH = -L $(TOP)/lisp
 
 ifdef CYGPATH
   LOAD_PATH += -L $(shell cygpath --mixed $(DASH_DIR))
+  LOAD_PATH += -L $(shell cygpath --mixed $(GHUB_DIR))
   LOAD_PATH += -L $(shell cygpath --mixed $(MAGIT_POPUP_DIR))
   LOAD_PATH += -L $(shell cygpath --mixed $(WITH_EDITOR_DIR))
 else
   LOAD_PATH += -L $(DASH_DIR)
+  LOAD_PATH += -L $(GHUB_DIR)
   LOAD_PATH += -L $(MAGIT_POPUP_DIR)
   LOAD_PATH += -L $(WITH_EDITOR_DIR)
 endif

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -31,7 +31,8 @@ magit.elc:		git-commit.elc magit-core.elc magit-diff.elc \
 magit-status.elc:	magit.elc
 magit-refs.elc: 	magit.elc
 magit-files.elc:	magit.elc
-magit-branch.elc:	magit.elc
+magit-collab.elc:	magit.elc
+magit-branch.elc:	magit.elc magit-collab.el
 magit-worktree.elc:	magit.elc
 magit-notes.elc:	magit.elc
 magit-obsolete.elc:	magit.elc

--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -32,6 +32,7 @@
 ;;; Code:
 
 (require 'magit)
+(require 'magit-collab)
 
 ;;; Options
 

--- a/lisp/magit-collab.el
+++ b/lisp/magit-collab.el
@@ -1,0 +1,113 @@
+;;; magit-collab.el --- collaboration tools       -*- lexical-binding: t -*-
+
+;; Copyright (C) 2010-2017  The Magit Project Contributors
+;;
+;; You should have received a copy of the AUTHORS.md file which
+;; lists all contributors.  If not, see http://magit.vc/authors.
+
+;; Author: Jonas Bernoulli <jonas@bernoul.li>
+;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
+
+;; Magit is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; Magit is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+;; License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Magit.  If not, see http://www.gnu.org/licenses.
+
+;;; Commentary:
+
+;; This library implements various collaboration tools.  These tools
+;; are only early incarnation -- implementing collaboration tools is
+;; a top priority for future development.
+
+;; Currently these tools (including `magit-branch-pull-request', which
+;; is defined elsewhere) only support Github, but support for other
+;; Git forges as well as mailing list based collaboration is in
+;; planning.
+
+;;; Code:
+
+(require 'magit)
+(require 'ghub)
+
+;;; Variables
+
+(defvar magit-github-token-scopes '(repo)
+  "The Github API scopes needed by Magit.
+
+`repo' is the only required scope.  Without this scope none of
+Magit's features that use the API work.  Instead of this scope
+you could use `public_repo' if you are only interested in public
+repositories.
+
+`repo' Grants read/write access to code, commit statuses,
+  invitations, collaborators, adding team memberships, and
+  deployment statuses for public and private repositories
+  and organizations.
+
+`public_repo' Grants read/write access to code, commit statuses,
+  collaborators, and deployment statuses for public repositories
+  and organizations. Also required for starring public
+  repositories.")
+
+;;; Utilities
+
+(defun magit-read-pull-request (prompt)
+  "Read a pull request from the user, prompting with PROMPT.
+Return the Git forge's API response.  Currently this function
+only supports Github, but that will change eventually."
+  (let* ((origin (magit-upstream-repository))
+         (url    (magit-get "remote" origin "url"))
+         (prs    (ghub-get
+                  (format "/repos/%s/pulls"
+                          (and (string-match
+                                "github.com[:/]\\(.+?\\)\\(?:\\.git\\)?\\'" url)
+                               (match-string 1 url)))
+                  nil :auth 'magit))
+         (choice (magit-completing-read
+                  prompt
+                  (--map (format "%s  %s"
+                                 (cdr (assq 'number it))
+                                 (cdr (assq 'title  it)))
+                         prs)
+                  nil t))
+         (number (and (string-match "\\([0-9]+\\)" choice)
+                      (string-to-number (match-string 1 choice)))))
+    (--first (eq (cdr (assq 'number it)) number) prs)))
+
+(defun magit-upstream-repository ()
+  "Return the remote name of the upstream repository.
+
+If the Git variable `magit.upstream' is set, then return its
+value.  Otherwise return \"origin\".  If the remote does not
+exist, then raise an error."
+  (let ((remote (or (magit-get "magit.upstream") "origin")))
+    (unless (magit-remote-p remote)
+      (error "No remote named `%s' exists (consider setting `magit.upstream')"
+             remote))
+    (unless (string-match-p "github\\.com" (magit-get "remote" remote "url"))
+      (error "Currently only Github is supported"))
+    remote))
+
+(defconst magit--github-url-regexp "\
+\\`\\(?:git://\\|git@\\|ssh://git@\\|https://\\)github.com[/:]\
+\\(\\([^/]+\\)/\\(.+?\\)\\)\
+\\(?:\\.git\\)?\\'")
+
+(defun magit--github-url-equal (r1 r2)
+  (or (equal r1 r2)
+      (let ((n1 (and (string-match magit--github-url-regexp r1)
+                     (match-string 1 r1)))
+            (n2 (and (string-match magit--github-url-regexp r2)
+                     (match-string 1 r2))))
+        (and n1 n2 (equal n1 n2)))))
+
+(provide 'magit-collab)
+;;; magit-collab.el ends here

--- a/lisp/magit-collab.el
+++ b/lisp/magit-collab.el
@@ -57,6 +57,22 @@ repositories.
   and organizations. Also required for starring public
   repositories.")
 
+;;; Commands
+
+;;;###autoload
+(defun magit-browse-pull-request (pr)
+  "Visit pull-request PR using `browse-url'.
+
+Currently this only supports Github, but that restriction will
+be lifted eventually to support other Git forges."
+  (interactive (list (magit-read-pull-request "Visit pull request")))
+  (browse-url (format "https://github.com/%s/pull/%s"
+                      (--> pr
+                           (cdr (assq 'base it))
+                           (cdr (assq 'repo it))
+                           (cdr (assq 'full_name it)))
+                      (cdr (assq 'number pr)))))
+
 ;;; Utilities
 
 (defun magit-read-pull-request (prompt)

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -142,6 +142,7 @@ The value has the form ((COMMAND nil|PROMPT DEFAULT)...).
     (const abort-merge)       (const merge-dirty)
     (const drop-stashes)      (const resect-bisect)
     (const kill-process)      (const delete-unmerged-branch)
+    (const delete-pr-branch)
     (const stage-all-changes) (const unstage-all-changes)
     (const safe-with-wip)))
 
@@ -212,6 +213,13 @@ References:
   to confirm the deletion of a branch by accepting the default
   choice (or selecting another branch), but when a branch has
   not been merged yet, also make sure the user is aware of that.
+
+  `delete-pr-branch' When deleting a branch that was created from
+  a pull request and if no other branches still exist on that
+  remote, then `magit-branch-delete' offers to delete the remote
+  as well.  This should be safe because it only happens if no
+  other refs exist in the remotes namespace, and you can recreate
+  the remote if necessary.
 
   `drop-stashes' Dropping a stash is dangerous because Git stores
   stashes in the reflog.  Once a stash is removed, there is no

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -16,7 +16,7 @@
 ;;	Rémi Vanicat      <vanicat@debian.org>
 ;;	Yann Hodique      <yann.hodique@gmail.com>
 
-;; Package-Requires: ((emacs "24.4") (async "20170823") (dash "20170810") (with-editor "20170817") (git-commit "20170823") (magit-popup "20171121"))
+;; Package-Requires: ((emacs "24.4") (async "20170823") (dash "20170810") (ghub "20171204") (let-alist "1.0.5") (with-editor "20170817") (git-commit "20170823") (magit-popup "20171121"))
 ;; Keywords: git tools vc
 ;; Homepage: https://github.com/magit/magit
 


### PR DESCRIPTION
The new command `magit-branch-pull-request` creates a local branch for the pull-request, adds a remote if necessary, and configures the branch to make working with pull-requests from outside collaborators just as easy as working with pull-requests whose branches have been pushed to the upstream repository.

`magit-branch-delete` has been taught to cleanup when deleting a "pull-request branch". That may involve deleting the "contributor's remote".

This is only a tiny step toward the goals described in #2972, but for people like me who review all pull-requests in Magit instead of by clicking around in a browser, it is a huge win.

Before I can merge this, I have to improve `ghub.el` somewhat. Most importantly it has to be made easier to create a new token but there are also some bugs.