### PR TITLE
magit-blame--format-time-string: Correct timezone handling

### DIFF
--- a/Documentation/RelNotes/2.13.0.txt
+++ b/Documentation/RelNotes/2.13.0.txt
@@ -9,3 +9,6 @@ Changes since v2.12.0
 
 Fixes since v2.12.0
 -------------------
+
+* Time zones were not handled correctly when calculating times for
+  blame headings.  #3443

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -673,12 +673,14 @@ modes is toggled, then this mode also gets toggled automatically.
                (face-attribute 'magit-blame-heading :background nil t))))
 
 (defun magit-blame--format-time-string (time tz)
-  (setq time (string-to-number time))
-  (setq tz   (string-to-number tz))
-  (format-time-string
-   (or (magit-blame--style-get 'time-format)
-       magit-blame-time-format)
-   (seconds-to-time (+ time (* (/ tz 100) 60 60) (* (% tz 100) 60)))))
+  (let* ((time-format (or (magit-blame--style-get 'time-format)
+                          magit-blame-time-format))
+         (tz-in-second (and (not (version< emacs-version "25"))
+                            (string-match "%z" time-format)
+                            (car (last (parse-time-string tz))))))
+    (format-time-string time-format
+                        (seconds-to-time (string-to-number time))
+                        tz-in-second)))
 
 (defun magit-blame--remove-overlays (&optional beg end)
   (save-restriction


### PR DESCRIPTION
Because the time variable is an Unix time which is not related to time zone,
we don't have to update time according to time zone.

If time-format contains the time zone symbol ( %z or %Z ),
use tz-in-second to format the time in committer time zone or author time zone.

If time-format doesn't contain the time zone symbol ( %z or %Z ),
assign tz-in-second to nil to format the time in local time zone.
