### PR TITLE
Fix magit-submodule-deinit being copy-pasted

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.11.0 (2.11.0-227-gaeca03f04+1)
+#+SUBTITLE: for version 2.11.0 (2.11.0-232-gac96a04f7+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -22,7 +22,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+BEGIN_QUOTE
-This manual is for Magit version 2.11.0 (2.11.0-227-gaeca03f04+1).
+This manual is for Magit version 2.11.0 (2.11.0-232-gac96a04f7+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@bernoul.li>
 
@@ -5606,7 +5606,7 @@ the super-repository by adding ~magit-insert-submodules~ to the hook
 
   Fetch submodule.  With a prefix argument fetch all remotes.
 
-- Key: o i, magit-submodule-init
+- Key: o d, magit-submodule-deinit
 
   Unregister the submodule at PATH.
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.11.0 (2.11.0-227-gaeca03f04+1)
+@subtitle for version 2.11.0 (2.11.0-232-gac96a04f7+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -52,7 +52,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @quotation
-This manual is for Magit version 2.11.0 (2.11.0-227-gaeca03f04+1).
+This manual is for Magit version 2.11.0 (2.11.0-232-gac96a04f7+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@@bernoul.li>
 
@@ -7764,9 +7764,9 @@ Update each submodule's remote URL according to ".gitmodules".
 
 Fetch submodule.  With a prefix argument fetch all remotes.
 
-@kindex o i
-@cindex magit-submodule-init
-@item @kbd{o i} @tie{}@tie{}@tie{}@tie{}(@code{magit-submodule-init})
+@kindex o d
+@cindex magit-submodule-deinit
+@item @kbd{o d} @tie{}@tie{}@tie{}@tie{}(@code{magit-submodule-deinit})
 
 Unregister the submodule at PATH.
 @end table


### PR DESCRIPTION
The binding and command name were incorrectly copy-pasted from `magit-submodule-init`