### PR TITLE
Bind [tab] whenever "C-i" is bound

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -358,6 +358,7 @@ starts complicating other things, then it will be removed."
            (define-key map (kbd "C-m") 'magit-visit-thing)
            (define-key map (kbd "C-M-i") 'magit-dired-jump)
            (define-key map (kbd "C-i") 'magit-section-toggle)
+           (define-key map [tab]       'magit-section-toggle)
            (define-key map [C-tab]     'magit-section-cycle)
            (define-key map [M-tab]     'magit-section-cycle-diffs)
            ;; [backtab] is the most portable binding for Shift+Tab.

--- a/lisp/magit-popup.el
+++ b/lisp/magit-popup.el
@@ -188,6 +188,7 @@ before entering a popup has.
            (define-key map (kbd "DEL") 'backward-button)
            (define-key map (kbd "C-p") 'backward-button)
            (define-key map (kbd "C-i") 'forward-button)
+           (define-key map [tab]       'forward-button)
            (define-key map (kbd "C-n") 'forward-button)))
     map)
   "Keymap for `magit-popup-mode'.

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -550,6 +550,7 @@ defaulting to the tag at point.
            (define-key map [return] 'magit-invoke-popup-action))
           (t
            (define-key map (kbd "C-i") 'magit-invoke-popup-action)
+           (define-key map [tab]       'magit-invoke-popup-action)
            (define-key map (kbd "C-m") 'magit-invoke-popup-action)))
     map)
   "Keymap used by `magit-dispatch-popup'.")


### PR DESCRIPTION
Same people have [tab] and "C-i" uncoupled so that binding to "C-i" will
not necessarily bind to the tab key.

Thus we should bind to <tab> whenever we bind to "C-i".