### PR TITLE
magit-submodule-update: Make operation resursive

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -5832,7 +5832,8 @@ the super-repository by adding ~magit-insert-submodules~ to the hook
 - Key: o u, magit-submodule-update
 
   Clone missing submodules and checkout appropriate commits.  With a
-  prefix argument also register submodules in ".git/config".
+  prefix argument also register submodules in ".git/config".  The
+  command will update nested submodules recursively.
 
 - Key: o s, magit-submodule-sync
 

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -186,7 +186,7 @@ PATH also becomes the name."
 With a prefix argument also register submodules in \".git/config\"."
   (interactive "P")
   (magit-with-toplevel
-    (magit-run-git-async "submodule" "update" (and init "--init"))))
+    (magit-run-git-async "submodule" "update" "--recursive" (and init "--init"))))
 
 ;;;###autoload
 (defun magit-submodule-sync ()


### PR DESCRIPTION
`git submodule update` is invoked in order to match the submodules with the
currently checked-out superproject commit. It makes sense to perform the update
operation recursively. Otherwise, the working tree won't fully match the
superproject commit because nested submodules won't be updated.

Magit is great software, thanks! :heart: