### PR TITLE
Use mode-line-process to indicate process errors

### DIFF
--- a/Documentation/RelNotes/2.12.0.txt
+++ b/Documentation/RelNotes/2.12.0.txt
@@ -200,14 +200,26 @@ Changes since v2.11.0
   with `magit-branch-pull-request' or `magit-checkout-pull-request',
   provided that remote has no other tracking branches.  #3134
 
-* Added new face `magit-mode-line-process' which is applied to the
-  mode line process status indicator shown while Git is running for
-  side-effects.  This improves the visibility of pending asynchronous
+* The mode line process indicator, displayed in the mode line when Git
+  is run for side-effects, is now more visible than before, and is
+  additionally used to highlight process errors.
+
+  New face `magit-mode-line-process' is applied to the mode line
+  process indicator to improve the visibility of pending asynchronous
   processes (in particular), as Magit remains responsive after
   initiating such commands (for instance fetching or rebasing), but
   will not update its buffers until the process has completed, which
   might take longer than anticipated.  Customize this face if you wish
   to make this indicator more (or less) visible.  #3284
+
+  If the Git process returns an error, the mode line process indicator
+  is no longer removed, and new face `magit-mode-line-process-error`
+  is applied to highlight the error status.  Details of the error from
+  the process buffer are also provided as a tooltip.  The error
+  indicator will remain visible in the mode line until a magit buffer
+  is refreshed.  If you do not want errors to be indicated in the mode
+  line, customize the `magit-process-display-mode-line-error' user
+  option.  #3297
 
 * When staging and unstaging at the file level and there are arguments
   that cause whitespace differences to be hidden, then apply the

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1551,12 +1551,14 @@ will also have to install the ~ido-completing-read+~ package and use
 *** Viewing Git Output
 
 Magit runs Git either for side-effects (e.g. when pushing) or to get
-some value (e.g. the name of the current branch).  When Git is run for
-side-effects, the mode line displays a process status indicator (using
-the ~magit-mode-line-process~ face), and the process output goes into
-a per-repository log buffer, which can be consulted when things don't
-go as expected.  Process errors are indicated at the top of the status
-buffer.
+some value (e.g. the name of the current branch).
+
+When Git is run for side-effects, the process output is logged in a
+per-repository log buffer, which can be consulted using the
+~magit-process~ command when things don't go as expected.
+
+The output/errors for up to `magit-process-log-max' Git commands are
+retained.
 
 - Key: $, magit-process
 
@@ -1575,6 +1577,26 @@ sections are available.  There is one additional command.
   When this is non-nil then the output of all calls to git are logged
   in the process buffer.  This is useful when debugging, otherwise it
   just negatively affects performance.
+
+*** Git Process Status
+
+When a Git process is running for side-effects, Magit displays an
+indicator in the mode line, using the ~magit-mode-line-process~ face.
+
+If the Git process exits successfully, the process indicator is
+removed from the mode line immediately.
+
+In the case of a Git error, the process indicator is not removed, but
+is instead highlighted with the ~magit-mode-line-process-error~ face,
+and the error details from the process buffer are provided as a
+tooltip for mouse users.  This error indicator persists in the mode
+line until the next magit buffer refresh.
+
+If you do not wish process errors to be indicated in the mode line,
+customize the ~magit-process-display-mode-line-error~ user option.
+
+Process errors are additionally indicated at the top of the status
+buffer.
 
 *** Running Git Manually
 

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1011,6 +1011,7 @@ Run hooks `magit-pre-refresh-hook' and `magit-post-refresh-hook'."
         (setq magit-section-highlighted-section nil)
         (setq magit-section-highlighted-sections nil)
         (setq magit-section-unhighlight-sections nil)
+        (magit-process-unset-mode-line-error-status)
         (let ((inhibit-read-only t))
           (erase-buffer)
           (save-excursion

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -817,12 +817,22 @@ as argument."
 (advice-add 'tramp-sh-handle-process-file :around
             'tramp-sh-handle-process-file--magit-tramp-process-environment)
 
+(defvar magit-mode-line-process-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "<mode-line> <mouse-1>")
+      'magit-process-buffer)
+    map)
+  "Keymap for `mode-line-process'.")
+
 (defun magit-process-set-mode-line (program args)
   "Display the git command (sans arguments) in the mode line."
   (when (equal program magit-git-executable)
     (setq args (nthcdr (length magit-git-global-arguments) args)))
   (let ((str (concat " " (propertize
                           (concat program (and args (concat " " (car args))))
+                          'mouse-face 'highlight
+                          'keymap magit-mode-line-process-map
+                          'help-echo "mouse-1: Show process buffer"
                           'face 'magit-mode-line-process))))
     (magit-repository-local-set 'mode-line-process str)
     (dolist (buf (magit-mode-get-buffers))
@@ -840,8 +850,14 @@ If ERROR is supplied, include it in the `mode-line-process' tooltip.
 If STR is supplied, it replaces the `mode-line-process' text."
   (setq str (or str (magit-repository-local-get 'mode-line-process)))
   (when str
+    (setq error (format "%smouse-1: Show process buffer"
+                        (if (stringp error)
+                            (concat error "\n\n")
+                          "")))
     (setq str (concat " " (propertize
                            (substring-no-properties str 1)
+                           'mouse-face 'highlight
+                           'keymap magit-mode-line-process-map
                            'help-echo error
                            'face 'magit-mode-line-process-error)))
     (magit-repository-local-set 'mode-line-process str)

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -793,6 +793,7 @@ as argument."
             'tramp-sh-handle-process-file--magit-tramp-process-environment)
 
 (defun magit-process-set-mode-line (program args)
+  "Display the git command (sans arguments) in the mode line."
   (when (equal program magit-git-executable)
     (setq args (nthcdr (length magit-git-global-arguments) args)))
   (let ((str (concat " " (propertize
@@ -800,11 +801,14 @@ as argument."
                           'face 'magit-mode-line-process))))
     (dolist (buf (magit-mode-get-buffers))
       (with-current-buffer buf
-        (setq mode-line-process str)))))
+        (setq mode-line-process str)))
+    (force-mode-line-update t)))
 
 (defun magit-process-unset-mode-line ()
+  "Remove the git command from the mode line."
   (dolist (buf (magit-mode-get-buffers))
-    (with-current-buffer buf (setq mode-line-process nil))))
+    (with-current-buffer buf (setq mode-line-process nil)))
+  (force-mode-line-update t))
 
 (defvar magit-process-error-message-regexps
   (list "^\\*ERROR\\*: Canceled by user$"

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -609,8 +609,7 @@ Magit status buffer."
               (magit-refresh))
           (with-temp-buffer
             (setq default-directory (process-get process 'default-dir))
-            (magit-refresh)))))
-    (force-mode-line-update t)))
+            (magit-refresh)))))))
 
 (defun magit-sequencer-process-sentinel (process event)
   "Special sentinel used by `magit-run-git-sequencer'."


### PR DESCRIPTION
Closes #3297

This provides an error state for `mode-line-process`, when the Git process exits with an error.

This includes an error face, a mouse tooltip with the error details, and a keymap so users can click to open the process log.

A by-product of this was a new general-purpose "repository-local" value cache which provides a more persistent alternative to buffer-local variables for storing data which is relevant to the repository in general.  I added the code for this in `magit-mode.el` primarily because that is where the `magit--default-directory` variable is defined, as this value is used to identify the repository.

Questions:

* I've made `magit-repository-local-repository` call `magit--not-inside-repository-error` if it can't establish a repository key. Is that sensible?

* I've limited the number of *lines* displayed in the tooltip for an error, but not the number of columns.  Is that likely to be a problem?

* In `magit-process-finish` it used to be the case that calling `magit-process-unset-mode-line` was one of the very first things to happen, which meant that even if an elisp error occurred in subsequent code, the mode line would still have been cleaned up.  Now that I'm leaving this until later, there is more potential for a stale `mode-line-process` to be left behind (but presumably only if there are bugs).  Is that ok, or should I split the code in order to take care of the no-error case back where it used to happen?
