### PR TITLE
swap args 2 & 3 in magit-ediff-stage's call to magit-completing-read

### DIFF
--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -159,8 +159,8 @@ conflicts, including those already resolved by Git, use
   "Stage and unstage changes to FILE using Ediff.
 FILE has to be relative to the top directory of the repository."
   (interactive
-   (list (magit-completing-read "Selectively stage file" nil
-                                (magit-tracked-files) nil nil nil
+   (list (magit-completing-read "Selectively stage file"
+                                (magit-tracked-files) nil nil nil nil
                                 (magit-current-file))))
   (magit-with-toplevel
     (let* ((conf (current-window-configuration))


### PR DESCRIPTION
I was getting an error when I tried to use `magit-ediff-stage` where emacs would try to call the list of tracked files as a function, resulting in an error like this:

    Invalid function: (".gitignore" .....)

It seemed to me after a little investigation that this was happening because of `magit-ediff-stage` calling out to `magit-completing-read` with `(magit-tracked-files)` as the PREDICATE argument, when it should be COLLECTION (which was `nil`).

This pull request simply swaps those two arguments in that particular function call: now the call to `magit-completing-read` from `magit-ediff-stage` uses `(magit-tracked-files)` as the candidates, and `nil` as the predicate. An hour or two of casual use hasn't turned up any errors for me, so I thought I'd submit the change. 