### PR TITLE
Align header-line contents with the text area

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1462,24 +1462,22 @@ Staging and applying changes is documented in info node
 In such buffers the buffer-local value of `magit-refresh-args'
 has the same form as the arguments of this function.  The value
 is set in `magit-mode-setup'."
-  (setq header-line-format
-        (propertize
-         (if (member "--no-index" const)
-             (apply #'format " Differences between %s and %s" files)
-           (concat (if rev-or-range
-                       (if (string-match-p "\\(\\.\\.\\|\\^-\\)"
-                                           rev-or-range)
-                           (format " Changes in %s" rev-or-range)
-                         (format " Changes from %s to working tree" rev-or-range))
-                     (if (member "--cached" const)
-                         " Staged changes"
-                       " Unstaged changes"))
-                   (pcase (length files)
-                     (0)
-                     (1 (concat " in file " (car files)))
-                     (_ (concat " in files "
-                                (mapconcat #'identity files ", "))))))
-         'face 'magit-header-line))
+  (magit-set-header-line-format
+   (if (member "--no-index" const)
+       (apply #'format "Differences between %s and %s" files)
+     (concat (if rev-or-range
+                 (if (string-match-p "\\(\\.\\.\\|\\^-\\)"
+                                     rev-or-range)
+                     (format "Changes in %s" rev-or-range)
+                   (format "Changes from %s to working tree" rev-or-range))
+               (if (member "--cached" const)
+                   "Staged changes"
+                 "Unstaged changes"))
+             (pcase (length files)
+               (0)
+               (1 (concat " in file " (car files)))
+               (_ (concat " in files "
+                          (mapconcat #'identity files ", ")))))))
   (magit-insert-section (diffbuf)
     (run-hook-with-args 'magit-diff-sections-hook rev-or-range)))
 
@@ -1814,15 +1812,15 @@ Staging and applying changes is documented in info node
               'magit-bookmark--revision-make-record))
 
 (defun magit-revision-refresh-buffer (rev __const _args files)
-  (setq header-line-format
-        (propertize (concat " " (capitalize (magit-object-type rev))
-                            " " rev
-                            (pcase (length files)
-                              (0)
-                              (1 (concat " limited to file " (car files)))
-                              (_ (concat " limited to files "
-                                         (mapconcat #'identity files ", ")))))
-                    'face 'magit-header-line))
+  (magit-set-header-line-format
+   (concat (capitalize (magit-object-type rev))
+           " "
+           rev
+           (pcase (length files)
+             (0)
+             (1 (concat " limited to file " (car files)))
+             (_ (concat " limited to files "
+                        (mapconcat #'identity files ", "))))))
   (setq magit-buffer-revision-hash (magit-rev-parse rev))
   (magit-insert-section (commitbuf)
     (run-hook-with-args 'magit-revision-sections-hook rev)))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -145,6 +145,11 @@ This is useful if you use really long branch names."
   "Face for the date part of the log output."
   :group 'magit-faces)
 
+(defface magit-header-line-log-select
+  '((t :inherit bold))
+  "Face for the `header-line' in `magit-log-select-mode'."
+  :group 'magit-faces)
+
 ;;;; File Log
 
 (defcustom magit-log-buffer-file-locked t
@@ -1279,19 +1284,27 @@ Type \\[magit-log-select-quit] to abort without selecting a commit."
   (setq magit-log-select-pick-function pick)
   (setq magit-log-select-quit-function quit)
   (when magit-log-select-show-usage
-    (setq msg (substitute-command-keys
-               (format-spec
-                (if msg
-                    (if (string-suffix-p "," msg)
-                        (concat msg " or %q to abort")
-                      msg)
-                  "Type %p to select commit at point, or %q to abort")
-                '((?p . "\\[magit-log-select-pick]")
-                  (?q . "\\[magit-log-select-quit]")))))
+    (let ((pick (propertize (substitute-command-keys
+                             "\\[magit-log-select-pick]")
+                            'face
+                            'magit-header-line-key))
+          (quit (propertize (substitute-command-keys
+                             "\\[magit-log-select-quit]")
+                            'face
+                            'magit-header-line-key)))
+      (setq msg (format-spec
+                 (if msg
+                     (if (string-suffix-p "," msg)
+                         (concat msg " or %q to abort")
+                       msg)
+                   "Type %p to select commit at point, or %q to abort")
+                 `((?p . ,pick)
+                   (?q . ,quit)))))
+    (add-face-text-property 0 (length msg) 'magit-header-line-log-select t msg)
     (when (memq magit-log-select-show-usage '(both header-line))
       (magit-set-header-line-format msg))
     (when (memq magit-log-select-show-usage '(both echo-area))
-      (message "%s" msg))))
+      (message "%s" (substring-no-properties msg)))))
 
 (defun magit-log-select-pick ()
   "Select the commit at point and act on it.

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -812,15 +812,14 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
   "Arguments which disable the graph speedup hack.")
 
 (defun magit-log-refresh-buffer (revs args files)
-  (setq header-line-format
-        (propertize
-         (concat " Commits in " (mapconcat 'identity revs  " ")
-                 (and files (concat " touching "
-                                    (mapconcat 'identity files " ")))
-                 (--some (and (string-prefix-p "-L" it)
-                              (concat " " it))
-                         args))
-         'face 'magit-header-line))
+  (magit-set-header-line-format
+   (concat "Commits in "
+           (mapconcat #'identity revs " ")
+           (and files (concat " touching "
+                              (mapconcat 'identity files " ")))
+           (--some (and (string-prefix-p "-L" it)
+                        (concat " " it))
+                   args)))
   (unless (= (length files) 1)
     (setq args (remove "--follow" args)))
   (when (--any-p (string-match-p
@@ -1290,7 +1289,7 @@ Type \\[magit-log-select-quit] to abort without selecting a commit."
                 '((?p . "\\[magit-log-select-pick]")
                   (?q . "\\[magit-log-select-quit]")))))
     (when (memq magit-log-select-show-usage '(both header-line))
-      (setq header-line-format (propertize (concat " " msg) 'face 'bold)))
+      (magit-set-header-line-format msg))
     (when (memq magit-log-select-show-usage '(both echo-area))
       (message "%s" msg))))
 
@@ -1397,8 +1396,7 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
               'magit-bookmark--reflog-make-record))
 
 (defun magit-reflog-refresh-buffer (ref args)
-  (setq header-line-format
-        (propertize (concat " Reflog for " ref) 'face 'magit-header-line))
+  (magit-set-header-line-format (concat "Reflog for " ref))
   (magit-insert-section (reflogbuf)
     (magit-git-wash (apply-partially 'magit-log-wash-log 'reflog)
       "reflog" "show" "--format=%h%x00%aN%x00%gd%x00%gs" "--date=raw"

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -1247,7 +1247,7 @@ variable whose value may be used as a default."
     (when fun
       (setq dsc
             (-when-let (branch (funcall fun))
-              (if (next-single-property-change 0 'face (concat "0" branch))
+              (if (text-property-not-all 0 (length branch) 'face nil branch)
                   branch
                 (magit-branch-set-face branch)))))
     (when dsc

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -219,9 +219,8 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
     (setq ref "HEAD"))
   (unless (magit-rev-verify ref)
     (setq magit-refs-show-commit-count nil))
-  (setq header-line-format
-        (propertize (format " %s %s" ref (mapconcat #'identity args " "))
-                    'face 'magit-header-line))
+  (magit-set-header-line-format
+   (format "%s %s" ref (mapconcat #'identity args " ")))
   (magit-insert-section (branchbuf)
     (run-hooks 'magit-refs-sections-hook)))
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -778,7 +778,7 @@ insert a newline character if necessary."
   (declare (indent defun))
   (when args
     (let ((heading (apply #'concat args)))
-      (insert (if (next-single-property-change 0 'face (concat "0" heading))
+      (insert (if (text-property-not-all 0 (length heading) 'face nil heading)
                   heading
                 (propertize heading 'face 'magit-section-heading)))))
   (unless (bolp)

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -398,10 +398,10 @@ instead of \"Stashes:\"."
               #'magit-bookmark--stash-make-record))
 
 (defun magit-stash-refresh-buffer (stash _const _args _files)
-  (setq header-line-format
-        (concat
-         "\s" (propertize (capitalize stash) 'face 'magit-section-heading)
-         "\s" (magit-rev-format "%s" stash)))
+  (magit-set-header-line-format
+   (concat (propertize (capitalize stash) 'face 'magit-section-heading)
+           " "
+           (magit-rev-format "%s" stash)))
   (setq magit-buffer-revision-hash (magit-rev-parse stash))
   (magit-insert-section (stash)
     (run-hooks 'magit-stash-sections-hook)))

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -603,12 +603,21 @@ Unless optional argument KEEP-EMPTY-LINES is t, trim all empty lines."
 (defun magit-set-header-line-format (string)
   "Set the header-line using STRING.
 Propertize STRING with the `magit-header-line' face if no face is
-present, and make sure it aligns with the text area."
+present, and pad the left and right sides of STRING equally such
+that it will align with the text area."
   (let ((header-line
          (concat (propertize " "
                              'display
                              '(space :align-to 0))
-                 string)))
+                 string
+                 (propertize
+                  " "
+                  'display
+                  `(space :width (+ left-fringe
+                                    left-margin
+                                    ,@(and (eq (car (window-current-scroll-bars))
+                                               'left)
+                                           '(scroll-bar))))))))
     (setq header-line-format
           (if (text-property-not-all 0 (length header-line) 'face nil header-line)
               header-line

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -600,6 +600,22 @@ Unless optional argument KEEP-EMPTY-LINES is t, trim all empty lines."
       (insert-file-contents file)
       (split-string (buffer-string) "\n" (not keep-empty-lines)))))
 
+(defun magit-set-header-line-format (string)
+  "Set the header-line using STRING.
+Propertize STRING with the `magit-header-line' face if no face is
+present, and make sure it aligns with the text area."
+  (let ((header-line
+         (concat (propertize " "
+                             'display
+                             '(space :align-to 0))
+                 string)))
+    (setq header-line-format
+          (if (text-property-not-all 0 (length header-line) 'face nil header-line)
+              header-line
+            (propertize header-line
+                        'face
+                        'magit-header-line)))))
+
 ;;; Missing from Emacs
 
 (defun magit-kill-this-buffer ()

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -75,7 +75,15 @@
 
 (defface magit-header-line
   '((t :inherit magit-section-heading))
-  "Face for the `header-line'."
+  "Face for the `header-line' in some Magit modes.
+Note that some modes, such as `magit-log-select-mode', have their
+own faces for the `header-line', or for parts of the
+`header-line'."
+  :group 'magit-faces)
+
+(defface magit-header-line-key
+  '((t :inherit magit-popup-key))
+  "Face for keys in the `header-line'."
   :group 'magit-faces)
 
 (defface magit-dimmed

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -268,10 +268,9 @@ inspect the merge and change the commit message.
 (defun magit-merge-preview-refresh-buffer (rev)
   (let* ((branch (magit-get-current-branch))
          (head (or branch (magit-rev-verify "HEAD"))))
-    (setq header-line-format
-          (propertize (format "Preview merge of %s into %s"
-                              rev (or branch "HEAD"))
-                      'face 'magit-header-line))
+    (magit-set-header-line-format (format "Preview merge of %s into %s"
+                                          rev
+                                          (or branch "HEAD")))
     (magit-insert-section (diffbuf)
       (magit-git-wash #'magit-diff-wash-diffs
         "merge-tree" (magit-git-string "merge-base" head rev) head rev))))


### PR DESCRIPTION
A space is not a robust alignment; the left fringe may not be the same pixel
width as a space, and there may not even be a fringe present (e.g., terminal
Emacs).

In my current installation, the fringe width is one pixel less than the width of a space, and once you see that one pixel offset you just can't ignore it.