### PR TITLE
Translate `pcase-lambda` to `lambda`/`pcase-let*`

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -379,10 +379,11 @@ acts similarly to `completing-read', except for the following:
   `magit-builtin-completing-read'."
   (setq magit-completing-read--silent-default nil)
   (-if-let (dwim (and def
-                      (or (nth 2 (-first (pcase-lambda (`(,cmd ,re ,_))
-                                           (and (eq this-command cmd)
-                                                (or (not re)
-                                                    (string-match-p re prompt))))
+                      (or (nth 2 (-first (lambda (arg)
+                                           (pcase-let ((`(,cmd ,re ,_) arg))
+                                             (and (eq this-command cmd)
+                                                  (or (not re)
+                                                      (string-match-p re prompt)))))
                                          magit-dwim-selection))
                           (memq this-command
                                 (with-no-warnings magit-no-confirm-default)))))


### PR DESCRIPTION
The `pcase-lambda` macro is not available in emacs 24.5.1 (e.g.,
provided by Ubuntu 16.04LTS), so we translate `pcase-lambda` to the
equivalent `lambda`/`pcase-let*`.

Closes #3255.