### PR TITLE
magit-read-starting-point: allow completion for FETCH_HEAD, ...

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1864,7 +1864,9 @@ the reference is used.  The first regexp submatch becomes the
                       (concat " "
                               (propertize branch 'face 'magit-branch-local))))
                " starting at")
-       (cons "HEAD" (magit-list-refnames))
+       (nconc (list "HEAD")
+              (magit-list-refnames)
+              (directory-files (magit-git-dir) nil "_HEAD\\'"))
        nil nil nil 'magit-revision-history
        (magit--default-starting-point))
       (user-error "Nothing selected")))


### PR DESCRIPTION
This commit adds a list of predefined Git names for temporary branches
in addition to the already existing HEAD: FETCH_HEAD, ORIG_HEAD,
MERGE_HEAD and CHERRY_PICK_HEAD.

I mostly use FETCH_HEAD as a starting point for branch creation, when
fetching commits from Gerrit (I can write the name and create a
branch, but completion does not recognize it). The other names are
added for completeness.
