### PR TITLE
git-rebase.el: noop-related changes

### DIFF
--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -191,6 +191,7 @@
     ["Squash" git-rebase-squash t]
     ["Fixup" git-rebase-fixup t]
     ["Kill" git-rebase-kill-line t]
+    ["Noop" git-rebase-noop t]
     ["Execute" git-rebase-exec t]
     ["Move Down" git-rebase-move-line-down t]
     ["Move Up" git-rebase-move-line-up t]

--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -519,6 +519,8 @@ running 'man git-rebase' at the command line) for details."
       ("^\\(exec\\) \\(.*\\)"
        (1 'font-lock-keyword-face)
        (2 'git-rebase-description))
+      ("^\\(noop\\)"
+       (1 'font-lock-keyword-face))
       (git-rebase-match-comment-line 0 'font-lock-comment-face)
       (,(concat git-rebase-comment-re " *" action-re)
        0 'git-rebase-killed-action t)


### PR DESCRIPTION
This adds the “noop” operation to the “rebase” menu, and colours this instruction in the “git rebase” buffer.