### PR TITLE
Use --format with \0 separated fields in refs buffer

### DIFF
--- a/Documentation/RelNotes/2.12.0.txt
+++ b/Documentation/RelNotes/2.12.0.txt
@@ -44,6 +44,9 @@ Changes since v2.11.0
   for information on how to best use this and other blaming commands.
   #3055
 
+* Kewords in brackets are now being highlighted in `magit-refs-mode'
+  buffers like they already were in logs.  #3179
+
 Fixes since v2.11.0
 -------------------
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1037,14 +1037,7 @@ Do not add this to a hook variable."
                                     (?Y 'magit-signature-expired-key)
                                     (?R 'magit-signature-revoked)
                                     (?E 'magit-signature-error)))))
-          (let ((start 0))
-            (while (string-match "\\[[^[]*\\]" msg start)
-              (setq start (match-end 0))
-              (when magit-log-highlight-keywords
-                (put-text-property (match-beginning 0)
-                                   (match-end 0)
-                                   'face 'magit-keyword msg))))
-          (insert msg))
+          (insert (magit-log-propertize-keywords msg)))
         (when (and refs magit-log-show-refname-after-summary)
           (insert ?\s)
           (insert (magit-format-ref-labels refs)))
@@ -1107,6 +1100,16 @@ Do not add this to a hook variable."
               (unless (string-match-p "[/\\]" graph)
                 (insert graph ?\n))))))))
   t)
+
+(defun magit-log-propertize-keywords (msg)
+  (let ((start 0))
+    (while (string-match "\\[[^[]*\\]" msg start)
+      (setq start (match-end 0))
+      (when magit-log-highlight-keywords
+        (put-text-property (match-beginning 0)
+                           (match-end 0)
+                           'face 'magit-keyword msg))))
+  msg)
 
 (defun magit-log-maybe-show-more-commits (section)
   "When point is at the end of a log buffer, insert more commits.

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -490,7 +490,7 @@ line is inserted at all."
        `((?c . ,(or mark count ""))
          (?C . ,(or mark " "))
          (?h . ,(or (propertize hash 'face 'magit-hash) ""))
-         (?m . ,(or message ""))
+         (?m . ,(magit-log-propertize-keywords (or message "")))
          (?n . ,(propertize (or branch "(detached)") 'face face))
          (?u . ,(or upstream ""))
          (?U . ,(if upstream

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -487,11 +487,11 @@ line is inserted at all."
   "For internal use, don't add to a hook."
   (unless magit-refs-show-commit-count
     (setq format (replace-regexp-in-string "%[0-9]\\([cC]\\)" "%1\\1" format t)))
-  (if (equal branch "HEAD")
-      (magit-insert-section it (commit (magit-rev-parse "HEAD") t)
-        (apply #'magit-insert-branch-1 it nil format args))
-    (magit-insert-section it (branch branch t)
-      (apply #'magit-insert-branch-1 it branch format args))))
+  (if branch
+      (magit-insert-section it (branch branch t)
+        (apply #'magit-insert-branch-1 it branch format args))
+    (magit-insert-section it (commit (magit-rev-parse "HEAD") t)
+      (apply #'magit-insert-branch-1 it nil format args))))
 
 (defun magit-insert-branch-1
     (section branch format current branches face

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -471,12 +471,12 @@ line is inserted at all."
         (dolist (line (magit-git-lines "branch" "-vvr"
                                        (cadr magit-refresh-args)))
           (cond
+           ((string-prefix-p (concat remote "/") branch)) ; noop
            ((string-match magit-refs-branch-line-re line)
             (magit-bind-match-strings (branch hash message) line
-              (when (string-match-p (format "^%s/" remote) branch)
-                (magit-insert-branch
-                 branch magit-refs-remote-branch-format current branches
-                 'magit-branch-remote hash message))))
+              (magit-insert-branch
+               branch magit-refs-remote-branch-format current branches
+               'magit-branch-remote hash message)))
            ((string-match magit-refs-symref-line-re line)
             (magit-bind-match-strings (symref ref) line
               (magit-insert-symref symref ref 'magit-branch-remote))))))

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -426,13 +426,13 @@ Insert a header line with the name and description of the
 current branch.  The description is taken from the Git variable
 `branch.<NAME>.description'; if that is undefined then no header
 line is inserted at all."
-  (let ((branch (magit-get-current-branch)))
-    (-when-let* ((desc (magit-get "branch" branch "description"))
-                 (desc-lines (split-string desc "\n")))
-      (magit-insert-section (branchdesc branch t)
-        (magit-insert-heading branch ": " (car desc-lines))
-        (insert (mapconcat 'identity (cdr desc-lines) "\n"))
-        (insert "\n\n")))))
+  (-when-let* ((branch (magit-get-current-branch))
+               (desc (magit-get "branch" branch "description"))
+               (desc-lines (split-string desc "\n")))
+    (magit-insert-section (branchdesc branch t)
+      (magit-insert-heading branch ": " (car desc-lines))
+      (insert (mapconcat 'identity (cdr desc-lines) "\n"))
+      (insert "\n\n"))))
 
 (defun magit-insert-local-branches ()
   "Insert sections showing all local branches."

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -450,10 +450,7 @@ line is inserted at all."
               (setq branch nil))
             (magit-insert-branch
              branch magit-refs-local-branch-format current branches
-             'magit-branch-local hash message upstream ahead behind gone)))
-         ((string-match magit-refs-symref-line-re line)
-          (magit-bind-match-strings (symref ref) line
-            (magit-insert-symref symref ref 'magit-branch-local))))))
+             'magit-branch-local hash message upstream ahead behind gone))))))
     (insert ?\n)
     (magit-make-margin-overlay nil t)))
 

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -500,11 +500,11 @@ line is inserted at all."
          (?u . ,(or upstream ""))
          (?U . ,(if upstream
                     (format (propertize "[%s%s] " 'face 'magit-dimmed)
-                            upstream
-                            (if utrack
-                                (concat ":" (if (equal utrack "gone")
-                                                (propertize "gone" 'face 'error)
-                                              utrack))
+                            (if (equal utrack "gone")
+                                (propertize upstream 'face 'error)
+                              upstream)
+                            (if (and utrack (not (equal utrack "gone")))
+                                (concat " " utrack)
                               ""))
                   "")))))
     (when (magit-buffer-margin-p)

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -469,9 +469,9 @@ line is inserted at all."
       (let ((current  (magit-get-current-branch))
             (branches (magit-list-local-branch-names)))
         (dolist (line (magit-git-lines "branch" "-vvr"
+                                       "--list" (concat remote "/*")
                                        (cadr magit-refresh-args)))
           (cond
-           ((string-prefix-p (concat remote "/") branch)) ; noop
            ((string-match magit-refs-branch-line-re line)
             (magit-bind-match-strings (branch hash message) line
               (magit-insert-branch

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -483,14 +483,7 @@ line is inserted at all."
                            (propertize "@" 'face 'magit-head)
                          (propertize "#" 'face 'magit-tag)))
                       ((equal branch current)
-                       (propertize "." 'face 'magit-head))))
-         (ahead  (and utrack
-                      (string-match "ahead \\([0-9]+\\)" utrack)
-                      (match-string 1 utrack)))
-         (behind (and utrack
-                      (string-match "behind \\([0-9]+\\)" utrack)
-                      (match-string 1 utrack)))
-         (gone   (equal utrack "gone")))
+                       (propertize "." 'face 'magit-head)))))
     (when upstream
       (setq upstream (propertize upstream 'face
                                  (if (member upstream branches)
@@ -499,9 +492,7 @@ line is inserted at all."
     (magit-insert-heading
       (format-spec
        format
-       `((?a . ,(or ahead ""))
-         (?b . ,(or behind ""))
-         (?c . ,(or mark count ""))
+       `((?c . ,(or mark count ""))
          (?C . ,(or mark " "))
          (?h . ,(or (propertize hash 'face 'magit-hash) ""))
          (?m . ,(or message ""))
@@ -510,15 +501,11 @@ line is inserted at all."
          (?U . ,(if upstream
                     (format (propertize "[%s%s] " 'face 'magit-dimmed)
                             upstream
-                            (cond
-                             (gone
-                              (concat ": " (propertize gone 'face 'error)))
-                             ((or ahead behind)
-                              (concat ": "
-                                      (and ahead (format "ahead %s" ahead))
-                                      (and ahead behind ", ")
-                                      (and behind (format "behind %s" behind))))
-                             (t "")))
+                            (if utrack
+                                (concat ":" (if (equal utrack "gone")
+                                                (propertize "gone" 'face 'error)
+                                              utrack))
+                              ""))
                   "")))))
     (when (magit-buffer-margin-p)
       (magit-refs-format-margin branch))


### PR DESCRIPTION
And other cleanup. Keywords are now properly highlighted.

Closes #3179.