### PR TITLE
Fix man page search

### DIFF
--- a/lisp/magit-imenu.el
+++ b/lisp/magit-imenu.el
@@ -33,7 +33,7 @@
 
 ;;; Code:
 
-(require 'subr-x)
+(eval-when-compile (require 'subr-x))
 
 (require 'magit)
 (require 'git-rebase)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -348,7 +348,7 @@ the upstream isn't ahead of the current branch) show."
                (?S "Show signatures"         "--show-signature")
                (?u "Show diffs"              "--patch")
                (?s "Show diffstats"          "--stat")
-               (?h "Show header"             "++header")
+               (?h "Show header"             "++header" magit-log++header)
                (?D "Simplify by decoration"  "--simplify-by-decoration")
                (?f "Follow renames when showing single-file log" "--follow"))
     :options  ((?n "Limit number of commits" "-n")
@@ -432,10 +432,20 @@ the upstream isn't ahead of the current branch) show."
       (user-error "Trace is invalid, see man git-log"))))
 
 (defun magit-log-select-order (&rest _ignored)
+  "Set one `--<value>-order' option in Git log.
+This encompasses the options `--author-date-order',
+`--date-order', and `--topo-order'."
   (magit-read-char-case "Order commits by " t
     (?t "[t]opography"     "topo")
     (?a "[a]uthor date"    "author-date")
     (?c "[c]ommitter date" "date")))
+
+;; This is a dummy procedure used to show help in `magit-log-popup'.
+(defun magit-log++header ()
+  "Insert a header after each revision summary in Git log.
+Customize `magit-log-revision-headers-format' to change this
+header."
+  nil)
 
 (defun magit-log-get-buffer-args ()
   (cond ((and magit-use-sticky-arguments

--- a/lisp/magit-notes.el
+++ b/lisp/magit-notes.el
@@ -34,7 +34,7 @@
 ;;;###autoload (autoload 'magit-notes-popup "magit" nil t)
 (magit-define-popup magit-notes-popup
   "Popup console for notes commands."
-  :man-page "git-tag"
+  :man-page "git-notes"
   :switches '("Switch for prune"
               (?n "Dry run"          "--dry-run"))
   :options  '("Option for edit and remove"

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -956,7 +956,16 @@ and are defined in `magit-popup-mode-map' (which see)."
     (user-error "No man page associated with %s"
                 (magit-popup-get :man-page)))
   (when arg
-    (setq arg (magit-popup-event-arg arg)))
+    (setq arg (magit-popup-event-arg arg))
+    (when (string-prefix-p "--" arg)
+      ;; handle --[no-] options
+      (setq arg (if (string-prefix-p "--no-" arg)
+                    (concat "--"
+                            "\\[?no-\\]?"
+                            (substring arg 5))
+                  (concat "--"
+                          "\\(?:\\[no-\\]\\)?"
+                          (substring arg 2))))))
   (let ((winconf (current-window-configuration)) buffer)
     (pcase magit-popup-manpage-package
       (`woman (delete-other-windows)

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -958,14 +958,17 @@ and are defined in `magit-popup-mode-map' (which see)."
   (when arg
     (setq arg (magit-popup-event-arg arg))
     (when (string-prefix-p "--" arg)
-      ;; handle --[no-] options
-      (setq arg (if (string-prefix-p "--no-" arg)
-                    (concat "--"
-                            "\\[?no-\\]?"
-                            (substring arg 5))
-                  (concat "--"
-                          "\\(?:\\[no-\\]\\)?"
-                          (substring arg 2))))))
+      ;; handle '--' option and the '--[no-]' shorthand
+      (setq arg (cond ((string= "-- " arg)
+                       "\\(?:\\[--\\] \\)?<[^[:space:]]+>\\.\\.\\.")
+                      ((string-prefix-p "--no-" arg)
+                       (concat "--"
+                               "\\[?no-\\]?"
+                               (substring arg 5)))
+                      (t
+                       (concat "--"
+                               "\\(?:\\[no-\\]\\)?"
+                               (substring arg 2)))))))
   (let ((winconf (current-window-configuration)) buffer)
     (pcase magit-popup-manpage-package
       (`woman (delete-other-windows)

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -934,9 +934,13 @@ and are defined in `magit-popup-mode-map' (which see)."
                   (lookup-key (current-global-map) key))))
     (pcase def
       (`magit-invoke-popup-switch
-       (magit-popup-manpage man (magit-popup-lookup int :switches)))
+       (--if-let (magit-popup-lookup int :switches)
+           (magit-popup-manpage man it)
+         (user-error "%c isn't bound to any switch" int)))
       (`magit-invoke-popup-option
-       (magit-popup-manpage man (magit-popup-lookup int :options)))
+       (--if-let (magit-popup-lookup int :options)
+           (magit-popup-manpage man it)
+         (user-error "%c isn't bound to any option" int)))
       (`magit-popup-help
        (magit-popup-manpage man nil))
       ((or `self-insert-command

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -1002,7 +1002,7 @@ and are defined in `magit-popup-mode-map' (which see)."
                  (re-search-forward
                   ;; should start with whitespace, and may have any
                   ;; number of options before/after
-                  (format "^[\t\s]+\\(?:%s, \\)*%s%s\\(?:, %s\\)*$"
+                  (format "^[\t\s]+\\(?:%s, \\)*?\\(?1:%s\\)%s\\(?:, %s\\)*$"
                           others
                           ;; options don't necessarily end in an '='
                           ;; (e.g., '--gpg-sign[=<keyid>]')
@@ -1031,7 +1031,7 @@ and are defined in `magit-popup-mode-map' (which see)."
                           others)
                   nil
                   t)))
-          (goto-char (1+ (match-beginning 0)))
+          (goto-char (match-beginning 1))
         (goto-char (point-min))))))
 
 (defun magit-popup-describe-function (function)

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -935,11 +935,17 @@ and are defined in `magit-popup-mode-map' (which see)."
     (pcase def
       (`magit-invoke-popup-switch
        (--if-let (magit-popup-lookup int :switches)
-           (magit-popup-manpage man it)
+           (if (and (string-prefix-p "++" (magit-popup-event-arg it))
+                    (magit-popup-event-fun it))
+               (magit-popup-describe-function (magit-popup-event-fun it))
+             (magit-popup-manpage man it))
          (user-error "%c isn't bound to any switch" int)))
       (`magit-invoke-popup-option
        (--if-let (magit-popup-lookup int :options)
-           (magit-popup-manpage man it)
+           (if (and (string-prefix-p "++" (magit-popup-event-arg it))
+                    (magit-popup-event-fun it))
+               (magit-popup-describe-function (magit-popup-event-fun it))
+             (magit-popup-manpage man it))
          (user-error "%c isn't bound to any option" int)))
       (`magit-popup-help
        (magit-popup-manpage man nil))

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -389,7 +389,11 @@ or `:only' which doesn't change the behaviour."
     (let ((a (nth 2 it)))
       (make-magit-popup-event
        :key (car it) :dsc (cadr it) :arg a
-       :use (and (member a val) t)))))
+       :use (and (member a val) t)
+       ;; For arguments implemented in lisp, this function's
+       ;; doc-string is used by `magit-popup-help'.  That is
+       ;; the only thing it is used for.
+       :fun (and (string-prefix-p "\+\+" a) (nth 3 it))))))
 
 (defun magit-popup-convert-options (val def)
   (magit-popup-convert-events def

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -29,7 +29,7 @@
 
 (require 'magit)
 
-(require 'subr-x)
+(eval-when-compile (require 'subr-x))
 
 (defvar bookmark-make-record-function)
 


### PR DESCRIPTION
I noticed that searching the man pages didn't work very often, so I thought I would fix it. Unfortunately, I didn't expect that there would be so many edge cases, so the end result looks awful. Perhaps I should put more comments in?

There are still two cases that aren't handled, though. The first is the `--` argument, which is sometimes absent and sometimes present as `[--]`, and the options that start with `++` (e.g., those in `magit-log-popup`). What would you like to happen with those? Should the `++` options have their own help pages?

I also made it a `user-error` to try and bring up the man page for an invalid option/switch.