### PR TITLE
magit-popup: locally set help-window-select and display-buffer-overriding-action

### DIFF
--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -961,7 +961,8 @@ and are defined in `magit-popup-mode-map' (which see)."
               (split-window-below)
               (with-no-warnings ; display-buffer-function is obsolete
                 (let ((display-buffer-alist nil)
-                      (display-buffer-function nil))
+                      (display-buffer-function nil)
+                      (display-buffer-overriding-action nil))
                   (woman topic)))
               (setq buffer (current-buffer)))
       (`man   (cl-letf (((symbol-function #'fboundp) (lambda (_) nil)))
@@ -991,6 +992,7 @@ and are defined in `magit-popup-mode-map' (which see)."
     (with-no-warnings ; display-buffer-function is obsolete
       (let ((display-buffer-alist '(("" display-buffer-use-some-window)))
             (display-buffer-function nil)
+            (display-buffer-overriding-action nil)
             (help-window-select nil))
         (describe-function function)))
     (fit-window-to-buffer)

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -990,7 +990,8 @@ and are defined in `magit-popup-mode-map' (which see)."
     (other-window 1)
     (with-no-warnings ; display-buffer-function is obsolete
       (let ((display-buffer-alist '(("" display-buffer-use-some-window)))
-            (display-buffer-function nil))
+            (display-buffer-function nil)
+            (help-window-select nil))
         (describe-function function)))
     (fit-window-to-buffer)
     (other-window 1)


### PR DESCRIPTION
Binding these variables is needed to ensure behavior that was implicitly assumed. Fixes #3173.