### PR TITLE
Add subject-prefix to magit-format-patch

### DIFF
--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -869,6 +869,7 @@ To add this command to the push popup add this to your init file:
               (?t "To"               "--to=")
               (?c "CC"               "--cc=")
               (?r "In reply to"      "--in-reply-to=")
+              (?P "Subject Prefix"   "--subject-prefix=")
               (?v "Reroll count"     "--reroll-count=")
               (?s "Thread style"     "--thread=")
               (?U "Context lines"    "-U")


### PR DESCRIPTION
This adds the ability to specify a subject prefix for patches created by
the `git-format-patch` command.  Adding this ability is especially
useful when creating versioned patch sets to be mailed.

Regarding the shortcut key, I've debated either `P` or `S`.  I'm not
aware of any other good candidates.

Signed-off-by: Kenny Ballou <kballou@devnulllabs.io>