### PR TITLE
Use relative paths for dired buffers

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -644,7 +644,8 @@ tracked file."
   (unless file
     (with-current-buffer (or (buffer-base-buffer)
                              (current-buffer))
-      (setq file (or magit-buffer-file-name buffer-file-name))))
+      (setq file (or magit-buffer-file-name buffer-file-name
+                     (and (derived-mode-p 'dired-mode) default-directory)))))
   (when (and file (or (not tracked)
                       (magit-file-tracked-p (file-relative-name file))))
     (--when-let (magit-toplevel

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -686,9 +686,7 @@ active, restrict the log to the lines that the region touches."
                            ;; of a trailing newline.
                            (1- end)))))))))
   (require 'magit)
-  (-if-let (file (or (magit-file-relative-name)
-                     (and (derived-mode-p 'dired-mode)
-                          default-directory)))
+  (-if-let (file (magit-file-relative-name))
       (magit-mode-setup-internal
        #'magit-log-mode
        (list (list (or magit-buffer-refname

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -695,7 +695,7 @@ active, restrict the log to the lines that the region touches."
              (let ((args (car (magit-log-arguments))))
                (when (and follow (not (member "--follow" args)))
                  (push "--follow" args))
-               (when (and beg end)
+               (when (and (file-regular-p file) beg end)
                  (setq args (cons (format "-L%s,%s:%s" beg end file)
                                   (cl-delete "-L" args :test
                                              'string-prefix-p)))


### PR DESCRIPTION
aac74cc466c40adbbeba373d85e13f72b175bc5e added support for `magit-log-buffer-file` in dired buffers, but `default-directory` returns the full directory path instead of relative path. 

This change adds dired support for `magit-file-relative-name`, tell me if this is not desirable.

### Scenario
Calling `magit-log-buffer-file` in a dired buffer sets:
```elisp
(magit-log-arguments)    ;; => (("-n256" "--graph" "--decorate") ("~/code/magit/lisp/"))
```
expected:
```elisp
(magit-log-arguments)    ;; => (("-n256" "--graph" "--decorate") ("lisp/"))
```