### PR TITLE
Replace references to magit-insert-modules-nested

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.11.0 (2.11.0-232-gac96a04f7+1)
+#+SUBTITLE: for version 2.11.0 (2.11.0-235-gc5ba3819a+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -22,7 +22,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+BEGIN_QUOTE
-This manual is for Magit version 2.11.0 (2.11.0-232-gac96a04f7+1).
+This manual is for Magit version 2.11.0 (2.11.0-235-gc5ba3819a+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@bernoul.li>
 
@@ -1995,7 +1995,7 @@ variable.
   Insert submodule sections.
 
   Hook ~magit-module-sections-hook~ controls which module sections are
-  inserted, and option ~magit-insert-modules-nested~ controls whether
+  inserted, and option ~magit-module-sections-nested~ controls whether
   they are wrapped in an additional section.
 
 - Option: magit-module-sections-hook

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.11.0 (2.11.0-232-gac96a04f7+1)
+@subtitle for version 2.11.0 (2.11.0-235-gc5ba3819a+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -52,7 +52,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @quotation
-This manual is for Magit version 2.11.0 (2.11.0-232-gac96a04f7+1).
+This manual is for Magit version 2.11.0 (2.11.0-235-gc5ba3819a+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@@bernoul.li>
 
@@ -2698,7 +2698,7 @@ variable.
 Insert submodule sections.
 
 Hook @code{magit-module-sections-hook} controls which module sections are
-inserted, and option @code{magit-insert-modules-nested} controls whether
+inserted, and option @code{magit-module-sections-nested} controls whether
 they are wrapped in an additional section.
 @end defun
 

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -204,7 +204,7 @@ With a prefix argument fetch all remotes."
 (defun magit-insert-modules ()
   "Insert submodule sections.
 Hook `magit-module-sections-hook' controls which module sections
-are inserted, and option `magit-insert-modules-nested' controls
+are inserted, and option `magit-module-sections-nested' controls
 whether they are wrapped in an additional section."
   (-when-let (modules (magit-get-submodules))
     (if magit-module-sections-nested


### PR DESCRIPTION
This variable name should instead be magit-module-sections-nested.

Closes #3257.