### PR TITLE
magit-switch-to-magit-buffer: new function

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -33,6 +33,7 @@
 (require 'dash)
 
 (require 'magit-section)
+(require 'magit-status)
 (require 'magit-git)
 (require 'magit-popup)
 
@@ -582,6 +583,13 @@ locked to its value, which is derived from MODE and ARGS."
     (with-current-buffer buffer
       (run-hooks 'magit-mode-setup-hook)
       (magit-refresh-buffer))))
+
+(defun magit-switch-to-magit-buffer ()
+  "Switch to magit's buffer if it exists otherwise call `magit-status'."
+  (interactive)
+  (if-let ((buffer (magit-mode-get-buffer #'magit-status-mode)))
+      (magit-display-buffer buffer)
+    (magit-status)))
 
 (defvar magit-display-buffer-noselect nil
   "If non-nil, then `magit-display-buffer' doesn't call `select-window'.")

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -33,7 +33,6 @@
 (require 'dash)
 
 (require 'magit-section)
-(require 'magit-status)
 (require 'magit-git)
 (require 'magit-popup)
 
@@ -583,13 +582,6 @@ locked to its value, which is derived from MODE and ARGS."
     (with-current-buffer buffer
       (run-hooks 'magit-mode-setup-hook)
       (magit-refresh-buffer))))
-
-(defun magit-switch-to-magit-buffer ()
-  "Switch to magit's buffer if it exists otherwise call `magit-status'."
-  (interactive)
-  (if-let ((buffer (magit-mode-get-buffer #'magit-status-mode)))
-      (magit-display-buffer buffer)
-    (magit-status)))
 
 (defvar magit-display-buffer-noselect nil
   "If non-nil, then `magit-display-buffer' doesn't call `select-window'.")

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -199,6 +199,14 @@ then offer to initialize it as a new repository."
 (put 'magit-status 'interactive-only 'magit-status-internal)
 
 ;;;###autoload
+(defun magit-switch-to-magit-buffer ()
+  "Switch to magit's buffer if it exists otherwise call `magit-status'."
+  (interactive)
+  (if-let ((buffer (magit-mode-get-buffer #'magit-status-mode)))
+      (magit-display-buffer buffer)
+    (magit-status)))
+
+;;;###autoload
 (defun magit-status-internal (directory)
   (magit--tramp-asserts directory)
   (let ((default-directory directory))


### PR DESCRIPTION
My magit workflow looks like this:
```
... -> do some work -> magit status -> diff -> commit -> bury the magit status buffer -> ...
(repeat)
```

When using `magit-status` with `magithub` installed, `magithub` fetches data every time when I run `magit-status`, even when I have a magit status buffer open and `magithub` has cached data. Because `magithub` fetches data synchronously, I'd have to stop and wait for `magithub` to finish fetching. You can see this can get quite annoying quickly.

So I thought, why not create a function that switch to the magit status buffer if it exists and create one if there's no such buffer. :)

PS.

Thanks for the great work you pour into `magit` and `magithub`. They are awesome!
