### PR TITLE
Use `git remote get-url` to find actual remote url.

### DIFF
--- a/lisp/magit-collab.el
+++ b/lisp/magit-collab.el
@@ -139,9 +139,9 @@ exist, then raise an error."
                 host)))))
 
 (defun magit--github-remote-p (remote)
-  (or (--when-let (magit-git-str "remote" "get-url" "--push" remote)
+  (or (--when-let (magit-git-string "remote" "get-url" "--push" remote)
         (magit--github-url-p it))
-      (--when-let (magit-git-str "remote" "get-url" "--all" remote)
+      (--when-let (magit-git-string "remote" "get-url" "--all" remote)
         (magit--github-url-p it))))
 
 (defun magit--github-url-equal (r1 r2)

--- a/lisp/magit-collab.el
+++ b/lisp/magit-collab.el
@@ -139,9 +139,9 @@ exist, then raise an error."
                 host)))))
 
 (defun magit--github-remote-p (remote)
-  (or (--when-let (magit-get "remote" remote "pushurl")
+  (or (--when-let (magit-git-str "remote" "get-url" "--push" remote)
         (magit--github-url-p it))
-      (--when-let (magit-get "remote" remote "url")
+      (--when-let (magit-git-str "remote" "get-url" "--all" remote)
         (magit--github-url-p it))))
 
 (defun magit--github-url-equal (r1 r2)


### PR DESCRIPTION
Using the value from the repo's `.git/config` does not expand in cases
where an alias is being used as the remote name.  Using `git remote
get-url` instead expands the url into what is actually being used (and
then supports both the alias and a more complete github url to match
against).

---

In my git config I have various alternate urls for `insteadOf` and `pushInsteadOf` purposes to differentiate between various github account requirements (personal, work, ...).

Since I'm using these features I take advantage and use abbreviations in the remote names and leverage `.gitconfig` to resolve them into the actual urls used in my `.ssh/config`.

```ini
[url "git@github.com:"]
     insteadOf = "gh:"
     PushInsteadOf = "https://github.com/"
     PushInsteadOf = "http://github.com/"
     PushInsteadOf = "git:github.com/"
     PushInsteadOf = "gh:"

[url "git@github.com:jleechpe"]
     insteadOf = "ghj:"
     PushInsteadOf = "https://github.com/jleechpe/"
     PushInsteadOf = "http://github.com/jleechpe/"
     PushInsteadOf = "git:github.com/jleechpe/"
     PushInsteadOf = "ghj:"
```

Because of this magit is unable to identify any of my `gh:` or `ghj:` remotes as being valid github repositories.

Changing `magit--github-remote-p` to use `git remote get-url --push <remote>` allows it to get the actual url being used and not just the key in the repo config.