### PR TITLE
Don't apply w32 env hacks for remote repositories

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -364,6 +364,7 @@ conversion."
 
 (defun magit-process-environment ()
   (append magit-git-environment
+          (cdr (assoc magit-git-executable magit-git-w32-path-hack))
           (and magit-need-cygwin-noglob
                (mapcar (lambda (var)
                          (concat var "=" (--if-let (getenv var)

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -358,19 +358,19 @@ Process output goes into a new section in the buffer returned by
 Identical to `process-file' but temporarily enable Cygwin's
 \"noglob\" option during the call and ensure unix eol
 conversion."
-  (let ((process-environment (append (magit-cygwin-env-vars)
-                                     process-environment))
+  (let ((process-environment (magit-process-environment))
         (default-process-coding-system (magit--process-coding-system)))
     (apply #'process-file args)))
 
-(defun magit-cygwin-env-vars ()
+(defun magit-process-environment ()
   (append magit-git-environment
           (and magit-need-cygwin-noglob
                (mapcar (lambda (var)
                          (concat var "=" (--if-let (getenv var)
                                              (concat it " noglob")
                                            "noglob")))
-                       '("CYGWIN" "MSYS")))))
+                       '("CYGWIN" "MSYS")))
+          process-environment))
 
 (defvar magit-this-process nil)
 
@@ -399,8 +399,7 @@ flattened before use."
                     (eq (process-status magit-this-process) 'run))
           (sleep-for 0.005)))
     (run-hooks 'magit-pre-call-git-hook)
-    (-let* ((process-environment (append (magit-cygwin-env-vars)
-                                         process-environment))
+    (-let* ((process-environment (magit-process-environment))
             (default-process-coding-system (magit--process-coding-system))
             (flat-args (magit-process-git-arguments args))
             ((process-buf . section)
@@ -519,8 +518,7 @@ Magit status buffer."
                   ;; Don't use a pty, because it would set icrnl
                   ;; which would modify the input (issue #20).
                   (and (not input) magit-process-connection-type))
-                 (process-environment (append (magit-cygwin-env-vars)
-                                              process-environment))
+                 (process-environment (magit-process-environment))
                  (default-process-coding-system (magit--process-coding-system)))
              (apply #'start-file-process
                     (file-name-nondirectory program)


### PR DESCRIPTION
This should fix #3345. The first two commits fix some other issues that I noticed while looking at that bug (https://github.com/magit/magit/issues/3345#issuecomment-360813859 and https://github.com/magit/magit/issues/3345#issuecomment-361331270 (bottom half)).

I want to double check the thing about tramp using `process-environment` though, as I would have assumed that `tramp-remote-process-environment` would be used instead...