### PR TITLE
Fix encoding of data and args for git subprocess on w32

### DIFF
--- a/Documentation/RelNotes/2.12.0.txt
+++ b/Documentation/RelNotes/2.12.0.txt
@@ -199,3 +199,6 @@ Fixes since v2.11.0
 
 * The command `magit-file-delete ignored' the prefix argument instead
   of forcing the action as intended.
+
+* Fixed encoding of non-ascii filename arguments to git on
+  `windows-nt' systems.  #3250

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -234,8 +234,17 @@ pass arguments through this function before handing them to Git,
 to do the following.
 
 * Flatten ARGS, removing nil arguments.
-* Prepend `magit-git-global-arguments' to ARGS."
-  (append magit-git-global-arguments (-flatten args)))
+* Prepend `magit-git-global-arguments' to ARGS.
+* On w32 systems, encode to `w32-ansi-code-page'."
+  (setq args (append magit-git-global-arguments (-flatten args)))
+  (if (and (eq system-type 'windows-nt) (boundp 'w32-ansi-code-page))
+      ;; On w32, the process arguments *must* be encoded in the
+      ;; current code-page (see #3250).
+      (mapcar (lambda (arg)
+                (encode-coding-string
+                 arg (intern (format "cp%d" w32-ansi-code-page))))
+              args)
+    args))
 
 (defun magit-git-exit-code (&rest args)
   "Execute Git with ARGS, returning its exit code."

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -359,6 +359,10 @@ option `magit-git-global-arguments' specifies constant arguments.
 The remaining arguments ARGS specify arguments to Git, they are
 flattened before use."
   (declare (indent 1))
+  (when (eq system-type 'windows-nt)
+    ;; On w32, git expects UTF-8 encoded input, ignore any user
+    ;; configuration telling us otherwise (see #3250).
+    (encode-coding-region (point-min) (point-max) 'utf-8-unix))
   (if (file-remote-p default-directory)
       ;; We lack `process-file-region', so fall back to asynch +
       ;; waiting in remote case.
@@ -497,6 +501,10 @@ Magit status buffer."
     (with-editor-set-process-filter process #'magit-process-filter)
     (set-process-sentinel process #'magit-process-sentinel)
     (set-process-buffer   process process-buf)
+    (when (eq system-type 'windows-nt)
+      ;; On w32, git expects UTF-8 encoded input, ignore any user
+      ;; configuration telling us otherwise.
+      (set-process-coding-system 'utf-8-unix))
     (process-put process 'section section)
     (process-put process 'command-buf (current-buffer))
     (process-put process 'default-dir default-directory)


### PR DESCRIPTION
I believe this should fix all the encoding issues when calling git:
- fix #3225
- fix #3111
- fix #2832

```
On windows-nt systems, the arguments to subprocesses must be encoded
in the current code-page.  But Windows git requires UTF-8 encoded
input.  The contradictory requirements mean we can't just set
default-process-coding-system to the right thing.  Therefore,
explicitly encode the arguments according to `w32-ansi-code-page', and
likewise encode input sent to git as `utf-8-unix'.
```