### PR TITLE
Make highlighting keywords in brackets optional

### DIFF
--- a/Documentation/RelNotes/2.11.1.txt
+++ b/Documentation/RelNotes/2.11.1.txt
@@ -28,6 +28,11 @@ Changes since v2.11.0
   substitute for `magit-checkout'.  Setup instructions can be found in
   the manual.  #3104
 
+* Added new customizable options `magit-log-highlight-keywords' and
+  `magit-diff-highlight-keywords' which control whether text inside
+  brackets is highlighted in magit-log and magit-diff buffers
+  respectively.  #3190
+
 Fixes since v2.11.0
 -------------------
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -228,6 +228,13 @@ visits the file in the working tree."
   :group 'magit-diff
   :type 'boolean)
 
+(defcustom magit-diff-highlight-keywords t
+  "Whether to highlight keywords in brackets in commit
+messages."
+  :package-version '(magit . "2.11.1")
+  :group 'magit-diff
+  :type 'boolean)
+
 ;;;; File Diff
 
 (defcustom magit-diff-buffer-file-locked t
@@ -1874,11 +1881,12 @@ or a ref which is not a branch, then it inserts nothing."
           (forward-line)
           (put-text-property beg (point) 'face 'magit-section-secondary-heading)
           (magit-insert-heading))
-        (save-excursion
-          (while (re-search-forward "\\[[^[]*\\]" nil t)
-            (put-text-property (match-beginning 0)
-                               (match-end 0)
-                               'face 'magit-keyword)))
+        (when magit-diff-highlight-keywords
+          (save-excursion
+            (while (re-search-forward "\\[[^[]*\\]" nil t)
+              (put-text-property (match-beginning 0)
+                                 (match-end 0)
+                                 'face 'magit-keyword))))
         (goto-char (point-max))))))
 
 (defun magit-insert-revision-notes (rev)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -121,6 +121,13 @@ This is useful if you use really long branch names."
   :group 'magit-log
   :type 'boolean)
 
+(defcustom magit-log-highlight-keywords t
+  "Whether to highlight keywords in brackets in commit
+summaries."
+  :package-version '(magit . "2.11.1")
+  :group 'magit-log
+  :type 'boolean)
+
 (defface magit-log-graph
   '((((class color) (background light)) :foreground "grey30")
     (((class color) (background  dark)) :foreground "grey80"))
@@ -1034,9 +1041,10 @@ Do not add this to a hook variable."
           (let ((start 0))
             (while (string-match "\\[[^[]*\\]" msg start)
               (setq start (match-end 0))
-              (put-text-property (match-beginning 0)
-                                 (match-end 0)
-                                 'face 'magit-keyword msg)))
+              (when magit-log-highlight-keywords
+                (put-text-property (match-beginning 0)
+                                   (match-end 0)
+                                   'face 'magit-keyword msg))))
           (insert msg))
         (when (and refs magit-log-show-refname-after-summary)
           (insert ?\s)


### PR DESCRIPTION
Highlighting keywords in brackets is a useful feature in case the convention in the project is to use such brackets to mark references to issues and PRs (for example on github).

However, in our project such brackets are often used for other purposes and I dislike the highlighting, so I would like to make it optional. As far as I know, customizing the magit-keyword face does not work, because it is used in two different places where the surrounding characters have differing faces so I wouldn't know how to set the magit-keyword face such that it resolves to face A (in magit-log) and face B (in magit-diff). If you have an idea how to do this the patch here wouldn't be required and I would appreciate hearing it.

I would have preferred to add only one defcustom, but I didn't find a good place to put it. I guess it would have to go into magit.el since it would be used both in magit-log.el and magit-diff.el. But there are only two other defcustoms in magit.el so it doesn't seem like the proper way to do it. Let me know if you have an idea for a solution with only one defcustom.