### PR TITLE
Define magit-section as a class instead of as a struct

### DIFF
--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -113,7 +113,7 @@ so causes the change to be applied to the index as well."
       (`(,_  files) (magit-apply-diffs  it args)))))
 
 (defun magit-apply--section-content (section)
-  (buffer-substring-no-properties (if (eq (oref section type) 'hunk)
+  (buffer-substring-no-properties (if (magit-hunk-section-p section)
                                       (oref section start)
                                     (oref section content))
                                   (oref section end)))
@@ -414,7 +414,7 @@ without requiring confirmation."
   (if (eq (magit-diff-type section) 'unstaged)
       (funcall apply section "--reverse")
     (if (magit-anything-unstaged-p
-         nil (if (eq (oref section type) 'file)
+         nil (if (magit-file-section-p section)
                  (oref section value)
                (magit-section-parent-value section)))
         (progn (let ((inhibit-magit-refresh t))
@@ -435,7 +435,7 @@ without requiring confirmation."
     (if (eq (magit-diff-type section) 'unstaged)
         (funcall apply sections "--reverse")
       (if (magit-anything-unstaged-p
-           nil (if (eq (oref section type) 'file)
+           nil (if (magit-file-section-p section)
                    (oref section value)
                  (magit-section-parent-value section)))
           (progn (let ((inhibit-magit-refresh t))

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -138,7 +138,7 @@ so causes the change to be applied to the index as well."
     (when (string-match "^diff --cc" (magit-section-value section))
       (user-error "Cannot un-/stage resolution hunks.  Stage the whole file"))
     (magit-apply-patch section args
-                       (concat (magit-section-diff-header section)
+                       (concat (oref section header)
                                (mapconcat 'magit-apply--section-content
                                           sections "")))))
 

--- a/lisp/magit-bookmark.el
+++ b/lisp/magit-bookmark.el
@@ -51,8 +51,9 @@ This function will:
     (when (derived-mode-p 'magit-mode)
       (-when-let (hidden-sections (bookmark-prop-get bookmark
                                                      'magit-hidden-sections))
-        (--each (magit-section-children magit-root-section)
-          (if (member (cons (magit-section-type it) (magit-section-value it))
+        (--each (oref magit-root-section children)
+          (if (member (cons (oref it type)
+                            (oref it value))
                       hidden-sections)
               (magit-section-hide it)
             (magit-section-show it)))))
@@ -87,9 +88,10 @@ specifies additional properties to store in the bookmark."
     (when (derived-mode-p 'magit-mode)
       (bookmark-prop-set
        bookmark 'magit-hidden-sections
-       (--map (cons (magit-section-type it) (magit-section-value it))
-              (-filter #'magit-section-hidden
-                       (magit-section-children magit-root-section)))))
+       (--map (cons (oref it type)
+                    (oref it value))
+              (--filter (oref it hidden)
+                        (oref magit-root-section children)))))
     (when make-props
       (pcase-dolist (`(,prop . ,value) (apply make-props magit-refresh-args))
         (bookmark-prop-set bookmark prop value)))
@@ -340,12 +342,12 @@ specifies additional properties to store in the bookmark."
         (magit-args  . ,args)
         (magit-files . ,files)
         (magit-hidden-sections
-         . ,(--map `(,(magit-section-type it)
+         . ,(--map `(,(oref it type)
                      . ,(replace-regexp-in-string (regexp-quote stash)
                                                   magit-buffer-revision-hash
-                                                  (magit-section-value it)))
-                   (-filter #'magit-section-hidden
-                            (magit-section-children magit-root-section))))))))
+                                                  (oref it value)))
+                   (--filter (oref it hidden)
+                             (oref magit-root-section children))))))))
 
 ;;; Submodules
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1783,8 +1783,8 @@ section or a child thereof."
                         'face 'magit-diff-file-heading))
     (magit-insert-heading)
     (unless (equal orig file)
-      (setf (magit-section-source section) orig))
-    (setf (magit-section-diff-header section) header)
+      (oset section source orig))
+    (oset section header header)
     (when modes
       (magit-insert-section (hunk)
         (insert modes)))
@@ -2516,10 +2516,10 @@ are highlighted."
   (if section
       (unless (magit-section-hidden section)
         (pcase (list magit-diff-refine-hunk
-                     (magit-section-refined section)
+                     (oref section refined)
                      (eq section (magit-current-section)))
           ((or `(all nil ,_) `(t nil t))
-           (setf (magit-section-refined section) t)
+           (oset section refined t)
            (save-excursion
              (goto-char (magit-section-start section))
              ;; `diff-refine-hunk' does not handle combined diffs.
@@ -2528,7 +2528,7 @@ are highlighted."
                (let ((write-region-inhibit-fsync t))
                  (diff-refine-hunk)))))
           ((or `(nil t ,_) `(t t nil))
-           (setf (magit-section-refined section) nil)
+           (oset section refined nil)
            (remove-overlays (magit-section-start section)
                             (magit-section-end   section)
                             'diff-mode 'fine))))
@@ -2665,7 +2665,7 @@ https://github.com/magit/magit/pull/2293 for more details)."
   (when (eq (magit-section-type section) 'hunk)
     (setq section (magit-section-parent section)))
   (when (eq (magit-section-type section) 'file)
-    (magit-section-diff-header section)))
+    (oref section header)))
 
 (defun magit-diff-hunk-region-header (section)
   (let ((patch (magit-diff-hunk-region-patch section)))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1004,7 +1004,7 @@ for a revision."
         (let ((prev (car magit-refresh-args)))
           (unless (equal rev prev)
             (dolist (child (cdr (oref magit-root-section children)))
-              (when (eq (oref child type) 'file)
+              (when (magit-file-section-p child)
                 (magit-section-cache-visibility child)))))))
     (magit-mode-setup #'magit-revision-mode rev nil args files)))
 
@@ -1869,7 +1869,7 @@ section or a child thereof."
 
 (defun magit-diff-expansion-threshold (section)
   "Keep new diff sections collapsed if washing takes too long."
-  (and (eq (oref section type) 'file)
+  (and (magit-file-section-p section)
        (> (float-time (time-subtract (current-time) magit-refresh-start-time))
           magit-diff-expansion-threshold)
        'hide))
@@ -2311,7 +2311,7 @@ actually a `diff' but a `diffstat' section."
 
 (defun magit-diff-unhighlight (section selection)
   "Remove the highlighting of the diff-related SECTION."
-  (when (eq (oref section type) 'hunk)
+  (when (magit-hunk-section-p section)
     (magit-diff-paint-hunk section selection nil)
     t))
 
@@ -2665,9 +2665,9 @@ https://github.com/magit/magit/pull/2293 for more details)."
 ;;; Diff Extract
 
 (defun magit-diff-file-header (section)
-  (when (eq (oref section type) 'hunk)
+  (when (magit-hunk-section-p section)
     (setq section (oref section parent)))
-  (when (eq (oref section type) 'file)
+  (when (magit-file-section-p section)
     (oref section header)))
 
 (defun magit-diff-hunk-region-header (section)

--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -285,7 +285,7 @@ mind at all, then it asks the user for a command to run."
   (interactive)
   (magit-section-case
     (hunk (save-excursion
-            (goto-char (magit-section-start (magit-section-parent it)))
+            (goto-char (oref (oref it parent) start))
             (magit-ediff-dwim)))
     (t
      (let ((range (magit-diff--dwim))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -704,7 +704,7 @@ Sorted from longest to shortest CYGWIN name."
 
 (defun magit-file-at-point ()
   (magit-section-case
-    (file (magit-section-value it))
+    (file (oref it value))
     (hunk (magit-section-parent-value it))))
 
 (defun magit-current-file ()
@@ -904,22 +904,22 @@ to, or to some other symbolic-ref that points to the same ref."
 
 (defun magit-branch-at-point ()
   (magit-section-case
-    (branch (magit-section-value it))
-    (commit (magit-name-branch (magit-section-value it)))))
+    (branch (oref it value))
+    (commit (magit-name-branch (oref it value)))))
 
 (defun magit-local-branch-at-point ()
   (magit-section-case
-    (branch (let ((branch (magit-ref-maybe-qualify (magit-section-value it))))
+    (branch (let ((branch (magit-ref-maybe-qualify (oref it value))))
               (when (member branch (magit-list-local-branch-names))
                 branch)))
-    (commit (magit-name-local-branch (magit-section-value it)))))
+    (commit (magit-name-local-branch (oref it value)))))
 
 (defun magit-remote-branch-at-point ()
   (magit-section-case
-    (branch (let ((branch (magit-section-value it)))
+    (branch (let ((branch (oref it value)))
               (when (member branch (magit-list-remote-branch-names))
                 branch)))
-    (commit (magit-name-remote-branch (magit-section-value it)))))
+    (commit (magit-name-remote-branch (oref it value)))))
 
 (defun magit-commit-at-point ()
   (or (magit-section-when commit)
@@ -929,10 +929,10 @@ to, or to some other symbolic-ref that points to the same ref."
 (defun magit-branch-or-commit-at-point ()
   (or magit-buffer-refname
       (magit-section-case
-        (branch (magit-ref-maybe-qualify (magit-section-value it)))
-        (commit (let ((rev (magit-section-value it)))
+        (branch (magit-ref-maybe-qualify (oref it value)))
+        (commit (let ((rev (oref it value)))
                   (or (magit-get-shortname rev) rev)))
-        (tag (magit-ref-maybe-qualify (magit-section-value it) "tags/")))
+        (tag (magit-ref-maybe-qualify (oref it value) "tags/")))
       (thing-at-point 'git-revision t)
       (and (derived-mode-p 'magit-revision-mode
                            'magit-merge-preview-mode)
@@ -940,15 +940,15 @@ to, or to some other symbolic-ref that points to the same ref."
 
 (defun magit-tag-at-point ()
   (magit-section-case
-    (tag    (magit-section-value it))
-    (commit (magit-name-tag (magit-section-value it)))))
+    (tag    (oref it value))
+    (commit (magit-name-tag (oref it value)))))
 
 (defun magit-stash-at-point ()
   (magit-section-when stash))
 
 (defun magit-remote-at-point ()
   (magit-section-case
-    (remote (magit-section-value it))
+    (remote (oref it value))
     (branch (magit-section-parent-value it))))
 
 (defun magit-get-current-branch ()

--- a/lisp/magit-imenu.el
+++ b/lisp/magit-imenu.el
@@ -110,7 +110,7 @@ This function is used as a value for
   (magit-section--backward-find
    (lambda ()
      (let ((section (magit-current-section)))
-       (and (equal (oref section type) 'file)
+       (and (magit-file-section-p section)
             (not (equal (oref (oref section parent) type)
                         'diffstat)))))))
 

--- a/lisp/magit-imenu.el
+++ b/lisp/magit-imenu.el
@@ -55,19 +55,19 @@ This function is used as a helper for functions set as
     (while (magit-section--backward-find
             (lambda ()
               (let* ((section (magit-current-section))
-                     (type (magit-section-type section))
-                     (parent (magit-section-parent section))
-                     (parent-type (magit-section-type parent)))
+                     (type (oref section type))
+                     (parent (oref section parent))
+                     (parent-type (oref parent type)))
                 (and (-contains-p entry-types type)
                      (-contains-p menu-types parent-type)))))
       (let* ((section (magit-current-section))
              (name (buffer-substring-no-properties
                     (line-beginning-position)
                     (line-end-position)))
-             (parent (magit-section-parent section))
+             (parent (oref section parent))
              (parent-title (buffer-substring-no-properties
-                            (magit-section-start parent)
-                            (1- (magit-section-content parent)))))
+                            (oref parent start)
+                            (1- (oref parent content)))))
         (puthash parent-title
                  (cons (cons name (point))
                        (gethash parent-title entries (list)))
@@ -86,7 +86,7 @@ This function is used as a value for
   (magit-section--backward-find
    (lambda ()
      (-contains-p '(commit stash)
-                  (magit-section-type (magit-current-section))))))
+                  (oref (magit-current-section) type)))))
 
 ;;;###autoload
 (defun magit-imenu--log-extract-index-name-function ()
@@ -109,10 +109,10 @@ This function is used as a value for
 `imenu-prev-index-position-function'."
   (magit-section--backward-find
    (lambda ()
-     (and (equal (magit-section-type (magit-current-section)) 'file)
-          (not (equal (magit-section-type
-                       (magit-section-parent (magit-current-section)))
-                      'diffstat))))))
+     (let ((section (magit-current-section)))
+       (and (equal (oref section type) 'file)
+            (not (equal (oref (oref section parent) type)
+                        'diffstat)))))))
 
 ;;;###autoload
 (defun magit-imenu--diff-extract-index-name-function ()
@@ -204,9 +204,7 @@ This function is used as a value for
 `imenu-prev-index-position-function'."
   (magit-section--backward-find
    (lambda ()
-     (eq
-      (magit-section-type (magit-current-section))
-      'process))))
+     (eq (oref (magit-current-section) type) 'process))))
 
 ;;;###autoload
 (defun magit-imenu--process-extract-index-name-function ()

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1034,10 +1034,10 @@ Run hooks `magit-pre-refresh-hook' and `magit-post-refresh-hook'."
 
 (defun magit-refresh-get-relative-position ()
   (-when-let (section (magit-current-section))
-    (let ((start (magit-section-start section)))
+    (let ((start (oref section start)))
       (list (count-lines start (point))
             (- (point) (line-beginning-position))
-            (and (eq (magit-section-type section) 'hunk)
+            (and (eq (oref section type) 'hunk)
                  (region-active-p)
                  (progn (goto-char (line-beginning-position))
                         (when  (looking-at "^[-+]") (forward-line))

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1037,7 +1037,7 @@ Run hooks `magit-pre-refresh-hook' and `magit-post-refresh-hook'."
     (let ((start (oref section start)))
       (list (count-lines start (point))
             (- (point) (line-beginning-position))
-            (and (eq (oref section type) 'hunk)
+            (and (magit-hunk-section-p section)
                  (region-active-p)
                  (progn (goto-char (line-beginning-position))
                         (when  (looking-at "^[-+]") (forward-line))

--- a/lisp/magit-obsolete.el
+++ b/lisp/magit-obsolete.el
@@ -137,5 +137,15 @@ use `magit-pre-refresh-hook', `magit-post-refresh-hook',
 (make-obsolete-variable 'magit-no-confirm-default
                         'magit-dwim-selection "Magit 2.12.0")
 
+(make-obsolete 'magit-section-type     "use (oref ... type) instead"     "Magit 2.12.0")
+(make-obsolete 'magit-section-value    "use (oref ... value) instead"    "Magit 2.12.0")
+(make-obsolete 'magit-section-start    "use (oref ... start) instead"    "Magit 2.12.0")
+(make-obsolete 'magit-section-content  "use (oref ... content) instead"  "Magit 2.12.0")
+(make-obsolete 'magit-section-end      "use (oref ... end) instead"      "Magit 2.12.0")
+(make-obsolete 'magit-section-hidden   "use (oref ... hidden) instead"   "Magit 2.12.0")
+(make-obsolete 'magit-section-washer   "use (oref ... washer) instead"   "Magit 2.12.0")
+(make-obsolete 'magit-section-parent   "use (oref ... parent) instead"   "Magit 2.12.0")
+(make-obsolete 'magit-section-children "use (oref ... children) instead" "Magit 2.12.0")
+
 (provide 'magit-obsolete)
 ;;; magit-obsolete.el ends here

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -344,7 +344,7 @@ different, but only if you have customized the option
   (interactive)
   (if (and (derived-mode-p 'magit-refs-mode)
            (magit-section-match '(branch tag)))
-      (let ((ref (magit-section-value (magit-current-section))))
+      (let ((ref (oref (magit-current-section) value)))
         (cond (current-prefix-arg
                (cond ((memq 'focus-on-ref magit-visit-ref-behavior)
                       (magit-show-refs ref))
@@ -603,8 +603,8 @@ line is inserted at all."
 ;;;; Cherry Sections
 
 (defun magit-refs-insert-cherry-commits (head ref section)
-  (if (magit-section-hidden section)
-      (setf (magit-section-washer section)
+  (if (oref section hidden)
+      (oset section washer
             (apply-partially #'magit-refs-insert-cherry-commits-1
                              head ref section))
     (magit-refs-insert-cherry-commits-1 head ref section)))

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -303,7 +303,7 @@ If there is no previous sibling section, then move to the parent."
 (defun magit-hunk-set-window-start (section)
   "When SECTION is a `hunk', ensure that its beginning is visible.
 It the SECTION has a different type, then do nothing."
-  (when (eq (oref section type) 'hunk)
+  (when (magit-hunk-section-p section)
     (magit-section-set-window-start section)))
 
 (defmacro magit-define-section-jumper (name heading type &optional value)
@@ -463,8 +463,8 @@ hidden."
                       (list (magit-get-section '((staged)   (status)))
                             (magit-get-section '((unstaged) (status))))))
                     ((derived-mode-p 'magit-diff-mode)
-                     (--filter (eq (oref it type) 'file)
-                               (oref magit-root-section children)))))
+                     (-filter #'magit-file-section-p
+                              (oref magit-root-section children)))))
     (if (--any-p (oref it hidden) sections)
         (dolist (s sections)
           (magit-section-show s)
@@ -961,7 +961,7 @@ invisible."
               (forward-char char))
             (unless (eq (magit-current-section) it)
               (goto-char start))))
-      (or (and (eq (oref section type) 'hunk)
+      (or (and (magit-hunk-section-p section)
                (-when-let (parent (magit-get-section
                                    (magit-section-ident
                                     (oref section parent))))

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -31,6 +31,7 @@
 
 (require 'cl-lib)
 (require 'dash)
+(require 'eieio)
 
 (require 'magit-utils)
 
@@ -140,9 +141,20 @@ hardcoded section specific default (see `magit-insert-section')."
 
 ;;; Core
 
-(cl-defstruct magit-section
-  type value start content end hidden washer refined
-  source diff-header process parent children)
+(defclass magit-section ()
+  ((type     :initform nil :accessor magit-section-type     :initarg :type)
+   (value    :initform nil :accessor magit-section-value    :initarg :value)
+   (start    :initform nil :accessor magit-section-start    :initarg :start)
+   (content  :initform nil :accessor magit-section-content)
+   (end      :initform nil :accessor magit-section-end)
+   (hidden   :initform nil :accessor magit-section-hidden)
+   (washer   :initform nil :accessor magit-section-washer)
+   (process  :initform nil :accessor magit-section-process)
+   (parent   :initform nil :accessor magit-section-parent   :initarg :parent)
+   (children :initform nil :accessor magit-section-children)
+   (source      :initform nil :accessor magit-section-source)
+   (diff-header :initform nil :accessor magit-section-diff-header)
+   (refined     :initform nil :accessor magit-section-refined)))
 
 (defvar-local magit-root-section nil
   "The root section in the current buffer.
@@ -695,7 +707,7 @@ anything this time around.
   (let ((s (if (symbolp (car args))
                (pop args)
              (cl-gensym "section"))))
-    `(let* ((,s (make-magit-section
+    `(let* ((,s (magit-section ""
                  :type ,(let ((type (nth 0 (car args))))
                           (if (eq (car-safe type) 'eval)
                               (cadr type)

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -149,16 +149,16 @@ hardcoded section specific default (see `magit-insert-section')."
    (end      :initform nil :accessor magit-section-end)
    (hidden   :initform nil :accessor magit-section-hidden)
    (washer   :initform nil :accessor magit-section-washer)
-   (process  :initform nil :accessor magit-section-process)
+   (process  :initform nil)
    (parent   :initform nil :accessor magit-section-parent   :initarg :parent)
    (children :initform nil :accessor magit-section-children)))
 
 (defclass magit-file-section (magit-section)
-  ((source   :initform nil :accessor magit-section-source)
-   (header   :initform nil :accessor magit-section-header)))
+  ((source   :initform nil)
+   (header   :initform nil)))
 
 (defclass magit-hunk-section (magit-section)
-  ((refined  :initform nil :accessor magit-section-refined)))
+  ((refined  :initform nil)))
 
 (defvar-local magit-root-section nil
   "The root section in the current buffer.

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -151,10 +151,14 @@ hardcoded section specific default (see `magit-insert-section')."
    (washer   :initform nil :accessor magit-section-washer)
    (process  :initform nil :accessor magit-section-process)
    (parent   :initform nil :accessor magit-section-parent   :initarg :parent)
-   (children :initform nil :accessor magit-section-children)
-   (source      :initform nil :accessor magit-section-source)
-   (diff-header :initform nil :accessor magit-section-diff-header)
-   (refined     :initform nil :accessor magit-section-refined)))
+   (children :initform nil :accessor magit-section-children)))
+
+(defclass magit-file-section (magit-section)
+  ((source   :initform nil :accessor magit-section-source)
+   (header   :initform nil :accessor magit-section-header)))
+
+(defclass magit-hunk-section (magit-section)
+  ((refined  :initform nil :accessor magit-section-refined)))
 
 (defvar-local magit-root-section nil
   "The root section in the current buffer.
@@ -706,7 +710,9 @@ anything this time around.
                         (cadr type)
                       `',type)))
             (,s (funcall (pcase ,tp
-                           (_ 'magit-section))
+                           (`file 'magit-file-section)
+                           (`hunk 'magit-hunk-section)
+                           (_     'magit-section))
                          ""
                          :type ,tp
                          :value ,(nth 1 (car args))

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -174,9 +174,9 @@ never modify it.")
 (defun magit-section-ident (section)
   "Return an unique identifier for SECTION.
 The return value has the form ((TYPE . VALUE)...)."
-  (cons (cons (magit-section-type section)
-              (magit-section-value section))
-        (--when-let (magit-section-parent section)
+  (cons (cons (oref section type)
+              (oref section value))
+        (--when-let (oref section parent)
           (magit-section-ident it))))
 
 (defun magit-get-section (ident &optional root)
@@ -184,13 +184,14 @@ The return value has the form ((TYPE . VALUE)...)."
 IDENT has to be a list as returned by `magit-section-ident'."
   (setq ident (reverse ident))
   (let ((section (or root magit-root-section)))
-    (when (eq (car (pop ident)) (magit-section-type section))
+    (when (eq (car (pop ident))
+              (oref section type))
       (while (and ident
                   (setq section
                         (--first
-                         (and (eq    (caar ident) (magit-section-type it))
-                              (equal (cdar ident) (magit-section-value it)))
-                         (magit-section-children section))))
+                         (and (eq    (caar ident) (oref it type))
+                              (equal (cdar ident) (oref it value)))
+                         (oref section children))))
         (pop ident))
       section)))
 
@@ -207,13 +208,14 @@ IDENT has to be a list as returned by `magit-section-ident'."
   (if (eobp)
       (user-error "No next section")
     (let ((section (magit-current-section)))
-      (if (magit-section-parent section)
-          (let ((next (and (not (magit-section-hidden section))
-                           (not (= (magit-section-end section) (1+ (point))))
-                           (car (magit-section-children section)))))
+      (if (oref section parent)
+          (let ((next (and (not (oref section hidden))
+                           (not (= (oref section end)
+                                   (1+ (point))))
+                           (car (oref section children)))))
             (while (and section (not next))
               (unless (setq next (car (magit-section-siblings section 'next)))
-                (setq section (magit-section-parent section))))
+                (setq section (oref section parent))))
             (if next
                 (magit-section-goto next)
               (user-error "No next section")))
@@ -229,22 +231,24 @@ the beginning of the current section."
       (user-error "No previous section")
     (let ((section (magit-current-section)) children)
       (cond
-       ((and (= (point) (1- (magit-section-end section)))
-             (setq children (magit-section-children section)))
+       ((and (= (point)
+                (1- (oref section end)))
+             (setq children (oref section children)))
         (magit-section-goto (car (last children))))
-       ((and (magit-section-parent section)
-             (not (= (point) (magit-section-start section))))
+       ((and (oref section parent)
+             (not (= (point)
+                     (oref section start))))
         (magit-section-goto section))
        (t
         (let ((prev (car (magit-section-siblings section 'prev))))
           (if prev
-              (while (and (not (magit-section-hidden prev))
-                          (setq children (magit-section-children prev)))
+              (while (and (not (oref prev hidden))
+                          (setq children (oref prev children)))
                 (setq prev (car (last children))))
-            (setq prev (magit-section-parent section)))
+            (setq prev (oref section parent)))
           (cond (prev
                  (magit-section-goto prev))
-                ((magit-section-parent section)
+                ((oref section parent)
                  (user-error "No previous section"))
                 ;; Eob special cases.
                 ((not (get-text-property (1- (point)) 'invisible))
@@ -258,7 +262,7 @@ the beginning of the current section."
 (defun magit-section-up ()
   "Move to the beginning of the parent section."
   (interactive)
-  (--if-let (magit-section-parent (magit-current-section))
+  (--if-let (oref (magit-current-section) parent)
       (magit-section-goto it)
     (user-error "No parent section")))
 
@@ -267,7 +271,7 @@ the beginning of the current section."
 If there is no next sibling section, then move to the parent."
   (interactive)
   (let ((current (magit-current-section)))
-    (if (magit-section-parent current)
+    (if (oref current parent)
         (--if-let (car (magit-section-siblings current 'next))
             (magit-section-goto it)
           (magit-section-forward))
@@ -278,7 +282,7 @@ If there is no next sibling section, then move to the parent."
 If there is no previous sibling section, then move to the parent."
   (interactive)
   (let ((current (magit-current-section)))
-    (if (magit-section-parent current)
+    (if (oref current parent)
         (--if-let (car (magit-section-siblings current 'prev))
             (magit-section-goto it)
           (magit-section-backward))
@@ -288,18 +292,18 @@ If there is no previous sibling section, then move to the parent."
   (if (integerp arg)
       (progn (forward-line arg)
              (setq arg (magit-current-section)))
-    (goto-char (magit-section-start arg)))
+    (goto-char (oref arg start)))
   (run-hook-with-args 'magit-section-movement-hook arg))
 
 (defun magit-section-set-window-start (section)
   "Ensure the beginning of SECTION is visible."
-  (unless (pos-visible-in-window-p (magit-section-end section))
-    (set-window-start (selected-window) (magit-section-start section))))
+  (unless (pos-visible-in-window-p (oref section end))
+    (set-window-start (selected-window) (oref section start))))
 
 (defun magit-hunk-set-window-start (section)
   "When SECTION is a `hunk', ensure that its beginning is visible.
 It the SECTION has a different type, then do nothing."
-  (when (eq (magit-section-type section) 'hunk)
+  (when (eq (oref section type) 'hunk)
     (magit-section-set-window-start section)))
 
 (defmacro magit-define-section-jumper (name heading type &optional value)
@@ -314,7 +318,7 @@ With a prefix argument also expand it." heading)
      (--if-let (magit-get-section
                 (cons (cons ',type ,value)
                       (magit-section-ident magit-root-section)))
-         (progn (goto-char (magit-section-start it))
+         (progn (goto-char (oref it start))
                 (when expand
                   (with-local-quit (magit-section-show it))
                   (recenter 0)))
@@ -325,25 +329,25 @@ With a prefix argument also expand it." heading)
 (defun magit-section-show (section)
   "Show the body of the current section."
   (interactive (list (magit-current-section)))
-  (setf (magit-section-hidden section) nil)
-  (-when-let (washer (magit-section-washer section))
-    (setf (magit-section-washer section) nil)
+  (oset section hidden nil)
+  (-when-let (washer (oref section washer))
+    (oset section washer nil)
     (let ((inhibit-read-only t)
           (magit-insert-section--parent section)
-          (content (magit-section-content section)))
+          (content (oref section content)))
       (save-excursion
-        (if (and content (< content (magit-section-end section)))
+        (if (and content (< content (oref section end)))
             (funcall washer section) ; already partially washed (hunk)
-          (goto-char (magit-section-end section))
-          (setf (magit-section-content section) (point-marker))
+          (goto-char (oref section end))
+          (oset section content (point-marker))
           (funcall washer)
-          (setf (magit-section-end section) (point-marker)))))
+          (oset section end (point-marker)))))
     (magit-section-update-highlight))
-  (-when-let (beg (magit-section-content section))
-    (remove-overlays beg (magit-section-end section) 'invisible t))
+  (-when-let (beg (oref section content))
+    (remove-overlays beg (oref section end) 'invisible t))
   (magit-section-maybe-cache-visibility section)
-  (dolist (child (magit-section-children section))
-    (if (magit-section-hidden child)
+  (dolist (child (oref section children))
+    (if (oref child hidden)
         (magit-section-hide child)
       (magit-section-show child))))
 
@@ -352,9 +356,9 @@ With a prefix argument also expand it." heading)
   (interactive (list (magit-current-section)))
   (if (eq section magit-root-section)
       (user-error "Cannot hide root section")
-    (setf (magit-section-hidden section) t)
-    (-when-let (beg (magit-section-content section))
-      (let ((end (magit-section-end section)))
+    (oset section hidden t)
+    (-when-let (beg (oref section content))
+      (let ((end (oref section end)))
         (remove-overlays beg end 'invisible t)
         (let ((o (make-overlay beg end)))
           (overlay-put o 'evaporate t)
@@ -366,19 +370,19 @@ With a prefix argument also expand it." heading)
   (interactive (list (magit-current-section)))
   (if (eq section magit-root-section)
       (user-error "Cannot hide root section")
-    (goto-char (magit-section-start section))
-    (if (magit-section-hidden section)
+    (goto-char (oref section start))
+    (if (oref section hidden)
         (magit-section-show section)
       (magit-section-hide section))))
 
 (defun magit-section-toggle-children (section)
   "Toggle visibility of bodies of children of the current section."
   (interactive (list (magit-current-section)))
-  (goto-char (magit-section-start section))
-  (let* ((children (magit-section-children section))
-         (show (-any-p 'magit-section-hidden children)))
+  (goto-char (oref section start))
+  (let* ((children (oref section children))
+         (show (--any-p (oref it hidden) children)))
     (dolist (c children)
-      (setf (magit-section-hidden c) show)))
+      (oset c hidden show)))
   (magit-section-show section))
 
 (defun magit-section-show-children (section &optional depth)
@@ -390,18 +394,18 @@ children."
   (magit-section-show section))
 
 (defun magit-section-show-children-1 (section &optional depth)
-  (dolist (s (magit-section-children section))
-    (setf (magit-section-hidden s) nil)
+  (--each (oref section children)
+    (oset it hidden nil)
     (if depth
         (if (> depth 0)
-            (magit-section-show-children-1 s (1- depth))
-          (magit-section-hide s))
-      (magit-section-show-children-1 s))))
+            (magit-section-show-children-1 it (1- depth))
+          (magit-section-hide it))
+      (magit-section-show-children-1 it))))
 
 (defun magit-section-hide-children (section)
   "Recursively hide the bodies of children of the current section."
   (interactive (list (magit-current-section)))
-  (mapc 'magit-section-hide (magit-section-children section)))
+  (mapc 'magit-section-hide (oref section children)))
 
 (defun magit-section-show-headings (section)
   "Recursively show headings of children of the current section.
@@ -412,22 +416,22 @@ hidden."
   (magit-section-show section))
 
 (defun magit-section-show-headings-1 (section)
-  (dolist (s (magit-section-children section))
-    (setf (magit-section-hidden s) nil)
-    (when (or (magit-section-children s)
-              (not (magit-section-content s)))
-      (magit-section-show-headings-1 s))))
+  (--each (oref section children)
+    (oset it hidden nil)
+    (when (or (oref it children)
+              (not (oref it content)))
+      (magit-section-show-headings-1 it))))
 
 (defun magit-section-cycle (section)
   "Cycle visibility of current section and its children."
   (interactive (list (magit-current-section)))
-  (goto-char (magit-section-start section))
-  (if (magit-section-hidden section)
+  (goto-char (oref section start))
+  (if (oref section hidden)
       (progn (magit-section-show section)
              (magit-section-hide-children section))
-    (let ((children (magit-section-children section)))
-      (cond ((and (-any-p 'magit-section-hidden   children)
-                  (-any-p 'magit-section-children children))
+    (let ((children (oref section children)))
+      (cond ((and (--any-p (oref it hidden)   children)
+                  (--any-p (oref it children) children))
              (magit-section-show-headings section))
             ((-any-p 'magit-section-hidden-body children)
              (magit-section-show-children section))
@@ -437,9 +441,9 @@ hidden."
 (defun magit-section-cycle-global ()
   "Cycle visibility of all sections in the current buffer."
   (interactive)
-  (let ((children (magit-section-children magit-root-section)))
-    (cond ((and (-any-p 'magit-section-hidden   children)
-                (-any-p 'magit-section-children children))
+  (let ((children (oref magit-root-section children)))
+    (cond ((and (--any-p (oref it hidden)   children)
+                (--any-p (oref it children) children))
            (magit-section-show-headings magit-root-section))
           ((-any-p 'magit-section-hidden-body children)
            (magit-section-show-children magit-root-section))
@@ -453,21 +457,21 @@ hidden."
               (cond ((derived-mode-p 'magit-status-mode)
                      (--mapcat
                       (when it
-                        (when (magit-section-hidden it)
+                        (when (oref it hidden)
                           (magit-section-show it))
-                        (magit-section-children it))
+                        (oref it children))
                       (list (magit-get-section '((staged)   (status)))
                             (magit-get-section '((unstaged) (status))))))
                     ((derived-mode-p 'magit-diff-mode)
-                     (--filter (eq (magit-section-type it) 'file)
-                               (magit-section-children magit-root-section)))))
-    (if (-any-p 'magit-section-hidden sections)
+                     (--filter (eq (oref it type) 'file)
+                               (oref magit-root-section children)))))
+    (if (--any-p (oref it hidden) sections)
         (dolist (s sections)
           (magit-section-show s)
           (magit-section-hide-children s))
-      (let ((children (-mapcat 'magit-section-children sections)))
-        (cond ((and (-any-p 'magit-section-hidden   children)
-                    (-any-p 'magit-section-children children))
+      (let ((children (--mapcat (oref it children) sections)))
+        (cond ((and (--any-p (oref it hidden)   children)
+                    (--any-p (oref it children) children))
                (mapc 'magit-section-show-headings sections))
               ((-any-p 'magit-section-hidden-body children)
                (mapc 'magit-section-show-children sections))
@@ -475,17 +479,17 @@ hidden."
                (mapc 'magit-section-hide sections)))))))
 
 (defun magit-section-hidden-body (section &optional pred)
-  (--if-let (magit-section-children section)
+  (--if-let (oref section children)
       (funcall (or pred '-any-p) 'magit-section-hidden-body it)
-    (and (magit-section-content section)
-         (magit-section-hidden  section))))
+    (and (oref section content)
+         (oref section hidden))))
 
 (defun magit-section-invisible-p (section)
   "Return t if the SECTION's body is invisible.
 When the body of an ancestor of SECTION is collapsed then
 SECTION's body (and heading) obviously cannot be visible."
-  (or (magit-section-hidden section)
-      (--when-let (magit-section-parent section)
+  (or (oref section hidden)
+      (--when-let (oref section parent)
         (magit-section-invisible-p it))))
 
 (defun magit-section-show-level (level)
@@ -496,11 +500,13 @@ Sections at higher levels are hidden."
       (let ((s (magit-current-section)))
         (setq level (- level))
         (while (> (1- (length (magit-section-ident s))) level)
-          (setq s (magit-section-parent s))
-          (goto-char (magit-section-start s)))
+          (setq s (oref s parent))
+          (goto-char (oref s start)))
         (magit-section-show-children magit-root-section (1- level)))
-    (cl-do* ((s (magit-current-section) (magit-section-parent s))
-             (i (1- (length (magit-section-ident s))) (cl-decf i)))
+    (cl-do* ((s (magit-current-section)
+                (oref s parent))
+             (i (1- (length (magit-section-ident s)))
+                (cl-decf i)))
         ((cond ((< i level) (magit-section-show-children s (- level i 1)) t)
                ((= i level) (magit-section-hide s) t))
          (magit-section-goto s)))))
@@ -553,10 +559,10 @@ This command is intended for debugging purposes."
   (interactive)
   (let ((section (magit-current-section)))
     (message "%S %S %s-%s"
-             (magit-section-value section)
+             (oref section value)
              (apply 'vector (mapcar 'car (magit-section-ident section)))
-             (marker-position (magit-section-start section))
-             (marker-position (magit-section-end section)))))
+             (marker-position (oref section start))
+             (marker-position (oref section end)))))
 
 ;;; Match
 
@@ -623,7 +629,7 @@ See `magit-section-match' for the forms CONDITION can take."
      ;; to not quote CONDITION because that would needlessly break
      ;; backward compatibility.
      (when (magit-section-match ',condition it)
-       ,@(or body '((magit-section-value it))))))
+       ,@(or body '((oref it value))))))
 
 (defmacro magit-section-case (&rest clauses)
   "Choose among clauses on the type of the section at point.
@@ -718,7 +724,7 @@ anything this time around.
                          :value ,(nth 1 (car args))
                          :start (point-marker)
                          :parent magit-insert-section--parent)))
-       (setf (magit-section-hidden ,s)
+       (oset ,s hidden
              (-if-let (value (run-hook-with-args-until-success
                               'magit-section-set-visibility-hook ,s))
                  (eq value 'hide)
@@ -726,7 +732,7 @@ anything this time around.
                               (magit-get-section
                                (magit-section-ident ,s)
                                magit-insert-section--oldroot))
-                   (magit-section-hidden it)
+                   (oref it hidden)
                  ,(nth 2 (car args)))))
        (let ((magit-insert-section--current ,s)
              (magit-insert-section--parent  ,s)
@@ -739,13 +745,12 @@ anything this time around.
            ,@(cdr args)
            (run-hooks 'magit-insert-section-hook)
            (magit-insert-child-count ,s)
-           (set-marker-insertion-type (magit-section-start ,s) t)
-           (let* ((end (setf (magit-section-end ,s) (point-marker)))
-                  (map (intern (format "magit-%s-section-map"
-                                       (magit-section-type ,s))))
+           (set-marker-insertion-type (oref ,s start) t)
+           (let* ((end (oset ,s end (point-marker)))
+                  (map (intern (format "magit-%s-section-map" (oref ,s type))))
                   (map (and (boundp map) (symbol-value map))))
              (save-excursion
-               (goto-char (magit-section-start ,s))
+               (goto-char (oref ,s start))
                (while (< (point) end)
                  (let ((next (or (next-single-property-change
                                   (point) 'magit-section)
@@ -757,16 +762,16 @@ anything this time around.
                    (goto-char next)))))
            (if (eq ,s magit-root-section)
                (magit-section-show ,s)
-             (setf (magit-section-children (magit-section-parent ,s))
-                   (nconc (magit-section-children (magit-section-parent ,s))
+             (oset (oref ,s parent) children
+                   (nconc (oref (oref ,s parent) children)
                           (list ,s)))))
          ,s))))
 
 (defun magit-cancel-section ()
   (when magit-insert-section--current
-    (if (not (magit-section-parent magit-insert-section--current))
+    (if (not (oref magit-insert-section--current parent))
         (insert "(empty)\n")
-      (delete-region (magit-section-start magit-insert-section--current)
+      (delete-region (oref magit-insert-section--current start)
                      (point))
       (setq magit-insert-section--current nil)
       (throw 'cancel-section nil))))
@@ -807,7 +812,7 @@ insert a newline character if necessary."
   (unless (bolp)
     (insert ?\n))
   (magit-maybe-make-margin-overlay)
-  (setf (magit-section-content magit-insert-section--current) (point-marker)))
+  (oset magit-insert-section--current content (point-marker)))
 
 (defvar magit-insert-headers--hook nil "For internal use only.")
 (defvar magit-insert-headers--beginning nil "For internal use only.")
@@ -845,9 +850,9 @@ evaluated its BODY.  Admittedly that's a bit of a hack."
   ;; This has to be fast, not pretty!
   (let (content count)
     (when (and magit-section-show-child-count
-               (setq count (length (magit-section-children section)))
+               (setq count (length (oref section children)))
                (> count 0)
-               (setq content (magit-section-content section))
+               (setq content (oref section content))
                (eq (char-before (1- content)) ?:))
       (save-excursion
         (goto-char (- content 2))
@@ -889,7 +894,8 @@ evaluated its BODY.  Admittedly that's a bit of a hack."
         (restore-buffer-modified-p nil)
         (unless (eq magit-section-highlighted-section section)
           (setq magit-section-highlighted-section
-                (unless (magit-section-hidden section) section))))
+                (and (not (oref section hidden))
+                     section))))
       (setq deactivate-mark nil))))
 
 (defun magit-section-highlight (section selection)
@@ -898,13 +904,13 @@ This function works for any section but produces undesirable
 effects for diff related sections, which by default are
 highlighted using `magit-diff-highlight'.  Return t."
   (cond (selection
-         (magit-section-make-overlay (magit-section-start     (car selection))
-                                     (magit-section-end (car (last selection)))
+         (magit-section-make-overlay (oref (car selection) start)
+                                     (oref (car (last selection)) end)
                                      'magit-section-highlight)
          (magit-section-highlight-selection nil selection))
         (t
-         (magit-section-make-overlay (magit-section-start section)
-                                     (magit-section-end   section)
+         (magit-section-make-overlay (oref section start)
+                                     (oref section end)
                                      'magit-section-highlight)))
   t)
 
@@ -924,9 +930,9 @@ invisible."
   (when (and selection
              (not (and (eq this-command 'mouse-drag-region))))
     (--each selection
-      (magit-section-make-overlay (magit-section-start it)
-                                  (or (magit-section-content it)
-                                      (magit-section-end it))
+      (magit-section-make-overlay (oref it start)
+                                  (or (oref it content)
+                                      (oref it end))
                                   'magit-section-heading-selection))
     t))
 
@@ -947,7 +953,7 @@ invisible."
 (defun magit-section-goto-successor (section line char arg)
   (let ((ident (magit-section-ident section)))
     (--if-let (magit-get-section ident)
-        (let ((start (magit-section-start it)))
+        (let ((start (oref it start)))
           (goto-char start)
           (unless (eq it magit-root-section)
             (ignore-errors
@@ -955,11 +961,11 @@ invisible."
               (forward-char char))
             (unless (eq (magit-current-section) it)
               (goto-char start))))
-      (or (and (eq (magit-section-type section) 'hunk)
+      (or (and (eq (oref section type) 'hunk)
                (-when-let (parent (magit-get-section
                                    (magit-section-ident
-                                    (magit-section-parent section))))
-                 (let* ((children (magit-section-children parent))
+                                    (oref section parent))))
+                 (let* ((children (oref parent children))
                         (siblings (magit-section-siblings section 'prev))
                         (previous (nth (length siblings) children)))
                    (if (not arg)
@@ -969,22 +975,21 @@ invisible."
                      (when previous
                        (magit-section-goto previous))
                      (if (and (stringp arg)
-                              (re-search-forward
-                               arg (magit-section-end parent) t))
+                              (re-search-forward arg (oref parent end) t))
                          (goto-char (match-beginning 0))
-                       (goto-char (magit-section-end (car (last children))))
+                       (goto-char (oref (car (last children)) end))
                        (forward-line -1)
                        (while (looking-at "^ ")    (forward-line -1))
                        (while (looking-at "^[-+]") (forward-line -1))
                        (forward-line))))))
           (goto-char (--if-let (magit-section-goto-successor-1 section)
-                         (if (eq (magit-section-type it) 'button)
+                         (if (eq (oref it type) 'button)
                              (point-min)
-                           (magit-section-start it))
+                           (oref it start))
                        (point-min)))))))
 
 (defun magit-section-goto-successor-1 (section)
-  (or (--when-let (pcase (magit-section-type section)
+  (or (--when-let (pcase (oref section type)
                     (`staged 'unstaged)
                     (`unstaged 'staged)
                     (`unpushed 'unpulled)
@@ -994,7 +999,7 @@ invisible."
         (magit-get-section (magit-section-ident it)))
       (--when-let (car (magit-section-siblings section 'prev))
         (magit-get-section (magit-section-ident it)))
-      (--when-let (magit-section-parent section)
+      (--when-let (oref section parent)
         (or (magit-get-section (magit-section-ident it))
             (magit-section-goto-successor-1 it)))))
 
@@ -1013,20 +1018,20 @@ invisible."
   ;; Emacs 24 doesn't have `alist-get'.
   (let* ((id  (magit-section-visibility-ident section))
          (elt (assoc id magit-section-visibility-cache))
-         (val (if (magit-section-hidden section) 'hide 'show)))
+         (val (if (oref section hidden) 'hide 'show)))
     (if elt
         (setcdr elt val)
       (push (cons id val) magit-section-visibility-cache))))
 
 (cl-defun magit-section-maybe-cache-visibility
     (&optional (section magit-insert-section--current))
-  (when (memq (magit-section-type section)
+  (when (memq (oref section type)
               magit-section-cache-visibility-types)
     (magit-section-cache-visibility section)))
 
 (defun magit-section-visibility-ident (section)
-  (let ((type  (magit-section-type  section))
-        (value (magit-section-value section)))
+  (let ((type  (oref section type))
+        (value (oref section value)))
     (cons type
           (cond ((not (memq type '(unpulled unpushed))) value)
                 ((string-match-p "@{upstream}" value) value)
@@ -1058,12 +1063,12 @@ invisible."
             (memq section (if sselection
                               selection
                             (setq selection (magit-region-sections))))
-            (--when-let (magit-section-parent section)
+            (--when-let (oref section parent)
               (magit-section-selected-p it selection)))))
 
 (defun magit-section-parent-value (section)
-  (setq section (magit-section-parent section))
-  (when section (magit-section-value  section)))
+  (-when-let (parent (oref section parent))
+    (oref parent value)))
 
 (defun magit-section-siblings (section &optional direction)
   "Return a list of the sibling sections of SECTION.
@@ -1072,8 +1077,8 @@ If optional DIRECTION is `prev', then return siblings that come
 before SECTION.  If it is `next', then return siblings that come
 after SECTION.  For all other values, return all siblings
 excluding SECTION itself."
-  (-when-let (parent (magit-section-parent section))
-    (let ((siblings  (magit-section-children parent)))
+  (-when-let (parent (oref section parent))
+    (let ((siblings (oref parent children)))
       (pcase direction
         (`prev  (cdr (member section (reverse siblings))))
         (`next  (cdr (member section siblings)))
@@ -1088,7 +1093,8 @@ or is not a valid section selection, then return nil.  If optional
 TYPES is non-nil then the selection not only has to be valid; the
 types of all selected sections additionally have to match one of
 TYPES, or nil is returned."
-  (mapcar #'magit-section-value (magit-region-sections types multiple)))
+  (--map (oref it value)
+         (magit-region-sections types multiple)))
 
 (defun magit-region-sections (&optional types multiple)
   "Return a list of the selected sections.
@@ -1136,7 +1142,7 @@ single type, instead of a list of types."
             (when (and types (symbolp types))
               (setq types (list types)))
             (when (or (not types)
-                      (--all-p (memq (magit-section-type it) types) sections))
+                      (--all-p (memq (oref it type) types) sections))
               sections)))))))
 
 (defun magit-section-position-in-heading-p (&optional section pos)
@@ -1148,9 +1154,9 @@ current section."
   (unless pos
     (setq pos (point)))
   (and section
-       (>= pos (magit-section-start section))
-       (<  pos (or (magit-section-content section)
-                   (magit-section-end section)))
+       (>= pos (oref section start))
+       (<  pos (or (oref section content)
+                   (oref section end)))
        t))
 
 (defun magit-section-internal-region-p (&optional section)

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -461,7 +461,8 @@ that make up the stash."
   (magit-insert-section section (note)
     (magit-insert-heading "Notes")
     (magit-git-insert "notes" "show" (car magit-refresh-args))
-    (if (= (point) (magit-section-content section))
+    (if (= (point)
+           (oref section content))
         (magit-cancel-section)
       (insert "\n"))))
 

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -236,8 +236,8 @@ whether they are wrapped in an additional section."
             (format "%s (%s)"
                     (propertize "Modules" 'face 'magit-section-heading)
                     (length modules)))
-          (if (magit-section-hidden section)
-              (setf (magit-section-washer section) 'magit--insert-modules)
+          (if (oref section hidden)
+              (oset section washer 'magit--insert-modules)
             (magit--insert-modules)))
       (magit--insert-modules))))
 
@@ -255,8 +255,8 @@ or, failing that, the abbreviated HEAD commit hash."
         (format "%s (%s)"
                 (propertize "Modules overview" 'face 'magit-section-heading)
                 (length modules)))
-      (if (magit-section-hidden section)
-          (setf (magit-section-washer section) 'magit--insert-modules-overview)
+      (if (oref section hidden)
+          (oset section washer 'magit--insert-modules-overview)
         (magit--insert-modules-overview)))))
 
 (defvar magit-modules-overview-align-numbers t)
@@ -383,9 +383,11 @@ These sections can be expanded to show the respective commits."
                   (concat (propertize module 'face 'magit-diff-file-heading) ":"))
                 (magit-git-wash (apply-partially 'magit-log-wash-log 'module)
                   "-c" "push.default=current" "log" "--oneline" range)
-                (when (> (point) (magit-section-content sec))
+                (when (> (point)
+                         (oref sec content))
                   (delete-char -1)))))))
-      (if (> (point) (magit-section-content section))
+      (if (> (point)
+             (oref section content))
           (insert ?\n)
         (magit-cancel-section)))))
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -807,7 +807,7 @@ above."
   (if (use-region-p)
       (copy-region-as-kill nil nil 'region)
     (-when-let* ((section (magit-current-section))
-                 (value (magit-section-value section)))
+                 (value (oref section value)))
       (magit-section-case
         ((branch commit module-commit tag)
          (let ((default-directory default-directory) ref)

--- a/t/magit-tests.el
+++ b/t/magit-tests.el
@@ -254,9 +254,9 @@
 
 (defun magit-test-get-section (list file)
   (magit-status-internal default-directory)
-  (--first (equal (magit-section-value it) file)
-           (magit-section-children
-            (magit-get-section `(,list (status))))))
+  (--first (equal (oref it value) file)
+           (oref (magit-get-section `(,list (status)))
+                 children)))
 
 (ert-deftest magit-status:file-sections ()
   (magit-with-test-repository


### PR DESCRIPTION
This is only a first step. The benefits will come once we start using generic functions.