### PR TITLE
magit-log-buffer-file: Use absolute filename in call to file-regular-p

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3493,8 +3493,13 @@ buffers that are being blamed.
 - User Option: magit-blame-show-headings
 
   This option controls whether blame block headings are initially
-  shown.  The headings can also be toggled locally using the command
-  ~magit-blame-toggle-headings~.
+  shown.  Whether blame headings are shown in the current buffer
+  can be changed using the command ~magit-blame-toggle-headings~.
+
+  When headings are not shown, then the information for the current
+  chunk is shown in the echo-area instead.  If you do not want that,
+  then remove ~magit-blame-maybe-show-message~ from
+  ~magit-blame-goto-chunk-hook~.
 
 - User Option: magit-blame-goto-chunk-hook
 

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -78,13 +78,16 @@ and then turned on again when turning off the latter."
   :group 'magit-blame
   :type '(choice (const :tag "No lighter" "") string))
 
-(defcustom magit-blame-goto-chunk-hook '(magit-blame-maybe-update-revision-buffer)
+(defcustom magit-blame-goto-chunk-hook
+  '(magit-blame-maybe-update-revision-buffer
+    magit-blame-maybe-show-message)
   "Hook run by `magit-blame-next-chunk' and `magit-blame-previous-chunk'."
-  :package-version '(magit . "2.1.0")
+  :package-version '(magit . "2.13.0")
   :group 'magit-blame
   :type 'hook
   :get 'magit-hook-custom-get
-  :options '(magit-blame-maybe-update-revision-buffer))
+  :options '(magit-blame-maybe-update-revision-buffer
+             magit-blame-maybe-show-message))
 
 (defface magit-blame-heading
   '((((class color) (background light))
@@ -437,6 +440,15 @@ only arguments available from `magit-blame-popup' should be used.
   (format-time-string
    magit-blame-time-format
    (seconds-to-time (+ time (* (/ tz 100) 60 60) (* (% tz 100) 60)))))
+
+(defun magit-blame-maybe-show-message ()
+  (unless magit-blame-show-headings
+    (let ((message-log-max 0))
+      (--if-let (cdr (assq 'heading
+                           (gethash (car (magit-blame-chunk))
+                                    magit-blame-cache)))
+          (message "%s" (substring it 0 -1))
+        (message "Commit data not available yet.  Still blaming.")))))
 
 ;;; Commands
 

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -308,8 +308,7 @@ only arguments available from `magit-blame-popup' should be used.
     (set-process-filter   process 'magit-blame-process-filter)
     (set-process-sentinel process 'magit-blame-process-sentinel)
     (process-put process 'arguments (list revision file args))
-    (with-current-buffer (process-buffer process)
-      (setq magit-blame-cache (make-hash-table :test 'equal)))
+    (setq magit-blame-cache (make-hash-table :test 'equal))
     (setq magit-blame-process process)))
 
 (defun magit-blame-process-quickstart-sentinel (process event)
@@ -339,7 +338,10 @@ only arguments available from `magit-blame-popup' should be used.
   (internal-default-process-filter process string)
   (let ((buf  (process-get process 'command-buf))
         (pos  (process-get process 'parsed))
-        (mark (process-mark process)))
+        (mark (process-mark process))
+        cache)
+    (with-current-buffer buf
+      (setq cache magit-blame-cache))
     (with-current-buffer (process-buffer process)
       (goto-char pos)
       (let (end rev chunk alist)
@@ -364,8 +366,8 @@ only arguments available from `magit-blame-popup' should be used.
                                (match-string 2)) alist)))
             (forward-line))
           (if alist
-              (puthash rev alist magit-blame-cache)
-            (setq alist (gethash rev magit-blame-cache)))
+              (puthash rev alist cache)
+            (setq alist (gethash rev cache)))
           (magit-blame-make-overlay buf chunk alist)
           (setq alist nil)
           (process-put process 'parsed (point)))))))

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -536,7 +536,7 @@ instead of the hash, like `kill-ring-save' would."
       (run-with-idle-timer
        magit-update-other-window-delay nil
        (lambda ()
-         (-let [(rev buf) magit--update-revision-buffer]
+         (pcase-let ((`(,rev ,buf) magit--update-revision-buffer))
            (setq magit--update-revision-buffer nil)
            (when (buffer-live-p buf)
              (let ((magit-display-buffer-noselect t))

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -230,7 +230,7 @@ modes is toggled, then this mode also gets toggled automatically.
   (magit-blame-read-only-mode (if buffer-read-only 1 -1)))
 
 (defun magit-blame-after-save-refresh ()
-  (apply 'magit-blame
+  (apply 'magit-blame--run
          (nconc (magit-blame-arguments* magit-blame-reverse-p t)
                 (list nil t))))
 
@@ -289,7 +289,7 @@ modes is toggled, then this mode also gets toggled automatically.
   "For each line show the last revision in which a line still existed.
 \n(fn REVISION FILE &optional ARGS)" ; LINE is for internal use
   (interactive (magit-blame-arguments* t))
-  (magit-blame revision file (cons "--reverse" args) line))
+  (magit-blame--run revision file (cons "--reverse" args) line))
 
 ;;;###autoload
 (defun magit-blame (revision file &optional args line force)
@@ -309,6 +309,9 @@ ARGS is a list of additional arguments to pass to `git blame';
 only arguments available from `magit-blame-popup' should be used.
 \n(fn REVISION FILE &optional ARGS)" ; LINE is for internal use
   (interactive (magit-blame-arguments* nil))
+  (magit-blame--run revision file args line force))
+
+(defun magit-blame--run (revision file &optional args line force)
   (let ((toplevel (or (magit-toplevel)
                       (user-error "Not in git repository"))))
     (let ((default-directory toplevel))

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -492,6 +492,29 @@ only arguments available from `magit-blame-popup' should be used."
 
 ;;; Commands
 
+(defun magit-blame-visit-prev-file ()
+  "Visit the blob before the one that added the current chunk."
+  (interactive)
+  (with-slots (prev-rev prev-file orig-line)
+      (magit-current-blame-chunk)
+    (unless prev-rev
+      (user-error "Chunk has no further history"))
+    (magit-with-toplevel
+      (magit-find-file prev-rev prev-file))
+    ;; TODO Adjust line like magit-diff-visit-file.
+    (goto-char (point-min))
+    (forward-line (1- orig-line))))
+
+(defun magit-blame-visit-orig-file ()
+  "Visit the blob that added the current chunk."
+  (interactive)
+  (with-slots (orig-rev orig-file orig-line)
+      (magit-current-blame-chunk)
+    (magit-with-toplevel
+      (magit-find-file orig-rev orig-file))
+    (goto-char (point-min))
+    (forward-line (1- orig-line))))
+
 (defun magit-blame-quit ()
   "Turn off Magit-Blame mode.
 If the buffer was created during a recursive blame,

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -216,12 +216,15 @@ modes is toggled, then this mode also gets toggled automatically.
            (funcall mode 1))
          (when (process-live-p magit-blame-process)
            (kill-process magit-blame-process))
-         (save-excursion
-           (save-restriction
-             (widen)
-             (dolist (ov (overlays-in (point-min) (point-max)))
-               (when (overlay-get ov 'magit-blame)
-                 (delete-overlay ov))))))))
+         (magit-blame--clear-overlays))))
+
+(defun magit-blame--clear-overlays ()
+  (save-excursion
+    (save-restriction
+      (widen)
+      (dolist (ov (overlays-in (point-min) (point-max)))
+        (when (overlay-get ov 'magit-blame)
+          (delete-overlay ov))))))
 
 (defun magit-blame-toggle-read-only ()
   (magit-blame-read-only-mode (if buffer-read-only 1 -1)))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -42,7 +42,8 @@
 ;; For `magit-insert-revision-gravatar'
 (defvar gravatar-size)
 ;; For `magit-show-commit' and `magit-diff-show-or-scroll'
-(declare-function magit-blame-chunk "magit-blame" (&optional pos))
+(declare-function magit-current-blame-chunk "magit-blame" ())
+(eval-when-compile (add-to-list 'eieio--known-slot-names 'orig-rev))
 (declare-function magit-blame-mode "magit-blame" (&optional arg))
 (defvar magit-blame-mode)
 (defvar git-rebase-line)
@@ -1009,7 +1010,7 @@ for a revision."
   (interactive
    (let* ((mcommit (magit-section-when module-commit))
           (atpoint (or (and (bound-and-true-p magit-blame-mode)
-                            (car (magit-blame-chunk)))
+                            (oref (magit-current-blame-chunk) orig-rev))
                        mcommit
                        (magit-branch-or-commit-at-point))))
      (nconc (cons (or (and (not current-prefix-arg) atpoint)
@@ -1476,7 +1477,7 @@ commit or stash at point, then prompt for a commit."
   (let (rev cmd buf win)
     (cond
      (magit-blame-mode
-      (setq rev (car (magit-blame-chunk)))
+      (setq rev (oref (magit-current-blame-chunk) orig-rev))
       (setq cmd 'magit-show-commit)
       (setq buf (magit-mode-get-buffer 'magit-revision-mode)))
      ((derived-mode-p 'git-rebase-mode)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -695,7 +695,7 @@ active, restrict the log to the lines that the region touches."
              (let ((args (car (magit-log-arguments))))
                (when (and follow (not (member "--follow" args)))
                  (push "--follow" args))
-               (when (and (file-regular-p file) beg end)
+               (when (and (file-regular-p (buffer-file-name)) beg end)
                  (setq args (cons (format "-L%s,%s:%s" beg end file)
                                   (cl-delete "-L" args :test
                                              'string-prefix-p)))


### PR DESCRIPTION
Calling `magit-log-buffer-file` interactively with an active region would previously call `magit-log` with a corresponding `-L<beg>,<end>:<file>` argument, to display the log of the selected region. This currently does not work for any files that aren't in the base dir of the repo.

It looks like this function was changed in 293bf0d6c to only enable `-L` if the file is a regular file, using `file-regular-p`. However, it calls `file-regular-p` with the filename *relative to the repo's root directory*, but the `default-directory` of this command is the dir that the file is located in.

e.g. in the repo `/home/user/repo`, if editing the file `/home/user/repo/some/example.txt` with an active region, calling `magit-log-buffer-file` would end up checking `(file-regular-p "some/example.txt")`, which refers to the absolute filename `"/home/user/repo/some/some/example.txt"` which doesn't exist, and therefore `-L` arg isn't enabled.
