### PR TITLE
Handle empty credential.cache value

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -101,8 +101,9 @@ When this is nil, no sections are ever removed."
 
 (defcustom magit-credential-cache-daemon-socket
   (--some (-let [(prog . args) (split-string it)]
-            (if (string-match-p
-                 "\\`\\(?:\\(?:/.*/\\)?git-credential-\\)?cache\\'" prog)
+            (if (and prog
+                     (string-match-p
+                      "\\`\\(?:\\(?:/.*/\\)?git-credential-\\)?cache\\'" prog))
                 (or (cl-loop for (opt val) on args
                              if (string= opt "--socket")
                              return val)


### PR DESCRIPTION
It is an intended use case for Git to override previously specified `credential.cache` values by providing an empty string as a new value. Fix the definition of `magit-credential-cache-daemon-socket` so that it handles this case, instead of throwing an error.