### PR TITLE
magit-gitk-executable: fix default gitk filename, on Windows.

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -36,8 +36,9 @@
 
 (defcustom magit-gitk-executable
   (or (and (eq system-type 'windows-nt)
-           (let ((exe (expand-file-name
-                       "gitk" (file-name-directory magit-git-executable))))
+           (let ((exe (magit-git-string
+                       "-c" "alias.X=!x() { which \"$1\" | cygpath -mf -; }; x"
+                       "X" "gitk.exe")))
              (and (file-executable-p exe) exe)))
       (executable-find "gitk") "gitk")
   "The Gitk executable."

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -37,7 +37,7 @@
 (defcustom magit-gitk-executable
   (or (and (eq system-type 'windows-nt)
            (let ((exe (expand-file-name
-                       "gitk" (file-name-nondirectory magit-git-executable))))
+                       "gitk" (file-name-directory magit-git-executable))))
              (and (file-executable-p exe) exe)))
       (executable-find "gitk") "gitk")
   "The Gitk executable."


### PR DESCRIPTION
Avoid an error where we try to open "git.exe/gitk", which triggers Tramp to try to extract a file "gitk" from an archive "git.exe", which causes an error, "package 'tramp-archive' not supported".

To reproduce the error (on Windows), have magit installed, then run "emacs -Q", then:

    M-x package-initialize RET
    M-x load-library RET magit-extras RET
