### PR TITLE
Always display a diff while committing and improve toggling

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -862,7 +862,6 @@ be committed."
   (unless (magit-commit-message-buffer)
     (user-error "No commit in progress"))
   (let ((magit-display-buffer-noselect t)
-        (toplevel (magit-toplevel))
         (diff-buf (magit-mode-get-buffer 'magit-diff-mode)))
     (if (and (or ;; most likely an explicit amend
                  (not (magit-anything-staged-p))
@@ -870,10 +869,8 @@ be committed."
                  (and (eq (current-buffer) diff-buf)))
              (or (not diff-buf)
                  (with-current-buffer diff-buf
-                   (or ;; default to include last commit
-                       (not (equal (magit-toplevel) toplevel))
-                       ;; toggle to include last commit
-                       (not (car magit-refresh-args))))))
+                   ;; toggle to include last commit
+                   (not (car magit-refresh-args)))))
         (magit-diff-while-amending args)
       (magit-diff-staged nil args))))
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -859,23 +859,23 @@ While amending, invoking the command again toggles between
 showing just the new changes or all the changes that will
 be committed."
   (interactive (list (car (magit-diff-arguments))))
+  (unless (magit-commit-message-buffer)
+    (user-error "No commit in progress"))
   (let ((magit-display-buffer-noselect t)
         (toplevel (magit-toplevel))
         (diff-buf (magit-mode-get-buffer 'magit-diff-mode)))
-    (if (magit-commit-message-buffer)
-        (if (and (or ;; most likely an explicit amend
-                     (not (magit-anything-staged-p))
-                     ;; explicitly toggled from within diff
-                     (and (eq (current-buffer) diff-buf)))
-                 (or (not diff-buf)
-                     (with-current-buffer diff-buf
-                       (or ;; default to include last commit
-                           (not (equal (magit-toplevel) toplevel))
-                           ;; toggle to include last commit
-                           (not (car magit-refresh-args))))))
-            (magit-diff-while-amending args)
-          (magit-diff-staged nil args))
-      (user-error "No commit in progress"))))
+    (if (and (or ;; most likely an explicit amend
+                 (not (magit-anything-staged-p))
+                 ;; explicitly toggled from within diff
+                 (and (eq (current-buffer) diff-buf)))
+             (or (not diff-buf)
+                 (with-current-buffer diff-buf
+                   (or ;; default to include last commit
+                       (not (equal (magit-toplevel) toplevel))
+                       ;; toggle to include last commit
+                       (not (car magit-refresh-args))))))
+        (magit-diff-while-amending args)
+      (magit-diff-staged nil args))))
 
 (define-key git-commit-mode-map
   (kbd "C-c C-d") 'magit-diff-while-committing)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -859,7 +859,8 @@ While amending, invoking the command again toggles between
 showing just the new changes or all the changes that will
 be committed."
   (interactive (list (car (magit-diff-arguments))))
-  (let ((toplevel (magit-toplevel))
+  (let ((magit-display-buffer-noselect t)
+        (toplevel (magit-toplevel))
         (diff-buf (magit-mode-get-buffer 'magit-diff-mode)))
     (if (magit-commit-message-buffer)
         (if (and (or ;; most likely an explicit amend

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -864,11 +864,12 @@ be committed."
   (let ((magit-display-buffer-noselect t)
         (diff-buf (magit-mode-get-buffer 'magit-diff-mode)))
     (if diff-buf
-        (if (eq diff-buf (window-buffer (selected-window)))
-            ;; Attempt to toggle (may fail).
-            (if (car magit-refresh-args)
-                (magit-diff-staged nil args)
-              (magit-diff-while-amending args))
+        (if (get-buffer-window diff-buf)
+            (with-current-buffer diff-buf
+              ;; Attempt to toggle (may fail).
+              (if (car magit-refresh-args)
+                  (magit-diff-staged nil args)
+                (magit-diff-while-amending args)))
           (with-current-buffer diff-buf
             ;; If there are staged changes, then show them.
             ;; Otherwise toggle from amend to staged (empty).

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -853,12 +853,12 @@ a commit read from the minibuffer."
   (magit-diff-setup nil nil args files))
 
 ;;;###autoload
-(defun magit-diff-while-committing (&optional args files)
+(defun magit-diff-while-committing (&optional args)
   "While committing, show the changes that are about to be committed.
 While amending, invoking the command again toggles between
 showing just the new changes or all the changes that will
 be committed."
-  (interactive (magit-diff-arguments))
+  (interactive (list (car (magit-diff-arguments))))
   (let ((toplevel (magit-toplevel))
         (diff-buf (magit-mode-get-buffer 'magit-diff-mode)))
     (if (magit-commit-message-buffer)
@@ -872,15 +872,15 @@ be committed."
                            (not (equal (magit-toplevel) toplevel))
                            ;; toggle to include last commit
                            (not (car magit-refresh-args))))))
-            (magit-diff-while-amending args files)
-          (magit-diff-staged nil args files))
+            (magit-diff-while-amending args)
+          (magit-diff-staged nil args))
       (user-error "No commit in progress"))))
 
 (define-key git-commit-mode-map
   (kbd "C-c C-d") 'magit-diff-while-committing)
 
-(defun magit-diff-while-amending (&optional args files)
-  (magit-diff-setup "HEAD^" (list "--cached") args files))
+(defun magit-diff-while-amending (&optional args)
+  (magit-diff-setup "HEAD^" (list "--cached") args nil))
 
 ;;;###autoload
 (defun magit-diff-buffer-file ()


### PR DESCRIPTION
Following the discussion in #3199 I have implemented this like so:

* Separate the task of initially displaying the most suitable diff and toggling.
* Displaying the initial diff is done by `magit-commit-diff` alone.
  * We considered to instead hand of that task to the black-box `magit-diff-while-committing` if we cannot decide based on `last-command`. Now that that function no longer is a black-box I was able to tell that that wouldn't have been a good idea :wink: 
* Toggling is done in `magit-diff-while-committing`.
  * Toggling is only done if the buffer previously displayed "the other" diff.
    * Previously we tried doing that too in most cases, but not in a reliable fashion and not in all cases.
  * Else the most appropriate diff is displayed. This can become necessary if the user previously killed the buffer.
* And, somewhat unrelated, `magit-diff-while-committing` now stays in the commit buffer.

Closes #3199.