### PR TITLE
In diffs, optionally use tab-width configured for resp. files

### DIFF
--- a/Documentation/RelNotes/2.12.0.txt
+++ b/Documentation/RelNotes/2.12.0.txt
@@ -224,6 +224,14 @@ Changes since v2.11.0
     (define-key magit-hunk-section-map (kbd "SPC")
       'magit-diff-visit-file-other-window)
 
+* The widths of tabs in diffs can now adjusted to match the width that
+  would be used in the corresponing file-visiting buffers.  Because
+  doing this can be expensive (and unnecessary when using spaces for
+  intendation), it is disabled by default.
+
+  Use the new option `magit-diff-adjust-tab-width' to control if and
+  when feature should be used.  #2929
+
 Fixes since v2.11.0
 -------------------
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.11.0 (2.11.0-315-g96cb64e6b+1)
+#+SUBTITLE: for version 2.11.0 (2.11.0-317-gf4944688f+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -22,7 +22,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+BEGIN_QUOTE
-This manual is for Magit version 2.11.0 (2.11.0-315-g96cb64e6b+1).
+This manual is for Magit version 2.11.0 (2.11.0-317-gf4944688f+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@bernoul.li>
 
@@ -2765,6 +2765,28 @@ without having to using one of the diff popups.
   - ~nil~ never show fine differences.
   - ~t~ show fine differences for the current diff hunk only.
   - ~all~ show fine differences for all displayed diff hunks.
+
+- User Option: magit-diff-adjust-tab-width
+
+  Whether to adjust the width of tabs in diffs.
+
+  Determining the correct width can be expensive if it requires
+  opening large and/or many files, so the widths are cached in the
+  variable ~magit-diff--tab-width-cache~.  Set that to nil to invalidate
+  the cache.
+
+  - ~nil~ Never ajust tab width.  Use `tab-width's value from them Magit
+    buffer itself instead.
+
+  - ~t~ If the corresponding file-visiting buffer exits, then use
+    ~tab-width~'s value from that buffer.  Doing this is cheap, so this
+    value is used even if a corresponding cache entry exists.
+
+  - ~always~ If there is no such buffer, then temporarily visit the file
+    to determine the value.
+
+  - NUMBER Like ~always~, but don't visit files larger than NUMBER
+    bytes.
 
 - User Option: magit-diff-paint-whitespace
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.11.0 (2.11.0-315-g96cb64e6b+1)
+@subtitle for version 2.11.0 (2.11.0-317-gf4944688f+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -52,7 +52,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @quotation
-This manual is for Magit version 2.11.0 (2.11.0-315-g96cb64e6b+1).
+This manual is for Magit version 2.11.0 (2.11.0-317-gf4944688f+1).
 
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@@bernoul.li>
 
@@ -3790,6 +3790,38 @@ Whether to show word-granularity differences within diff hunks.
 
 @item
 @code{all} show fine differences for all displayed diff hunks.
+@end itemize
+@end defopt
+
+@defopt magit-diff-adjust-tab-width
+
+Whether to adjust the width of tabs in diffs.
+
+Determining the correct width can be expensive if it requires
+opening large and/or many files, so the widths are cached in the
+variable @code{magit-diff--tab-width-cache}.  Set that to nil to invalidate
+the cache.
+
+@itemize
+@item
+@code{nil} Never ajust tab width.  Use `tab-width's value from them Magit
+buffer itself instead.
+
+
+@item
+@code{t} If the corresponding file-visiting buffer exits, then use
+@code{tab-width}'s value from that buffer.  Doing this is cheap, so this
+value is used even if a corresponding cache entry exists.
+
+
+@item
+@code{always} If there is no such buffer, then temporarily visit the file
+to determine the value.
+
+
+@item
+NUMBER Like @code{always}, but don't visit files larger than NUMBER
+bytes.
 @end itemize
 @end defopt
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2435,9 +2435,13 @@ are highlighted."
 (defun magit-diff-tab-width (file)
   (setq file (expand-file-name file))
   (cl-flet ((cache (value)
-                   (setf (alist-get file magit-diff--tab-width-cache
-                                    nil nil #'equal)
-                         value)))
+                   (let ((elt (assoc file magit-diff--tab-width-cache)))
+                     (if elt
+                         (setcdr elt value)
+                       (setq magit-diff--tab-width-cache
+                             (cons (cons file value)
+                                   magit-diff--tab-width-cache))))
+                   value))
     (let (buf)
       (cond
        ((not magit-diff-adjust-tab-width)


### PR DESCRIPTION
```
Teach `magit-diff-paint-tab' to use the value extracted from the
file-visiting buffer, or set by `hack-local-variables' if no such
buffer already exists.

Add a new option `magit-diff-adjust-tab-width' to let users set
how hard we should try to determine the appropriate value, because
doing so can be expensive.
```

Closes #2929.