### PR TITLE
Add trailing space to yes-or-no-p prompts

### DIFF
--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -522,7 +522,7 @@ that is being reset."
     (setq args (cons "--force" args)))
   (if (equal branch (magit-get-current-branch))
       (if (and (magit-anything-modified-p)
-               (not (yes-or-no-p "Uncommitted changes will be lost.  Proceed?")))
+               (not (yes-or-no-p "Uncommitted changes will be lost.  Proceed? ")))
           (user-error "Abort")
         (magit-reset-hard to)
         (when (and set-upstream (magit-branch-p to))

--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -141,7 +141,7 @@ conflicts, including those already resolved by Git, use
          (let ((bufC ediff-buffer-C)
                (bufS smerge-ediff-buf))
            (with-current-buffer bufS
-             (when (yes-or-no-p (format "Conflict resolution finished; save %s?"
+             (when (yes-or-no-p (format "Conflict resolution finished; save %s? "
                                         buffer-file-name))
                (erase-buffer)
                (insert-buffer-substring bufC)


### PR DESCRIPTION
A couple of yes-or-no-p prompts were missing a space after the prompt.
