### PR TITLE
Use a custom face for the process status indicator in the mode line

### DIFF
--- a/Documentation/RelNotes/2.12.0.txt
+++ b/Documentation/RelNotes/2.12.0.txt
@@ -200,6 +200,15 @@ Changes since v2.11.0
   with `magit-branch-pull-request' or magit-checkout-pull-request',
   provided that remote has no other tracking branches.  #3134
 
+* Added new face `magit-mode-line-process' which is applied to the
+  mode line process status indicator shown while Git is running for
+  side-effects.  This improves the visibility of pending asynchronous
+  processes (in particular), as Magit remains responsive after
+  initiating such commands (for instance fetching or rebasing), but
+  will not update its buffers until the process has completed, which
+  might take longer than anticipated.  Customize this face if you wish
+  to make this indicator more (or less) visible.  #3284
+
 Fixes since v2.11.0
 -------------------
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.11.0 (2.11.0-308-gfd1a9ad6b+1)
+#+SUBTITLE: for version 2.11.0 (2.11.0-311-gc6ef61b2e+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -22,7 +22,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+BEGIN_QUOTE
-This manual is for Magit version 2.11.0 (2.11.0-308-gfd1a9ad6b+1).
+This manual is for Magit version 2.11.0 (2.11.0-311-gc6ef61b2e+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@bernoul.li>
 
@@ -1549,8 +1549,11 @@ will also have to install the ~ido-completing-read+~ package and use
 
 Magit runs Git either for side-effects (e.g. when pushing) or to get
 some value (e.g. the name of the current branch).  When Git is run for
-side-effects then the output goes into a per-repository log buffer,
-which can be consulted when things don't go as expected.
+side-effects, the mode line displays a process status indicator (using
+the ~magit-mode-line-process~ face), and the process output goes into
+a per-repository log buffer, which can be consulted when things don't
+go as expected.  Process errors are indicated at the top of the status
+buffer.
 
 - Key: $, magit-process
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.11.0 (2.11.0-308-gfd1a9ad6b+1)
+@subtitle for version 2.11.0 (2.11.0-311-gc6ef61b2e+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -52,7 +52,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @quotation
-This manual is for Magit version 2.11.0 (2.11.0-308-gfd1a9ad6b+1).
+This manual is for Magit version 2.11.0 (2.11.0-311-gc6ef61b2e+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@@bernoul.li>
 
@@ -2132,8 +2132,11 @@ full name (e.g., "refs/heads/master").
 
 Magit runs Git either for side-effects (e.g. when pushing) or to get
 some value (e.g. the name of the current branch).  When Git is run for
-side-effects then the output goes into a per-repository log buffer,
-which can be consulted when things don't go as expected.
+side-effects, the mode line displays a process status indicator (using
+the @code{magit-mode-line-process} face), and the process output goes into
+a per-repository log buffer, which can be consulted when things don't
+go as expected.  Process errors are indicated at the top of the status
+buffer.
 
 @table @asis
 @kindex $

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -609,7 +609,8 @@ Magit status buffer."
               (magit-refresh))
           (with-temp-buffer
             (setq default-directory (process-get process 'default-dir))
-            (magit-refresh)))))))
+            (magit-refresh)))))
+    (force-mode-line-update t)))
 
 (defun magit-sequencer-process-sentinel (process event)
   "Special sentinel used by `magit-run-git-sequencer'."

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -199,6 +199,11 @@ non-nil, then the password is read from the user instead."
   "Face for non-zero exit-status."
   :group 'magit-faces)
 
+(defface magit-mode-line-process
+  '((t :inherit mode-line-emphasis))
+  "Face for `mode-line-process' status when Git is running for side-effects."
+  :group 'magit-faces)
+
 ;;; Process Mode
 
 (defvar magit-process-mode-map
@@ -790,9 +795,12 @@ as argument."
 (defun magit-process-set-mode-line (program args)
   (when (equal program magit-git-executable)
     (setq args (nthcdr (length magit-git-global-arguments) args)))
-  (let ((str (concat " " program (and args (concat " " (car args))))))
+  (let ((str (concat " " (propertize
+                          (concat program (and args (concat " " (car args))))
+                          'face 'magit-mode-line-process))))
     (dolist (buf (magit-mode-get-buffers))
-      (with-current-buffer buf (setq mode-line-process str)))))
+      (with-current-buffer buf
+        (setq mode-line-process str)))))
 
 (defun magit-process-unset-mode-line ()
   (dolist (buf (magit-mode-get-buffers))


### PR DESCRIPTION
New face `magit-mode-line-process' increases the visibility of the
running process when Git is run for side-effects.

In addition, `magit-process-sentinel' now forces the redisplay of all
mode lines, as otherwise the `mode-line-process' value set by Magit
could remain visible in other windows after it had been cleaned up in
the selected window.

Closes #3284.