### PR TITLE
magit-diff-tab-width fixups

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2453,8 +2453,9 @@ are highlighted."
           (or (cdr it)
               tab-width)))
        ((or (eq magit-diff-adjust-tab-width 'always)
-            (>= magit-diff-adjust-tab-width
-                (file-attribute-size (file-attributes file))))
+            (and (numberp magit-diff-adjust-tab-width)
+                 (>= magit-diff-adjust-tab-width
+                     (nth 7 (file-attributes file)))))
         (with-current-buffer (setq buf (find-file-noselect file))
           (cache tab-width)))
        (t

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2446,8 +2446,7 @@ are highlighted."
      ((not magit-diff-adjust-tab-width)
       tab-width)
      ((--when-let (find-buffer-visiting file)
-        (with-current-buffer it
-          (cache tab-width))))
+        (cache (buffer-local-value 'tab-width it))))
      ((--when-let (assoc file magit-diff--tab-width-cache)
         (or (cdr it)
             tab-width)))
@@ -2455,8 +2454,7 @@ are highlighted."
           (and (numberp magit-diff-adjust-tab-width)
                (>= magit-diff-adjust-tab-width
                    (nth 7 (file-attributes file)))))
-      (with-current-buffer (find-file-noselect file)
-        (cache tab-width)))
+      (cache (buffer-local-value 'tab-width (find-file-noselect file))))
      (t
       (cache nil)
       tab-width))))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2442,25 +2442,24 @@ are highlighted."
                              (cons (cons file value)
                                    magit-diff--tab-width-cache))))
                    value))
-    (let (buf)
-      (cond
-       ((not magit-diff-adjust-tab-width)
-        tab-width)
-       ((setq buf (find-buffer-visiting file))
-        (with-current-buffer buf
-          (cache tab-width)))
-       ((--when-let (assoc file magit-diff--tab-width-cache)
-          (or (cdr it)
-              tab-width)))
-       ((or (eq magit-diff-adjust-tab-width 'always)
-            (and (numberp magit-diff-adjust-tab-width)
-                 (>= magit-diff-adjust-tab-width
-                     (nth 7 (file-attributes file)))))
-        (with-current-buffer (setq buf (find-file-noselect file))
-          (cache tab-width)))
-       (t
-        (cache nil)
-        tab-width)))))
+    (cond
+     ((not magit-diff-adjust-tab-width)
+      tab-width)
+     ((--when-let (find-buffer-visiting file)
+        (with-current-buffer it
+          (cache tab-width))))
+     ((--when-let (assoc file magit-diff--tab-width-cache)
+        (or (cdr it)
+            tab-width)))
+     ((or (eq magit-diff-adjust-tab-width 'always)
+          (and (numberp magit-diff-adjust-tab-width)
+               (>= magit-diff-adjust-tab-width
+                   (nth 7 (file-attributes file)))))
+      (with-current-buffer (find-file-noselect file)
+        (cache tab-width)))
+     (t
+      (cache nil)
+      tab-width))))
 
 (defun magit-diff-paint-tab (merging width)
   (save-excursion

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -178,7 +178,7 @@ the variable `magit-diff--tab-width-cache'.  Set that to nil
 to invalidate the cache.
 
 nil       Never ajust tab width.  Use `tab-width's value from
-          them Magit buffer itself instead.
+          the Magit buffer itself instead.
 
 t         If the corresponding file-visiting buffer exits, then
           use `tab-width's value from that buffer.  Doing this is


### PR DESCRIPTION
#3298 introduced a couple of issues:

1. Use of the `file-attribute-size` accessor, which was only added in Emacs 26.
2. Passing the new `defcustom` `magit-diff-adjust-tab-width`, whose value could be `t`, to an arithmetic operator.

The first commit addresses these two issues. The second fixes what I believe to be a docstring typo, and the last two commits are suggestions for trivial logic simplification and optimisation.

Let me know if you'd like anything written/split differently, and thanks for this cool feature. :)