### PR TITLE
Use thing-at-point to guess which GitHub pull request is desired

### DIFF
--- a/lisp/magit-collab.el
+++ b/lisp/magit-collab.el
@@ -91,7 +91,10 @@ only supports Github, but that will change eventually."
                            (cdr (assq 'number pull-request))
                            (cdr (assq 'title  pull-request)))))
          (prs    (ghub-get (format "/repos/%s/pulls" id) nil :auth 'magit))
-         (choice (magit-completing-read prompt (mapcar fmtfun prs)))
+         (choice (magit-completing-read
+                  prompt (mapcar fmtfun prs) nil nil nil nil
+                  (let ((default (thing-at-point 'github-pull-request)))
+                    (and default (funcall fmtfun default)))))
          (number (and (string-match "\\([0-9]+\\)" choice)
                       (string-to-number (match-string 1 choice)))))
     (and number

--- a/lisp/magit-collab.el
+++ b/lisp/magit-collab.el
@@ -86,13 +86,12 @@ only supports Github, but that will change eventually."
          (id     (and (string-match "github.com[:/]\\(.+?\\)\\(?:\\.git\\)?\\'"
                                     url)
                       (match-string 1 url)))
+         (fmtfun (lambda (pull-request)
+                   (format "%s  %s"
+                           (cdr (assq 'number pull-request))
+                           (cdr (assq 'title  pull-request)))))
          (prs    (ghub-get (format "/repos/%s/pulls" id) nil :auth 'magit))
-         (choice (magit-completing-read
-                  prompt
-                  (--map (format "%s  %s"
-                                 (cdr (assq 'number it))
-                                 (cdr (assq 'title  it)))
-                         prs)))
+         (choice (magit-completing-read prompt (mapcar fmtfun prs)))
          (number (and (string-match "\\([0-9]+\\)" choice)
                       (string-to-number (match-string 1 choice)))))
     (and number

--- a/lisp/magit-collab.el
+++ b/lisp/magit-collab.el
@@ -96,7 +96,7 @@ only supports Github, but that will change eventually."
          (number (and (string-match "\\([0-9]+\\)" choice)
                       (string-to-number (match-string 1 choice)))))
     (and number
-         (or (--first (eq (cdr (assq 'number it)) number) prs)
+         (or (--first (= (cdr (assq 'number it)) number) prs)
              (ghub-get (format "/repos/%s" id) nil :auth 'magit)))))
 
 (defun magit-upstream-repository ()


### PR DESCRIPTION
There's a good bit of functionality in Magithub that could be taken advantage of in Magit to be more DWIM. In vermiculus/magithub#201, I introduced thingatpt support for a few symbols like github-pull-request. I'm not totally sold on using the 'github' prefix here -- perhaps something more generic like 'gitforge' could be used instead.

This is a very simple patch right now and I expect it will change before it's merged. Specifically, I'm not sure how to handle maintaining the ability to choose a PR that is *not* the one at point. As it's set up right now, if point is on something that defines github-pull-request, the user won't have the opportunity to override that value.