### PR TITLE
magit{,-popup}.org: make sure org-src-preserve-indentation is nil

### DIFF
--- a/Documentation/magit-popup.org
+++ b/Documentation/magit-popup.org
@@ -654,4 +654,5 @@ General Public License for more details.
 # eval: (require 'ox-texinfo+ nil t)
 # eval: (and (require 'ox-extra nil t) (ox-extras-activate '(ignore-headlines)))
 # indent-tabs-mode: nil
+# org-src-preserve-indentation: nil
 # End:

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -6847,4 +6847,5 @@ General Public License for more details.
 # eval: (require 'ox-texinfo+ nil t)
 # eval: (and (require 'ox-extra nil t) (ox-extras-activate '(ignore-headlines)))
 # indent-tabs-mode: nil
+# org-src-preserve-indentation: nil
 # End:


### PR DESCRIPTION
This is the default, but a non-nil value changes the way whitespace in
literal blocks is handled during export, so make the assumption
explicit by a file-local variable.