### PR TITLE
Apply ansi colors on the output of git process

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -31,6 +31,7 @@
 
 ;;; Code:
 
+(require 'ansi-color)
 (require 'cl-lib)
 (require 'dash)
 
@@ -817,6 +818,7 @@ as argument."
                                         'magit-process-ok
                                       'magit-process-ng)))
           (set-marker-insertion-type marker t))
+        (ansi-color-apply-on-region (point) (point-max))   
         (if (= (magit-section-end section)
                (+ (line-end-position) 2))
             (save-excursion


### PR DESCRIPTION
This will make the `*magit-process*` buffer a little bit more readable in case git runs hooks which produce colored output, as well as the output of git itself (which I suppose you now run without colors).

It is still not ideal, for example we run eslint on prehook and it prints a lot of control characters like this

```
 ❯ Running tasks for *.js
   ⠙ build/jscs.sh
[?25l[1000D[1A[1000D[1A[1000D[1A[1000D[1A[1000D ↓ Running tasks for *.{php,phpt} [skipped]
```
(and about 30 lines of the same...), but at least the final report gets colorized and readable :)