### PR TITLE
magit-submodule-add: check for Ido advice

### DIFF
--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -132,7 +132,10 @@ PATH also becomes the name."
    (magit-with-toplevel
      (let* ((url (magit-read-string-ns "Add submodule (remote url)"))
             (path (let ((read-file-name-function
-                         (if (eq read-file-name-function 'ido-read-file-name)
+                         (if (or (eq read-file-name-function 'ido-read-file-name)
+                                 (advice-function-member-p
+                                  'ido-read-file-name
+                                  read-file-name-function))
                              ;; The Ido variant doesn't work properly here.
                              #'read-file-name-default
                            read-file-name-function)))


### PR DESCRIPTION
`magit-submodule-add` currently checks whether `ido-read-file-name` will be used by comparing with `eq` against `read-file-name-function`. However, as of Emacs 26, the `ido-everywhere` minor mode uses `add-function` rather than setting `read-file-name-function` directly. Thus, also check with `advice-function-member-p`.

On the other hand, I briefly tested `magit-submodule-add` with `ido-read-file-name` in Emacs 27.0.50 and it seemed to work as I expected, so maybe the kludge isn't necessary in newer Emacsen? I don't know what the original problem was though.
