### PR TITLE
Enable magit-log-buffer-file to show log of deleted files

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -695,7 +695,9 @@ active, restrict the log to the lines that the region touches."
              (let ((args (car (magit-log-arguments))))
                (when (and follow (not (member "--follow" args)))
                  (push "--follow" args))
-               (when (and (file-regular-p (buffer-file-name)) beg end)
+               (when (and (buffer-file-name)
+                          (file-regular-p (buffer-file-name))
+                          beg end)
                  (setq args (cons (format "-L%s,%s:%s" beg end file)
                                   (cl-delete "-L" args :test
                                              'string-prefix-p)))


### PR DESCRIPTION
When looking at a commit, selecting a deleted file opens an empty buffer
which does not visit any file.