### PR TITLE
Use uniquify to make repository list unique

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2128,6 +2128,10 @@ buffers.
   ~magit-repository-directories-depth~ control which repositories are
   displayed.
 
+  Duplicates in repository names are made unique using via ~uniquify~.
+  Customize ~uniquify-buffer-name-style~ to modify how they are
+  displayed.
+
 - User Option: magit-repolist-columns
 
   This option controls what columns are displayed by the command

--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -307,10 +307,10 @@ With prefix argument simply read a directory name using
                                       (file-name-nondirectory it)
                                       (directory-file-name
                                        (file-name-directory it))
-                                      (+ 1 depth))
+                                      (1+ depth))
                                      it)
                                value)
-                        (+ 1 depth))))))
+                        (1+ depth))))))
      dict)
     result))
 

--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -30,6 +30,7 @@
 ;;; Code:
 
 (require 'magit-core)
+(require 'uniquify)
 
 (declare-function magit-status-internal 'magit-status)
 
@@ -289,7 +290,9 @@ With prefix argument simply read a directory name using
                    (directory-files directory t
                                     directory-files-no-dot-files-regexp t)))))
 
-(defun magit-list-repos-uniquify (alist)
+(defun magit-list-repos-uniquify (alist &optional depth)
+  (unless depth
+    (setq depth 0))
   (let (result (dict (make-hash-table :test 'equal)))
     (dolist (a (delete-dups alist))
       (puthash (car a) (cons (cdr a) (gethash (car a) dict)) dict))
@@ -300,13 +303,14 @@ With prefix argument simply read a directory name using
          (setq result
                (append result
                        (magit-list-repos-uniquify
-                        (--map (cons (concat
-                                      key "\\"
-                                      (file-name-nondirectory
-                                       (directory-file-name
-                                        (substring it 0 (- (1+ (length key)))))))
+                        (--map (cons (uniquify-get-proposed-name
+                                      (file-name-nondirectory it)
+                                      (directory-file-name
+                                       (file-name-directory it))
+                                      (+ 1 depth))
                                      it)
-                               value))))))
+                               value)
+                        (+ 1 depth))))))
      dict)
     result))
 


### PR DESCRIPTION
I have uniquify set up to make buffer names unique in a github style (`parent-dir/file`) rather than what magit does (`file\parent-dir`). So magit's style of resolving duplicate repository names in the output of `magit-list-repositories` doesn't fit in. Magit should either provide a way to to customize that style or defer to uniquify to do that. 

This fix makes magit delegate the style to `uniquify` and use whatever style user has configured for making buffer names unique. The out-of-the-box behaviour doesn't change, as far as I can tell, since `uniquify` also ends up using `repo\parent-dir` by default. 

~~Edit: Hm. I just realized that this enables uniquify by default (for buffers) which may not be something the user has asked for.~~ Looks like `uniquify` has been [enabled by default since emacs 24.4](https://www.reddit.com/r/emacs/comments/7fp39r/use_uniquify_functions_without_enabling_uniquify/). 

Also, thanks for creating and maintaining such a fantastic git interface!