### PR TITLE
git-commit-prev-message: Fix error in buffers without comments

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -556,7 +556,7 @@ With a numeric prefix ARG, go back ARG comments."
   (save-restriction
     (goto-char (point-min))
     (narrow-to-region (point)
-                      (if (re-search-forward (concat "^" comment-start))
+                      (if (re-search-forward (concat "^" comment-start) nil t)
                           (max 1 (- (point) 2))
                         (point-max)))
     (log-edit-previous-comment arg)))


### PR DESCRIPTION
When attempting to invoke `git-commit-prev-message` or `git-commit-next-message` in a buffer without comments, the functions would fail with the message:

    git-commit-prev-message: Search failed: "^#"

Such a buffer could be the result of a `prepare-commit-msg` git hook which does not emit any comment lines.

The rest of the code was already prepared to handle this scenario, so just fix the `re-search-forward` invocation to not error when the regexp was not found, and allow the caller to handle the failure.
