### PR TITLE
magit-run-git: Delete cache after running "init" or "clone"

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -292,6 +292,9 @@ Process output goes into a new section in the buffer returned by
 `magit-process-buffer'."
   (let ((magit--refresh-cache (list (cons 0 0))))
     (magit-call-git args)
+    (when (member (car args) '("init" "clone"))
+      ;; Creating a new repository invalidates the cache.
+      (setq magit--refresh-cache nil))
     (magit-refresh)))
 
 (defvar magit-pre-call-git-hook nil)


### PR DESCRIPTION
Fixes #3169.