### PR TITLE
git-commit.el: declare diff-default-read-only

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -127,6 +127,7 @@
 (defvar flyspell-generic-check-word-predicate)
 (defvar font-lock-beg)
 (defvar font-lock-end)
+(defvar diff-default-read-only)
 
 (declare-function magit-expand-git-file-name 'magit-git)
 (declare-function magit-list-local-branch-names 'magit-git)


### PR DESCRIPTION
When doing `make lisp` I get:
```
In toplevel form:
git-commit.el:802:1:Warning: Unused lexical variable ‘diff-default-read-only’
```

Normally, I would just go ahead and push such a trivial fix directly, but I don't see this warning in the travis logs, so I'm wondering if there is something wrong on my end.