### PR TITLE
Fix CONTRIBUTING.md link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Thanks to all of you, may (the history of) the source be with you!
 [![Paren Xkcb](https://img.shields.io/badge/%28-%20%20%20-red.svg)](https://xkcd.com/859)
 
 
-[contrib]: https://github.com/magit/magit/blob/master/CONTRIBUTING.md
+[contrib]: https://github.com/magit/magit/blob/master/Documentation/CONTRIBUTING.md
 [issues]:  https://github.com/magit/magit/issues
 [pulls]:   https://github.com/magit/magit/pulls
 


### PR DESCRIPTION
## Reason
The CONTRIBUTING.md link in the README.md returns 404.

## Implementation
* Point the contrib link to it's new location
