### PR TITLE
Update manual installation to include ghub dependency

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -7,7 +7,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.11.0 (2.11.0-350-g2eb2f60d3+1)
+#+SUBTITLE: for version 2.11.0 (2.11.0-356-gebd8c651+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -22,7 +22,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.11.0 (2.11.0-350-g2eb2f60d3+1).
+This manual is for Magit version 2.11.0 (2.11.0-356-gebd8c651+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@bernoul.li>
@@ -164,8 +164,8 @@ Now see [[*Post-Installation Tasks]].
 
 ** Installing from the Git Repository
 
-Magit depends on the ~dash~, ~magit-popup~ and ~with-editor~ libraries which
-are available from Melpa and Melpa-Stable.  Install them using ~M-x
+Magit depends on the ~dash~, ~magit-popup~, ~ghub~ and ~with-editor~ libraries
+which are available from Melpa and Melpa-Stable.  Install them using ~M-x
 package-install RET <package> RET~.  Of course you may also install
 them manually from their development repository.
 
@@ -188,15 +188,16 @@ Then compile the libraries and generate the info manuals:
   $ make
 #+END_SRC
 
-If you haven't installed ~dash~, ~magit-popup~ and ~with-editor~ from Melpa
-or at ~/path/to/magit/../<package>~, then you have to tell ~make~ where to
-find them.  To do so create the file ~/path/to/magit/config.mk~ with the
+If you haven't installed ~dash~, ~magit-popup~, ~ghub~ and ~with-editor~ from
+Melpa or at ~/path/to/magit/../<package>~, then you have to tell ~make~ where
+to find them.  To do so create the file ~/path/to/magit/config.mk~ with the
 following content before running ~make~:
 
 #+BEGIN_SRC makefile
   LOAD_PATH  = -L /path/to/magit/lisp
   LOAD_PATH += -L /path/to/dash
   LOAD_PATH += -L /path/to/magit-popup
+  LOAD_PATH += -L /path/to/ghub
   LOAD_PATH += -L /path/to/with-editor
 #+END_SRC
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -30,7 +30,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.11.0 (2.11.0-350-g2eb2f60d3+1)
+@subtitle for version 2.11.0 (2.11.0-356-gebd8c651+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -52,7 +52,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.11.0 (2.11.0-350-g2eb2f60d3+1).
+This manual is for Magit version 2.11.0 (2.11.0-356-gebd8c651+1).
 
 @quotation
 Copyright (C) 2015-2017 Jonas Bernoulli <jonas@@bernoul.li>
@@ -468,8 +468,8 @@ Now see @ref{Post-Installation Tasks}.
 @node Installing from the Git Repository
 @section Installing from the Git Repository
 
-Magit depends on the @code{dash}, @code{magit-popup} and @code{with-editor} libraries which
-are available from Melpa and Melpa-Stable.  Install them using @code{M-x
+Magit depends on the @code{dash}, @code{magit-popup}, @code{ghub} and @code{with-editor} libraries
+which are available from Melpa and Melpa-Stable.  Install them using @code{M-x
 package-install RET <package> RET}.  Of course you may also install
 them manually from their development repository.
 
@@ -492,15 +492,16 @@ Then compile the libraries and generate the info manuals:
 $ make
 @end example
 
-If you haven't installed @code{dash}, @code{magit-popup} and @code{with-editor} from Melpa
-or at @code{/path/to/magit/../<package>}, then you have to tell @code{make} where to
-find them.  To do so create the file @code{/path/to/magit/config.mk} with the
+If you haven't installed @code{dash}, @code{magit-popup}, @code{ghub} and @code{with-editor} from
+Melpa or at @code{/path/to/magit/../<package>}, then you have to tell @code{make} where
+to find them.  To do so create the file @code{/path/to/magit/config.mk} with the
 following content before running @code{make}:
 
 @example
 LOAD_PATH  = -L /path/to/magit/lisp
 LOAD_PATH += -L /path/to/dash
 LOAD_PATH += -L /path/to/magit-popup
+LOAD_PATH += -L /path/to/ghub
 LOAD_PATH += -L /path/to/with-editor
 @end example
 


### PR DESCRIPTION
`make` does not succeed without `ghub` being available on the load path.