### PR TITLE
Improve interface in case of 'git am' failure

### DIFF
--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -104,6 +104,7 @@ so causes the change to be applied to the index as well."
       (`(,_ region) (magit-apply-region it args))
       (`(,_   hunk) (magit-apply-hunk   it args))
       (`(,_  hunks) (magit-apply-hunks  it args))
+      (`(rebase-sequence file) (magit-patch-apply-popup))
       (`(,_   file) (magit-apply-diff   it args))
       (`(,_  files) (magit-apply-diffs  it args)))))
 

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -485,10 +485,11 @@ If DEFAULT is non-nil, use this as the default value instead of
 
 (defun magit-patch-apply (file &rest args)
   "Apply the patch file FILE."
-  (interactive (list (read-file-name "Apply patch: "
-                                     default-directory nil nil
-                                     (--when-let (magit-file-at-point)
-                                       (file-relative-name it)))
+  (interactive (list (expand-file-name
+                      (read-file-name "Apply patch: "
+                                      default-directory nil nil
+                                      (--when-let (magit-file-at-point)
+                                        (file-relative-name it))))
                      (magit-patch-apply-arguments)))
   (magit-run-git "apply" args "--" file))
 

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -573,9 +573,16 @@ If no such sequence is in progress, do nothing."
 
 (defun magit-sequence-insert-am-patch (type patch face)
   (magit-insert-section (file patch)
-    (insert (propertize type 'face face)
-            ?\s (propertize (file-name-nondirectory patch) 'face 'magit-hash)
-            ?\n)))
+    (let ((title
+           (with-temp-buffer
+             (insert-file-contents patch nil nil 4096)
+             (unless (re-search-forward "^Subject: " nil t)
+               (goto-char (point-min)))
+             (buffer-substring (point) (line-end-position)))))
+      (insert (propertize type 'face face)
+              ?\s (propertize (file-name-nondirectory patch) 'face 'magit-hash)
+              ?\s title
+              ?\n))))
 
 (defun magit-insert-rebase-sequence ()
   "Insert section for the on-going rebase sequence.


### PR DESCRIPTION
Currently, when `git am` fails, e.g, [if the patch was corruped by line wrapping](https://debbugs.gnu.org/cgi/bugreport.cgi?bug=28308#117), the sections magit presents are a bit unhelpful. It looks like this:

```
Applying patches
stop 0001
onto de8c782f34 Only match password prompts in part of line (Bug#28329)
```

where that funny "0001" represents the patch that failed. Git requires you to apply something to the index before `git am --continue` will succeed.

The first patch in this PR adds a title after the "0001", to make it more human friendly.
The next two allow applying it with `a`, although I'm not sure those represent the best way of doing that.