### PR TITLE
Bug fix for Git error summary messages

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -924,7 +924,8 @@ If STR is supplied, it replaces the `mode-line-process' text."
                      'magit-process-error-message-regexps
                      (lambda (re)
                        (save-excursion
-                         (and (re-search-backward re nil t)
+                         (and (re-search-backward
+                               re (magit-section-start section) t)
                               (or (match-string-no-properties 1)
                                   (and (not magit-process-raise-error)
                                        'suppressed))))))))))

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -909,7 +909,8 @@ If STR is supplied, it replaces the `mode-line-process' text."
 
 (defvar magit-process-error-message-regexps
   (list "^\\*ERROR\\*: Canceled by user$"
-        "^\\(?:error\\|fatal\\|git\\): \\(.*\\)$"))
+        "^\\(?:error\\|fatal\\|git\\): \\(.*\\)$"
+        "^\\(Cannot rebase:.*\\)$"))
 
 (define-error 'magit-git-error "Git error")
 


### PR DESCRIPTION
It was possible for Magit to report an earlier error instead of the current error.

I noticed this on account of "Cannot rebase" not being recognised as an error message, so I've added that to the list.