### PR TITLE
Fix parentheses mistakes in the docs

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -487,8 +487,8 @@ buffers whose major-modes derive from ~magit-mode~.
 
   This function displays most buffers so that they fill the entire
   height of the frame.  However, the buffer is displayed in another
-  window if 1) the buffer's mode derives from ~magit-process-mode~,
-  or 2) the buffer's mode derives from ~magit-diff-mode~, provided
+  window if (1) the buffer's mode derives from ~magit-process-mode~,
+  or (2) the buffer's mode derives from ~magit-diff-mode~, provided
   that the mode of the current buffer derives from ~magit-log-mode~ or
   ~magit-cherry-mode~.
 
@@ -5056,7 +5056,7 @@ The following colors are used:
 - The green commit is the commit the rebase sequence stopped at.  If
   this is the same commit as ~HEAD~ (e.g. because you haven't done
   anything yet after rebase stopped at the commit, then this commit is
-  shown in blue, not green.  There can only be a green *and* a blue
+  shown in blue, not green).  There can only be a green *and* a blue
   commit at the same time, if you create one or more new commits after
   rebase stops at a commit.
 
@@ -6450,7 +6450,7 @@ just one huge repository use this:
 - ~/path/to/huge/repo/.dir-locals.el~
 
   #+BEGIN_SRC emacs-lisp
-    ((nil . ((magit-refresh-buffers . nil))
+    ((nil . ((magit-refresh-buffers . nil))))
   #+END_SRC
 
 If you want to apply the same settings to several, but not all,

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -826,8 +826,8 @@ to pop up on the same side as they would if
 
 This function displays most buffers so that they fill the entire
 height of the frame.  However, the buffer is displayed in another
-window if 1) the buffer's mode derives from @code{magit-process-mode},
-or 2) the buffer's mode derives from @code{magit-diff-mode}, provided
+window if (1) the buffer's mode derives from @code{magit-process-mode},
+or (2) the buffer's mode derives from @code{magit-diff-mode}, provided
 that the mode of the current buffer derives from @code{magit-log-mode} or
 @code{magit-cherry-mode}.
 @end defun
@@ -6796,7 +6796,7 @@ The blue commit is the @code{HEAD} commit.
 The green commit is the commit the rebase sequence stopped at.  If
 this is the same commit as @code{HEAD} (e.g. because you haven't done
 anything yet after rebase stopped at the commit, then this commit is
-shown in blue, not green.  There can only be a green @strong{and} a blue
+shown in blue, not green).  There can only be a green @strong{and} a blue
 commit at the same time, if you create one or more new commits after
 rebase stops at a commit.
 
@@ -8816,7 +8816,7 @@ just one huge repository use this:
 @code{/path/to/huge/repo/.dir-locals.el}
 
 @lisp
-((nil . ((magit-refresh-buffers . nil))
+((nil . ((magit-refresh-buffers . nil))))
 @end lisp
 @end itemize
 


### PR DESCRIPTION
Also includes "1)" -> "(1)" to make it easy to catch such errors.  (And
to accommodate some Lispers who involuntarily twitch at "1)".)

*Note:* This includes changes to both `magit.org` and `magit.texi` since they are very minor, but I didn't run the generation thing.
