### PR TITLE
magit-insert-{local,remote}-branches: use for-each-ref

### DIFF
--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -418,9 +418,10 @@ line is inserted at all."
   "Insert sections showing all local branches."
   (magit-insert-section (local nil)
     (magit-insert-heading "Branches:")
-    (dolist (line (magit-git-lines "branch" "--format=\
+    (dolist (line (magit-git-lines "for-each-ref" "--format=\
 %(HEAD)%00%(refname:short)%00%(objectname:short)%00%(subject)%00\
 %(upstream:short)%00%(upstream)%00%(upstream:track,nobracket)"
+                                   "refs/heads"
                                    (cadr magit-refresh-args)))
       (pcase-let ((`(,head ,branch ,hash ,message
                            ,upstream ,uref ,utrack)
@@ -441,9 +442,9 @@ line is inserted at all."
               (push (magit-get "remote" remote "pushurl")))
           (format "%s (%s):" (capitalize remote)
                   (concat pull (and pull push ", ") push))))
-      (dolist (line (magit-git-lines "branch" "-r" "--format=\
+      (dolist (line (magit-git-lines "for-each-ref" "--format=\
 %(symref:short)%00%(refname:short)%00%(objectname:short)%00%(subject)"
-                                     "--list" (concat remote "/*")
+                                     (concat "refs/remotes/" remote)
                                      (cadr magit-refresh-args)))
         (pcase-let ((`(,symref ,branch ,hash ,message)
                      (-replace "" nil (split-string line "\0"))))


### PR DESCRIPTION
```
9cac1f53 (magit-insert-{local,remote}-branches: use NUL separated
fields, 2017-10-11) breaks magit-show-refs because "git branch" does
not support the --format option in Git versions earlier than 2.13.

[WIP] We can *almost* use for-each-ref as a drop-in replacement.  The
only discrepancy I've noticed is that the local refs do not include an
entry for a detached head.  At first glance, I don't see an issue with
dropping this because the buffer is about listing refs.  Thoughts?
```

Fixes #3203.