### PR TITLE
magit-blame-put-keymap-before-view-mode: Fix typo

### DIFF
--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -170,7 +170,7 @@ modes is toggled, then this mode also gets toggled automatically.
 
 (defun magit-blame-put-keymap-before-view-mode ()
   "Put `magit-blame-read-only-mode' ahead of `view-mode' in `minor-mode-map-alist'."
-  (--when-let (assq 'magit-blame-read-only--mode
+  (--when-let (assq 'magit-blame-read-only-mode
                     (cl-member 'view-mode minor-mode-map-alist :key #'car))
     (setq minor-mode-map-alist
           (cons it (delq it minor-mode-map-alist))))


### PR DESCRIPTION
This typo from 6d7127d6e37f48d7256c954cf36f98a82d6a23f5 reintroduced issue #1780.