### PR TITLE
git-commit-turn-on-flyspell: respect customized comment character

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -498,12 +498,13 @@ finally check current non-comment text."
   (turn-on-flyspell)
   (setq flyspell-generic-check-word-predicate
         'git-commit-flyspell-verify)
-  (let (end)
+  (let ((end)
+        (comment-start-regex (format "^\\(%s\\|$\\)" comment-start)))
     (save-excursion
       (goto-char (point-max))
-      (while (and (not (bobp)) (looking-at "^\\(#\\|$\\)"))
+      (while (and (not (bobp)) (looking-at comment-start-regex))
         (forward-line -1))
-      (unless (looking-at "^\\(#\\|$\\)")
+      (unless (looking-at comment-start-regex)
         (forward-line))
       (setq end (point)))
     (flyspell-region (point-min) end)))


### PR DESCRIPTION
I'm not sure about my commit message if it should be more elaborate.
Guess that one line is enough?!

I customized `core.commentchar` as sometimes I just put
`#123` as a reference to a issue in it's own line so I
set comment char to `;`.
