### PR TITLE
Fix typo in key chord of git-commit-save-message

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3311,7 +3311,7 @@ stored at the beginning and the end of an edit session (regardless of
 whether the session is finished successfully or was canceled).  It is
 sometimes useful to bring back messages from that ring.
 
-- Key: C-s M-s, git-commit-save-message
+- Key: C-c M-s, git-commit-save-message
 
   Save the current buffer content to the commit message ring.
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -4573,9 +4573,9 @@ whether the session is finished successfully or was canceled).  It is
 sometimes useful to bring back messages from that ring.
 
 @table @asis
-@kindex C-s M-s
+@kindex C-c M-s
 @cindex git-commit-save-message
-@item @kbd{C-s M-s} @tie{}@tie{}@tie{}@tie{}(@code{git-commit-save-message})
+@item @kbd{C-c M-s} @tie{}@tie{}@tie{}@tie{}(@code{git-commit-save-message})
 
 Save the current buffer content to the commit message ring.
 


### PR DESCRIPTION
Looks like it should be `C-c, M-s`, not `C-s, M-s`.