### PR TITLE
Translate `pcase-lambda` to `lambda`/`pcase-let`

### DIFF
--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -590,18 +590,20 @@ line is inserted at all."
                       def
                     (pcase-let ((`(,min . ,max) def))
                       (min max (apply #'max min (mapcar #'car lines)))))))
-    (mapcar (pcase-lambda (`(,_ ,branch ,focus ,branch-desc ,u:ahead ,p:ahead
-                                ,u:behind ,upstream ,p:behind ,push ,msg))
-              (list branch focus branch-desc u:ahead p:ahead
-                    (make-string (max 1 (- magit-refs-primary-column-width
-                                           (length (concat branch-desc
-                                                           u:ahead
-                                                           p:ahead
-                                                           u:behind))))
-                                 ?\s)
-                    u:behind upstream p:behind push
-                    msg))
-            lines)))
+    (mapcar (lambda (arg)
+              (pcase-let ((`(,_ ,branch ,focus ,branch-desc ,u:ahead ,p:ahead
+                                ,u:behind ,upstream ,p:behind ,push ,msg)
+                           arg))
+                (list branch focus branch-desc u:ahead p:ahead
+                      (make-string (max 1 (- magit-refs-primary-column-width
+                                             (length (concat branch-desc
+                                                             u:ahead
+                                                             p:ahead
+                                                             u:behind))))
+                                   ?\s)
+                      u:behind upstream p:behind push
+                      msg)))
+              lines)))
 
 (defun magit-refs--format-local-branch (line)
   (pcase-let ((`(,head ,branch ,upstream ,u:ref ,u:track


### PR DESCRIPTION
The pcase-lambda macro is not available in emacs 24.5.1 (e.g.,
provided by Ubuntu 16.04LTS), so translate pcase-lambda to the
equivalent lambda/pcase-let.
