### PR TITLE
Add support for `--gpg-sign` on rebase

### DIFF
--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -460,6 +460,7 @@ This discards all changes made since the sequence started."
               (?A "Autostash"                "--autostash")
               (?i "Interactive"              "--interactive")
               (?h "Disable hooks"            "--no-verify"))
+  :options  '((?S "Sign using gpg" "--gpg-sign=" magit-read-gpg-secret-key))
   :actions  '((lambda ()
                 (concat (propertize "Rebase " 'face 'magit-popup-heading)
                         (propertize (or (magit-get-current-branch) "HEAD")


### PR DESCRIPTION
It's currently possible to setup a gpg-sign when doing a commit, but
not when rebasing. The `git-rebase` commands allows to specify a
`--gpg-sign` when rebasing, so adding it as an option to the rebase
popup/action in magit.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
