### PR TITLE
Add PGP verification support

### DIFF
--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -1,0 +1,172 @@
+;;; magit-verify.el --- cryptographic signature support for Magit  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2012-2018  The Magit Project Contributors
+;;
+;; You should have received a copy of the AUTHORS.md file which
+;; lists all contributors.  If not, see http://magit.vc/authors.
+
+;; Author: Jonas Bernoulli <jonas@bernoul.li>
+;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
+
+;; Magit is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; Magit is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+;; License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Magit.  If not, see http://www.gnu.org/licenses.
+
+;;; Commentary:
+
+;; Verifies PGP signatures of commit and tag objects.
+
+;;; Code:
+
+(require 'magit)
+
+(defun magit-verify-commit (id &optional include-invalid)
+  "Verify cryptographic signature of commit ID.
+
+Return value is nil if ID is not signed, or a list of the form
+\(KEY-FP KEY-UID VALID OWNERTRUST KEY-EXPIRED SIG-EXPIRED), where:
+
+ - KEY-FP is a PGP key fingerprint.
+ - KEY-UID is the PGP key's primary UID.
+ - VALID is t if the signature is valid.  Unless INCLUDE-INVALID
+   is non-nil, this is always the case.
+ - OWNERTRUST is either a symbol between 'ultimate, 'full,
+   'unknown, 'undefined, 'marginal or nil (never)
+ - KEY-EXPIRED is non-nil if the key or a subkey has expired.
+ - SIG-EXPIRED is non-nil if the signature has expired.
+
+By default, this function returns nil for missing or invalid
+signature.  If INCLUDE-INVALID is non-nil, however, a list is
+always returned even if the signature is invalid.
+
+This function is implemented following GnuPG documentation at:
+https://www.gnupg.org/documentation/manuals/gnupg/Automated-signature-checking.html"
+  (magit-verify--parse-output (magit-git-lines "verify-commit" "--raw" id) include-invalid))
+
+(defun magit-verify-tag (name &optional include-invalid)
+  "Verify cryptographic signature of tag NAME.
+
+The return value has the same format as `magit-verify-tag', which
+see."
+  (magit-verify--parse-output (magit-git-lines "verify-tag" "--raw" name) include-invalid))
+
+(defun magit-verify--ownertrust-symbol (level)
+    "Internal, DO NOT USE.
+
+Convert owner trust LEVEL, a string, to a symbol.
+
+Accepted inputs are ULTIMATE ('ultimate), FULLY ('full),
+UNKNOWN ('unknown), UNDEFINED ('undefined), MARGINAL ('marginal)
+and NEVER (nil).  Any other value will raise an error.
+
+Input is case-insensitive."
+    (setq dlevel (downcase level))
+
+    (cond
+     ((equal dlevel "ultimate") 'ultimate)
+     ((equal dlevel "full") 'full)
+     ((equal dlevel "fully") 'full)
+     ((equal dlevel "undefined") 'undefined)
+     ((equal dlevel "marginal") 'marginal)
+     ((equal dlevel "never") nil)
+     (t (error "Unknown owner trust %s" level))))
+
+(defun magit-verify--parse-output (lines &optional include-invalid)
+  "Internal, DO NOT USE.
+
+The common part of `magit-verify-commit' and
+`magit-verify-tag'."
+
+  "Parse LINES as output of git verify-[tag,commit] --raw ...
+Returns a possibly empty list of (KEYID OWNERID)."
+  (when lines
+    (let ((keydata (-non-nil
+                    (mapcar
+                     (lambda (str)
+                       (when (string-match
+                              (rx
+                               line-start
+                               "[GNUPG:] "
+                               (group (or "GOODSIG" "BADSIG" "EXPKEYSIG" "EXPSIG"))
+                               " "
+                               (one-or-more hex-digit) ;; This a short ID, we'd rather not use it.
+                               " "
+                               (group (one-or-more any))
+                               line-end)
+                              str)
+                         (list (match-string 1 str) ;; GOOD/BAD/EXP/EXPSIG
+                               (match-string 2 str) ;; UID
+                               )))
+                     lines)))
+          (fingerprint (-non-nil
+                       (mapcar
+                        (lambda (str)
+                          (when (string-match
+                                 (rx
+                                  line-start
+                                  "[GNUPG:] VALIDSIG "
+                                  (group (one-or-more hex-digit))
+                                  " "
+                                  (one-or-more any)
+                                  line-end)
+                                 str)
+                            (match-string 1 str)))
+                        lines)))
+          (ownertrust (-non-nil
+                       (mapcar
+                        (lambda (str)
+                          (when (string-match
+                                 (rx
+                                  line-start
+                                  "[GNUPG:] TRUST_"
+                                  (group (one-or-more alpha))
+                                  " "
+                                  (one-or-more any)
+                                  line-end)
+                                 str)
+                            (match-string 1 str)))
+                        lines))))
+
+          ;; We should have processed exactly one
+          ;; GOODSIG/BADSIG/EXPSIG/EXPKEYSIG line and exactly one TRUST_
+          ;; line.  If this is not the case, panic.
+
+      (unless (= 1 (length keydata))
+        (error "Abnormal state 1 in magit-verify--parse-output"))
+
+      (unless (= 1 (length fingerprint))
+        (error "Abnormal state 2 in magit-verify--parse-output"))
+
+      (unless (= 1 (length ownertrust))
+        (error "Abnormal state 3 in magit-verify--parse-output"))
+
+      (let* ((keydata (car keydata))
+             (fingerprint (car fingerprint))
+             (ownertrust (car ownertrust))
+
+             (sig-validity (nth 0 keydata))
+             (key-uid (nth 1 keydata))
+             (valid (and
+                     (not (equal "BADSIG" sig-validity))
+                     (not (equal "NEVER" ownertrust)))))
+
+        (when (or valid include-invalid)
+          (list
+           fingerprint
+           key-uid
+           valid
+           (magit-verify--ownertrust-symbol ownertrust)
+           (equal "EXPKEYSIG" sig-validity)
+           (equal "EXPSIG" sig-validity)))))))
+
+(provide 'magit-verify)
+;;; magit-verify.el ends here

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -108,13 +108,12 @@ of this function, which provides a simpler and safer interface to
 the same functionality.
 
 Return a possibly empty list of `magit-pgp-signature' objects, which see."
-  (magit-verify--parse-output
-   ;; `magit-git-lines' only returns stdout, we need stderr.
-   (split-string (shell-command-to-string
-                  (format "%s verify-commit --raw %s"
-                          (shell-quote-argument magit-git-executable)
-                          (shell-quote-argument id)))
-                 "\n")))
+  (with-temp-buffer
+    (magit-process-file magit-git-executable nil t nil
+                        "verify-commit" "--raw"
+                        (shell-quote-argument id))
+    (magit-verify--parse-output
+     (split-string (buffer-string) "\n" t))))
 
 (defun magit-read-tag-signatures (name)
   "Return PGP signatures of tag NAME, regardless of their validity.
@@ -135,14 +134,12 @@ Return a possibly empty list of `magit-pgp-signature' objects, which see."
       (error "The tag object referred to by `%s' is actually named `%s'.  \
 Maybe you've given `magit-verify-tag' a hash instead of a name, \
 or maybe something fishy is going on" name realname)))
-
-  (magit-verify--parse-output
-   ;; `magit-git-lines' only returns stdout, we need stderr.
-   (split-string (shell-command-to-string
-                  (format "%s verify-tag --raw %s"
-                          (shell-quote-argument magit-git-executable)
-                          (shell-quote-argument name)))
-                 "\n")))
+  (with-temp-buffer
+    (magit-process-file magit-git-executable nil t nil
+                        "verify-tag" "--raw"
+                        (shell-quote-argument name))
+    (magit-verify--parse-output
+     (split-string (buffer-string) "\n" t))))
 
 (defun magit-verify-signature (sig &optional
                                    ignore-key-expiration

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -158,11 +158,9 @@ unmodified, otherwise return nil."
        (oref sig sig-validity)
        (or ignore-key-expiration (not (oref sig key-expired)))
        (or ignore-sig-expiration (not (oref sig sig-expired)))
-       ;; FIXME why not `eq'?
-       (or ignore-key-validity   (not (equal 'never (oref sig key-validity))))
-       (or ignore-revocation     (not (oref sig key-revoked))))
-  ;; FIXME this seems to be wrong
-  sig)
+       (or ignore-key-validity   (not (eq 'never (oref sig key-validity))))
+       (or ignore-revocation     (not (oref sig key-revoked)))
+       sig))
 
 ;;; Signature class
 

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -37,10 +37,13 @@ Return value is nil if ID is not signed, or a list of the form
 
  - KEY-FP is a PGP key fingerprint.
  - KEY-UID is the PGP key's primary UID.
- - VALID is t if the signature is valid.  Unless INCLUDE-INVALID
-   is non-nil, this is always the case.
- - OWNERTRUST is either a symbol between 'ultimate, 'full,
-   'unknown, 'undefined, 'marginal or nil (never)
+ - VALID is t if and only if the signature is valid.
+   Notice that unless INCLUDE-INVALID is non-nil,
+   you don't need to verify this value: the function
+   would have returned nil if the signature was invalid.
+ - OWNERTRUST is either a symbol ('ultimate, 'full,
+   'unknown, 'undefined, 'marginal) or nil if the key is NOT
+   trusted.
  - KEY-EXPIRED is non-nil if the key or a subkey has expired.
  - SIG-EXPIRED is non-nil if the signature has expired.
 
@@ -118,8 +121,9 @@ Returns a possibly empty list of (KEYID OWNERID)."
                                (match-string 1 str)))
                            lines))))
          ;; We should have processed exactly one
-         ;; GOODSIG/BADSIG/EXPSIG/EXPKEYSIG line and exactly one TRUST_
-         ;; line.  If this is not the case, panic.
+         ;; GOODSIG/BADSIG/EXPSIG/EXPKEYSIG line, exactly one VALIDSIG
+         ;; line and exactly one TRUST_ line.  If this is not the
+         ;; case, panic.
          (unless (= 1 (length keydata))
            (error "Abnormal state 1 in magit-verify--parse-output"))
          (unless (= 1 (length fingerprint))

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -70,7 +70,7 @@ revoked keys.  Enable if you know what you're doing."
                                 ignore-key-validity
                                 ignore-revocation)
                                key-fingerprint))
-           (magit-read-commit-signatures id))
+           (magit-read-commit-signatures id))))
 
 (defun magit-verify-tag (name &optional
                               ignore-key-expiration

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -350,9 +350,10 @@ Short, minimal, version:
     (dolist (line lines nil)
       (let ((fields (split-string line)))
         (pcase (car fields)
-        ;; Start reading a new signature
+          ;; Start reading a new signature
           ("NEWSIG"
-           (setq sigs (cons (setq sig (magit-pgp-signature)) sigs))
+           (setq sig (magit-pgp-signature))
+           (push sig sigs)
            (oset sig key-uid (nth 1 fields)))
           ("GOODSIG"
            (oset sig sig-validity t)

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -73,7 +73,6 @@ Input is case-insensitive."
 
     (cond
      ((equal dlevel "ultimate") 'ultimate)
-     ((equal dlevel "full") 'full)
      ((equal dlevel "fully") 'full)
      ((equal dlevel "undefined") 'undefined)
      ((equal dlevel "marginal") 'marginal)

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -156,14 +156,11 @@ non-revoked key, with a non-never ownertrust), return it
 unmodified, otherwise return nil."
   (and (not (oref sig error))
        (oref sig sig-validity)
-       (or ignore-key-expiration
-           (not (oref sig key-expired)))
-       (or ignore-sig-expiration
-           (not (oref sig sig-expired)))
-       (or ignore-key-validity
-           (not (equal 'never (oref sig key-validity))))
-       (or ignore-revocation
-           (not (oref sig key-revoked))))
+       (or ignore-key-expiration (not (oref sig key-expired)))
+       (or ignore-sig-expiration (not (oref sig sig-expired)))
+       ;; FIXME why not `eq'?
+       (or ignore-key-validity   (not (equal 'never (oref sig key-validity))))
+       (or ignore-revocation     (not (oref sig key-revoked))))
   ;; FIXME this seems to be wrong
   sig)
 

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -118,13 +118,13 @@ Returns a possibly empty list of (KEYID OWNERID)."
                             (not (equal "NEVER" ownertrust)))))
            (when (or valid include-invalid)
              (list fingerprint key-uid valid
-                   (pcase (downcase level)
+                   (pcase (downcase ownertrust)
                      ("ultimate"  'ultimate)
                      ("fully"     'full)
                      ("undefined" 'undefined)
                      ("marginal"  'marginal)
                      ("never"     nil)
-                     (_ (error "Unknown owner trust %s" level)))
+                     (_ (error "Unknown owner trust %s" ownertrust)))
                    (equal "EXPKEYSIG" sig-validity)
                    (equal "EXPSIG" sig-validity)))))))
 

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -25,108 +25,91 @@
 
 ;; Verifies PGP signatures of commit and tag objects.
 
+;; Also see
+;; https://www.gnupg.org/documentation/manuals/gnupg/Automated-signature-checking.html.
+
 ;;; Code:
 
 (require 'magit)
 
 (defun magit-verify-commit (id &optional include-invalid)
+  ;; TODO Update me.
   "Verify cryptographic signature of commit ID.
 
-Return value is nil if ID is not signed, or a list of the form
-\(KEY-FP KEY-UID VALID OWNERTRUST KEY-EXPIRED SIG-EXPIRED), where:
-
- - KEY-FP is a PGP key fingerprint.
- - KEY-UID is the PGP key's primary UID.
- - VALID is t if and only if the signature is valid.
-   Notice that unless INCLUDE-INVALID is non-nil,
-   you don't need to verify this value: the function
-   would have returned nil if the signature was invalid.
- - OWNERTRUST is either a symbol ('ultimate, 'full,
-   'unknown, 'undefined, 'marginal) or nil if the key is NOT
-   trusted.
- - KEY-EXPIRED is non-nil if the key or a subkey has expired.
- - SIG-EXPIRED is non-nil if the signature has expired.
+Return a `magit-gpg-signature' object (which see) or if the
+commit isn't signed nil.
 
 By default, this function returns nil for missing or invalid
 signature.  If INCLUDE-INVALID is non-nil, however, a list is
-always returned even if the signature is invalid.
-
-This function is implemented following GnuPG documentation at:
-https://www.gnupg.org/documentation/manuals/gnupg/Automated-signature-checking.html"
-  (magit-verify--parse-output (magit-git-lines "verify-commit" "--raw" id)
-                              include-invalid))
+always returned even if the signature is invalid."
+  (with-temp-buffer
+    (magit-git-insert "verify-commit" "--raw" id)
+    (magit-verify--parse-output include-invalid)))
 
 (defun magit-verify-tag (name &optional include-invalid)
   "Verify cryptographic signature of tag NAME.
 
 The return value has the same format as `magit-verify-tag', which
 see."
-  (magit-verify--parse-output (magit-git-lines "verify-tag" "--raw" name)
-                              include-invalid))
+  (with-temp-buffer
+    (magit-git-lines "verify-tag" "--raw" name)
+    (magit-verify--parse-output include-invalid)))
 
-(defun magit-verify--parse-output (lines &optional include-invalid)
-  "Internal, DO NOT USE.
+(defclass magit-gpg-signature ()
+  ;; TODO reasonable order and documentation
+  ((sig-validity)
+   (key-uid)
+   (fingerprint)
+   (ownertrust)
+   (valid)
+   (key-expired)
+   (sig-expired))
+  "
+ - KEY-FP is a PGP key fingerprint.
+ - KEY-UID is the PGP key's primary UID.
+ - VALID is t if and only if the signature is valid.
+   Notice that unless INCLUDE-INVALID is non-nil,
+   you don't need to verify this value: the function
+   would have returned nil if the signature was invalid.
+ - OWNERTRUST is either a symbol (`ultimate', `full',
+   `unknown', `undefined', `marginal') or nil if the key is NOT
+   trusted.
+ - KEY-EXPIRED is non-nil if the key or a subkey has expired.
+ - SIG-EXPIRED is non-nil if the signature has expired.")
 
-The common part of `magit-verify-commit' and
-`magit-verify-tag'."
-
-  "Parse LINES as output of git verify-[tag,commit] --raw ...
-Returns a possibly empty list of (KEYID OWNERID)."
-  (and lines
-       (let ((keydata (-non-nil
-                       (mapcar
-                        (lambda (str)
-                          (when (string-match
-                                 "^\\[GNUPG:] \\(\\(?:GOOD\\|BAD\\|EXPKEY\\|EXP\\)\\)SIG [[:xdigit:]]+ \\(.+\\)$"
-                                 str)
-                            (list (match-string 1 str) ; GOOD/BAD/EXP/EXPSIG
-                                  (match-string 2 str) ; UID
-                                  )))
-                        lines)))
-             (fingerprint (-non-nil
-                           (mapcar
-                            (lambda (str)
-                              (when (string-match
-                                     "^\\[GNUPG:] VALIDSIG \\([[:xdigit:]]+\\) .+$"
-                                     str)
-                                (match-string 1 str)))
-                            lines)))
-             (ownertrust (-non-nil
-                          (mapcar
-                           (lambda (str)
-                             (when (string-match
-                                    "^\\[GNUPG:] TRUST_\\([[:alpha:]]+\\) .+$"
-                                    str)
-                               (match-string 1 str)))
-                           lines))))
-         ;; We should have processed exactly one
-         ;; GOODSIG/BADSIG/EXPSIG/EXPKEYSIG line, exactly one VALIDSIG
-         ;; line and exactly one TRUST_ line.  If this is not the
-         ;; case, panic.
-         (unless (= 1 (length keydata))
-           (error "Abnormal state 1 in magit-verify--parse-output"))
-         (unless (= 1 (length fingerprint))
-           (error "Abnormal state 2 in magit-verify--parse-output"))
-         (unless (= 1 (length ownertrust))
-           (error "Abnormal state 3 in magit-verify--parse-output"))
-         (let* ((keydata (car keydata))
-                (fingerprint (car fingerprint))
-                (ownertrust (car ownertrust))
-                (sig-validity (nth 0 keydata))
-                (key-uid (nth 1 keydata))
-                (valid (and (not (equal "BAD" sig-validity))
-                            (not (equal "NEVER" ownertrust)))))
-           (and (or valid include-invalid)
-                (list fingerprint key-uid valid
-                      (pcase (downcase ownertrust)
-                        ("ultimate"  'ultimate)
-                        ("fully"     'full)
-                        ("undefined" 'undefined)
-                        ("marginal"  'marginal)
-                        ("never"     nil)
-                        (_ (error "Unknown owner trust %s" ownertrust)))
-                      (equal "EXPKEY" sig-validity)
-                      (equal "EXP" sig-validity)))))))
+(defun magit-verify--parse-output (&optional include-invalid)
+  (let ((obj (magit-gpg-signature)))
+    (with-slots (sig-validity key-uid fingerprint ownertrust
+                              valid key-expired sig-expired) obj
+      (while (not (eobp))
+        ;; TODO Are these in the correct order?
+        (cond
+         ((looking-at "^\\[GNUPG:] \\(\\(?:GOOD\\|BAD\\|EXPKEY\\|EXP\\)\\)SIG \
+[[:xdigit:]]+ \\(.+\\)$")
+          (cl-assert (not sig-validity) (buffer-string))
+          (setf sig-validity (match-string 1))
+          (setf key-uid (match-string 2)))
+         ((looking-at "^\\[GNUPG:] VALIDSIG \\([[:xdigit:]]+\\) .+$")
+          (cl-assert (not fingerprint) (buffer-string))
+          (setf fingerprint (match-string 1)))
+         ((looking-at "^\\[GNUPG:] TRUST_\\([[:alpha:]]+\\) .+$")
+          (cl-assert (not ownertrust) (buffer-string))
+          (setf ownertrust (match-string 1))))
+        (forward-line))
+      (cl-assert (and sig-validity key-uid fingerprint ownertrust)
+                 (buffer-string))
+      (setf ownertrust (pcase (downcase ownertrust)
+                         ("ultimate"  'ultimate)
+                         ("fully"     'full)
+                         ("undefined" 'undefined)
+                         ("marginal"  'marginal)
+                         ("never"     nil)
+                         (_ (error "Unknown owner trust %s" ownertrust))))
+      (setf valid (and (not (equal "BAD" sig-validity))
+                       (not (equal "NEVER" ownertrust))))
+      (setf key-expired (equal "EXPKEY" sig-validity))
+      (setf sig-expired (equal "EXP" sig-validity))
+      (and (or valid include-invalid) obj))))
 
 (provide 'magit-verify)
 ;;; magit-verify.el ends here

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -61,24 +61,6 @@ see."
   (magit-verify--parse-output (magit-git-lines "verify-tag" "--raw" name)
                               include-invalid))
 
-(defun magit-verify--ownertrust-symbol (level)
-    "Internal, DO NOT USE.
-
-Convert owner trust LEVEL, a string, to a symbol.
-
-Accepted inputs are ULTIMATE ('ultimate), FULLY ('full),
-UNKNOWN ('unknown), UNDEFINED ('undefined), MARGINAL ('marginal)
-and NEVER (nil).  Any other value will raise an error.
-
-Input is case-insensitive."
-    (pcase (downcase level)
-      ("ultimate"  'ultimate)
-      ("fully"     'full)
-      ("undefined" 'undefined)
-      ("marginal"  'marginal)
-      ("never"     nil)
-      (_ (error "Unknown owner trust %s" level))))
-
 (defun magit-verify--parse-output (lines &optional include-invalid)
   "Internal, DO NOT USE.
 
@@ -152,10 +134,14 @@ Returns a possibly empty list of (KEYID OWNERID)."
                 (valid (and (not (equal "BADSIG" sig-validity))
                             (not (equal "NEVER" ownertrust)))))
            (and (or valid include-invalid)
-                (list fingerprint
-                      key-uid
-                      valid
-                      (magit-verify--ownertrust-symbol ownertrust)
+                (list fingerprint key-uid valid
+                      (pcase (downcase level)
+                        ("ultimate"  'ultimate)
+                        ("fully"     'full)
+                        ("undefined" 'undefined)
+                        ("marginal"  'marginal)
+                        ("never"     nil)
+                        (_ (error "Unknown owner trust %s" level)))
                       (equal "EXPKEYSIG" sig-validity)
                       (equal "EXPSIG" sig-validity)))))))
 

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -35,6 +35,7 @@
 
 ;;; Code:
 
+(require 'parse-time)
 (require 'magit)
 
 ;;; High level interface

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -62,22 +62,21 @@ doing.
 
 If IGNORE-REVOCATION is non-nil, will accept signatures from
 revoked keys.  Enable if you know what you're doing."
-  (-non-nil
-   (mapcar (lambda (sig) (oref (magit-verify-signature
-                                sig
-                                ignore-key-expiration
-                                ignore-sig-expiration
-                                ignore-key-validity
-                                ignore-revocation)
-                               key-fingerprint))
-           (magit-read-commit-signatures id))))
+  (-keep (lambda (sig)
+           (oref (magit-verify-signature
+                  sig
+                  ignore-key-expiration
+                  ignore-sig-expiration
+                  ignore-key-validity
+                  ignore-revocation)
+                 key-fingerprint))
+         (magit-read-commit-signatures id)))
 
 (defun magit-verify-tag (name &optional
                               ignore-key-expiration
                               ignore-sig-expiration
                               ignore-key-validity
                               ignore-revocation)
-
   "Verify tag NAME.
 
 NAME must be a tag *name*, and cannot be a SHA-1 identifier.
@@ -89,15 +88,15 @@ be signaled.
 IGNORE-KEY-EXPIRATION, IGNORE-SIG-EXPIRATION, IGNORE-KEY-VALIDITY
 and IGNORE-REVOCATION have the same meaning as in
 `magit-verify-commit', which see."
-  (-non-nil
-   (mapcar (lambda (sig) (oref (magit-verify-signature
-                                sig
-                                ignore-key-expiration
-                                ignore-sig-expiration
-                                ignore-key-validity
-                                ignore-revocation)
-                               key-fingerprint))
-           (magit-read-tag-signatures name))))
+  (-keep (lambda (sig)
+           (oref (magit-verify-signature
+                  sig
+                  ignore-key-expiration
+                  ignore-sig-expiration
+                  ignore-key-validity
+                  ignore-revocation)
+                 key-fingerprint))
+         (magit-read-tag-signatures name)))
 
 ;;; Lower level interface
 
@@ -110,13 +109,12 @@ the same functionality.
 
 Return a possibly empty list of `magit-pgp-signature' objects, which see."
   (magit-verify--parse-output
-   (split-string
-    ;; `magit-git-lines' only returns stdout, we need stderr.
-    (shell-command-to-string (format
-                              "%s verify-commit --raw %s"
-                              (shell-quote-argument magit-git-executable)
-                              (shell-quote-argument id)))
-    "\n")))
+   ;; `magit-git-lines' only returns stdout, we need stderr.
+   (split-string (shell-command-to-string
+                  (format "%s verify-commit --raw %s"
+                          (shell-quote-argument magit-git-executable)
+                          (shell-quote-argument id)))
+                 "\n")))
 
 (defun magit-read-tag-signatures (name)
   "Return PGP signatures of tag NAME, regardless of their validity.
@@ -132,21 +130,19 @@ git verify-tag doesn't do.  If names don't match, an error will
 be signaled.
 
 Return a possibly empty list of `magit-pgp-signature' objects, which see."
-  (let ((realname (car (magit-git-lines "verify-tag" "--format" "%(tag)" name))))
-    (unless
-        (string= realname name)
-      (error
-       "The tag object referred to by `%s' is actually named `%s'.  Maybe you've given `magit-verify-tag' a hash instead of a name, or maybe something fishy is going on"
-       name realname)))
+  (let ((realname (magit-git-string "verify-tag" "--format" "%(tag)" name)))
+    (unless (string= realname name)
+      (error "The tag object referred to by `%s' is actually named `%s'.  \
+Maybe you've given `magit-verify-tag' a hash instead of a name, \
+or maybe something fishy is going on" name realname)))
 
   (magit-verify--parse-output
-   (split-string
-    ;; `magit-git-lines' only returns stdout, we need stderr.
-    (shell-command-to-string (format
-                              "%s verify-tag --raw %s"
-                              (shell-quote-argument magit-git-executable)
-                              (shell-quote-argument name)))
-    "\n")))
+   ;; `magit-git-lines' only returns stdout, we need stderr.
+   (split-string (shell-command-to-string
+                  (format "%s verify-tag --raw %s"
+                          (shell-quote-argument magit-git-executable)
+                          (shell-quote-argument name)))
+                 "\n")))
 
 (defun magit-verify-signature (sig &optional
                                    ignore-key-expiration
@@ -323,12 +319,10 @@ Short, minimal, version:
 
 (defun magit-verify--extract-uid (line sig)
   ;; Read name and comment from a "*SIG" LINE and `oset' them in SIG.
-
-  (unless
-      (string-match
-   ;; "^[A-Z]+SIG  \\(.*\\)\\(?: (<\\(.+\\))\\) <\\(.*\\)$>"
-       "^[A-Z]+SIG [[:xdigit:]]+ \\(.*?\\)\\(?: (\\(.*\\))\\)? <\\(.*\\)>$"
-       line)
+  (unless (string-match
+           ;; "^[A-Z]+SIG  \\(.*\\)\\(?: (<\\(.+\\))\\) <\\(.*\\)$>"
+           "^[A-Z]+SIG [[:xdigit:]]+ \\(.*?\\)\\(?: (\\(.*\\))\\)? <\\(.*\\)>$"
+           line)
     (error "Error parsing uid from %s" line))
   (oset sig key-name (match-string 1 line))
   (oset sig key-comment (match-string 2 line))
@@ -339,80 +333,71 @@ Short, minimal, version:
   ;;
   ;; If STR matches ^[[:digit:]]+$, it's treated as a unix timestmap,
   ;; otherwise as an RFC 8601 string.  If nothing works, raise an error."
-  (and
-   (not (string= str "0"))
-   (or
-    (and
-     (string-match "\\`[[:digit:]]+\\'" str)
-     (seconds-to-time (string-to-number str)))
-
-    ;; @FIXME If `parse-iso8601-time-string' fails, it will neither
-    ;; return an invalid value nor error, but instead delegate to
-    ;; the weird `parse-time-string' which will associate a value to
-    ;; every possible input.  This is not what we want, and we need
-    ;; a way to error if we can't parse the date.
-    (parse-iso8601-time-string str))))
+  (and (not (string= str "0"))
+       (or (and (string-match "\\`[[:digit:]]+\\'" str)
+                (seconds-to-time (string-to-number str)))
+           ;; @FIXME If `parse-iso8601-time-string' fails, it will neither
+           ;; return an invalid value nor error, but instead delegate to
+           ;; the weird `parse-time-string' which will associate a value to
+           ;; every possible input.  This is not what we want, and we need
+           ;; a way to error if we can't parse the date.
+           (parse-iso8601-time-string str))))
 
 (defun magit-verify--parse-output (lines)
   ;; Parse output from git verify-[tag|commit] --raw (which is
   ;; actually the output of gpg --verify --status-fd) and return a
   ;; possibly empty list of `magit-pgp-signature' object.
-  (let ((lines (-non-nil
-                (mapcar
-                 (lambda (line)
-                   (and
-                    (string-prefix-p "[GNUPG:] " line)
-                    (substring line 9)))
-                 lines)))
+  (let ((lines (cl-mapcan (lambda (line)
+                            (and (string-prefix-p "[GNUPG:] " line)
+                                 (list (substring line 9))))
+                          lines))
         (sigs nil)
         (sig nil))
-
     (message "%s" lines)
-
     (dolist (line lines nil)
       (let ((fields (split-string line)))
         (pcase (car fields)
         ;; Start reading a new signature
-          ("NEWSIG" (progn
-                      (setq sigs (cons (setq sig (magit-pgp-signature)) sigs))
-                      (oset sig key-uid (nth 1 fields))))
-          ("GOODSIG" (progn
-                       (oset sig sig-validity t)
-                       (oset sig sig-expired nil)
-                       (oset sig key-expired nil)
-                       (magit-verify--extract-uid line sig)))
-          ("EXPSIG" (progn
-                      (oset sig sig-validity t)
-                      (oset sig sig-expired t)
-                      (magit-verify--extract-uid line sig)))
-          ("EXPKEYSIG" (progn
-                         (oset sig sig-validity t)
-                         (oset sig key-expired t)
-                         (magit-verify--extract-uid line sig)))
-          ("REVKEYSIG" (progn
-                         (oset sig sig-validity t)
-                         (oset sig key-revoked t)
-                         (magit-verify--extract-uid line sig)))
-          ("ERRSIG" (progn
-                      (oset sig sig-validity nil)
-                      (oset sig error (pcase (number-to-string (nth 6 fields))
-                            (4 'unknown-algorithm)
-                            (9 'no-pubkey)
-                            (_ t)))))
-          ("BADSIG" (progn
-                      (oset sig sig-validity nil)
-                      (magit-verify--extract-uid line sig)))
-          ("VALIDSIG" (progn
-                        (oset sig key-fingerprint (nth 1 fields))
-                        (oset sig sig-creation-date (magit-verify--parse-date (nth 3 fields)))
-                        (oset sig sig-expiration-date (magit-verify--parse-date (nth 4 fields)))))
-          ("KEYEXPIRED" (oset sig key-expired t))
+          ("NEWSIG"
+           (setq sigs (cons (setq sig (magit-pgp-signature)) sigs))
+           (oset sig key-uid (nth 1 fields)))
+          ("GOODSIG"
+           (oset sig sig-validity t)
+           (oset sig sig-expired nil)
+           (oset sig key-expired nil)
+           (magit-verify--extract-uid line sig))
+          ("EXPSIG"
+           (oset sig sig-validity t)
+           (oset sig sig-expired t)
+           (magit-verify--extract-uid line sig))
+          ("EXPKEYSIG"
+           (oset sig sig-validity t)
+           (oset sig key-expired t)
+           (magit-verify--extract-uid line sig))
+          ("REVKEYSIG"
+           (oset sig sig-validity t)
+           (oset sig key-revoked t)
+           (magit-verify--extract-uid line sig))
+          ("ERRSIG"
+           (oset sig sig-validity nil)
+           (oset sig error (pcase (number-to-string (nth 6 fields))
+                             (4 'unknown-algorithm)
+                             (9 'no-pubkey)
+                             (_ t))))
+          ("BADSIG"
+           (oset sig sig-validity nil)
+           (magit-verify--extract-uid line sig))
+          ("VALIDSIG"
+           (oset sig key-fingerprint (nth 1 fields))
+           (oset sig sig-creation-date (magit-verify--parse-date (nth 3 fields)))
+           (oset sig sig-expiration-date (magit-verify--parse-date (nth 4 fields))))
+          ("KEYEXPIRED"      (oset sig key-expired t))
           ("TRUST_UNDEFINED" (oset sig key-validity 'undefined))
-          ("TRUST_NEVER" (oset sig key-validity 'never))
-          ("TRUST_MARGINAL" (oset sig key-validity 'marginal))
-          ("TRUST_FULLY" (oset sig key-validity 'fully))
-          ("TRUST_ULTIMATE" (oset sig key-validity 'ultimate))
-          ("NO_PUBKEY" (oset sig error 'no-pubkey))
+          ("TRUST_NEVER"     (oset sig key-validity 'never))
+          ("TRUST_MARGINAL"  (oset sig key-validity 'marginal))
+          ("TRUST_FULLY"     (oset sig key-validity 'fully))
+          ("TRUST_ULTIMATE"  (oset sig key-validity 'ultimate))
+          ("NO_PUBKEY"       (oset sig error 'no-pubkey))
 
           ;; Arguments we know we can ignore
           ("SIG_ID")
@@ -421,11 +406,13 @@ Short, minimal, version:
 
           ;; Error states We may have received more specific
           ;; information earlier, we don't want to overwrite them.
-          ("NODATA" (unless (member (string-to-number (nth 1 fields)) '(1 2))
-                      (error "PGP returned abnormal state NODATA %s" (nth 1 fields))))
-           ("FAILURE" (unless (or (not sig)
-                                  (oref sig error))
-                        (oset sig error t)))
+          ("NODATA"
+           (unless (member (string-to-number (nth 1 fields)) '(1 2))
+             (error "PGP returned abnormal state NODATA %s" (nth 1 fields))))
+          ("FAILURE"
+           (unless (or (not sig)
+                       (oref sig error))
+             (oset sig error t)))
 
           ;; The doc in doc/DETAILS states that: "an application should
           ;; always be willing to ignore unknown keywords that may be

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -114,7 +114,7 @@ Returns a possibly empty list of (KEYID OWNERID)."
                 (ownertrust (car ownertrust))
                 (sig-validity (nth 0 keydata))
                 (key-uid (nth 1 keydata))
-                (valid (and (not (equal "BADSIG" sig-validity))
+                (valid (and (not (equal "BAD" sig-validity))
                             (not (equal "NEVER" ownertrust)))))
            (and (or valid include-invalid)
                 (list fingerprint key-uid valid
@@ -125,8 +125,8 @@ Returns a possibly empty list of (KEYID OWNERID)."
                         ("marginal"  'marginal)
                         ("never"     nil)
                         (_ (error "Unknown owner trust %s" ownertrust)))
-                      (equal "EXPKEYSIG" sig-validity)
-                      (equal "EXPSIG" sig-validity)))))))
+                      (equal "EXPKEY" sig-validity)
+                      (equal "EXP" sig-validity)))))))
 
 (provide 'magit-verify)
 ;;; magit-verify.el ends here

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -158,18 +158,17 @@ Return a possibly empty list of `magit-pgp-signature' objects, which see."
 If SIG is a valid signature (non-expired, from a non-expired and
 non-revoked key, with a non-never ownertrust), return it
 unmodified, otherwise return nil."
-
-  (and
-   (not (oref sig error))
-   (oref sig sig-validity)
-   (or ignore-key-expiration
-       (not (oref sig key-expired)))
-   (or ignore-sig-expiration
-       (not (oref sig sig-expired)))
-   (or ignore-key-validity
-       (not (equal 'never (oref sig key-validity))))
-   (or ignore-revocation
-       (not (oref sig key-revoked))))
+  (and (not (oref sig error))
+       (oref sig sig-validity)
+       (or ignore-key-expiration
+           (not (oref sig key-expired)))
+       (or ignore-sig-expiration
+           (not (oref sig sig-expired)))
+       (or ignore-key-validity
+           (not (equal 'never (oref sig key-validity))))
+       (or ignore-revocation
+           (not (oref sig key-revoked))))
+  ;; FIXME this seems to be wrong
   sig)
 
 ;;; Signature class

--- a/lisp/magit-verify.el
+++ b/lisp/magit-verify.el
@@ -116,17 +116,17 @@ Returns a possibly empty list of (KEYID OWNERID)."
                 (key-uid (nth 1 keydata))
                 (valid (and (not (equal "BADSIG" sig-validity))
                             (not (equal "NEVER" ownertrust)))))
-           (when (or valid include-invalid)
-             (list fingerprint key-uid valid
-                   (pcase (downcase ownertrust)
-                     ("ultimate"  'ultimate)
-                     ("fully"     'full)
-                     ("undefined" 'undefined)
-                     ("marginal"  'marginal)
-                     ("never"     nil)
-                     (_ (error "Unknown owner trust %s" ownertrust)))
-                   (equal "EXPKEYSIG" sig-validity)
-                   (equal "EXPSIG" sig-validity)))))))
+           (and (or valid include-invalid)
+                (list fingerprint key-uid valid
+                      (pcase (downcase ownertrust)
+                        ("ultimate"  'ultimate)
+                        ("fully"     'full)
+                        ("undefined" 'undefined)
+                        ("marginal"  'marginal)
+                        ("never"     nil)
+                        (_ (error "Unknown owner trust %s" ownertrust)))
+                      (equal "EXPKEYSIG" sig-validity)
+                      (equal "EXPSIG" sig-validity)))))))
 
 (provide 'magit-verify)
 ;;; magit-verify.el ends here

--- a/t/magit-tests.el
+++ b/t/magit-tests.el
@@ -404,47 +404,47 @@ verify-[tag|commit] --raw"
     (should-not (oref sig key-comment))
     (should-not (oref sig key-validity))
     (should (oref sig key-expired))
-    (should (oref sig sig-expired)))
+    (should (oref sig sig-expired))))
 
-  ;; Bad signature from valid key
+;; Bad signature from valid key
 
-  ;;  Invalid_KEXP_SEXP.txt
-  "[GNUPG:] NEWSIG expired@badsig.example.com"
-  "[GNUPG:] KEYEXPIRED 1325376017"
-  "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
-  "[GNUPG:] KEYEXPIRED 1325376017"
-  "[GNUPG:] KEYEXPIRED 1325376017"
-  "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
-  "[GNUPG:] BADSIG FB2B6F167A81BDC5 Expired Badsig <expired@badsig.example.com>"
-  "[GNUPG:] VERIFICATION_COMPLIANCE_MODE 23"
-  ;; Invalid_KEXP_SOK.txt
-  "[GNUPG:] NEWSIG expired@badsig.example.com"
-  "[GNUPG:] KEYEXPIRED 1325376017"
-  "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
-  "[GNUPG:] KEYEXPIRED 1325376017"
-  "[GNUPG:] KEYEXPIRED 1325376017"
-  "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
-  "[GNUPG:] BADSIG FB2B6F167A81BDC5 Expired Badsig <expired@badsig.example.com>"
-  "[GNUPG:] VERIFICATION_COMPLIANCE_MODE 23"
-  ;; Invalid_KOK_SEXP.txt
-  "[GNUPG:] NEWSIG key@badsig.example.com"
-  "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
-  "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
-  "[GNUPG:] BADSIG 7A2E132C20E0EAF8 Normal Badsig <key@badsig.example.com>"
-  ;; Invalid_kok_sok.txt
-  "[GNUPG:] NEWSIG key@badsig.example.com"
-  "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
-  "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
-  "[GNUPG:] BADSIG 7A2E132C20E0EAF8 Normal Badsig <key@badsig.example.com>"
-  ;; Valid_KEXP_SOK.txt
-  ;; Valid_KOK_SEXP.txt
-  ;; Valid_KOK_SOK.txt
+;;  Invalid_KEXP_SEXP.txt
+"[GNUPG:] NEWSIG expired@badsig.example.com"
+"[GNUPG:] KEYEXPIRED 1325376017"
+"[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+"[GNUPG:] KEYEXPIRED 1325376017"
+"[GNUPG:] KEYEXPIRED 1325376017"
+"[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+"[GNUPG:] BADSIG FB2B6F167A81BDC5 Expired Badsig <expired@badsig.example.com>"
+"[GNUPG:] VERIFICATION_COMPLIANCE_MODE 23"
+;; Invalid_KEXP_SOK.txt
+"[GNUPG:] NEWSIG expired@badsig.example.com"
+"[GNUPG:] KEYEXPIRED 1325376017"
+"[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+"[GNUPG:] KEYEXPIRED 1325376017"
+"[GNUPG:] KEYEXPIRED 1325376017"
+"[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+"[GNUPG:] BADSIG FB2B6F167A81BDC5 Expired Badsig <expired@badsig.example.com>"
+"[GNUPG:] VERIFICATION_COMPLIANCE_MODE 23"
+;; Invalid_KOK_SEXP.txt
+"[GNUPG:] NEWSIG key@badsig.example.com"
+"[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+"[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+"[GNUPG:] BADSIG 7A2E132C20E0EAF8 Normal Badsig <key@badsig.example.com>"
+;; Invalid_kok_sok.txt
+"[GNUPG:] NEWSIG key@badsig.example.com"
+"[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+"[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+"[GNUPG:] BADSIG 7A2E132C20E0EAF8 Normal Badsig <key@badsig.example.com>"
+;; Valid_KEXP_SOK.txt
+;; Valid_KOK_SEXP.txt
+;; Valid_KOK_SOK.txt
 
 
 
 ;;; magit-tests.el ends soon
-  (provide 'magit-tests)
-  ;; Local Variables:
-  ;; indent-tabs-mode: nil
-  ;; End:
+(provide 'magit-tests)
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
 ;;; magit-tests.el ends here

--- a/t/magit-tests.el
+++ b/t/magit-tests.el
@@ -37,30 +37,30 @@
 
 (ert-deftest magit--with-safe-default-directory ()
   (magit-with-test-directory
-    (let ((find-file-visit-truename nil))
-      (should (equal (magit-toplevel "repo/")
-                     (magit-toplevel (expand-file-name "repo/"))))
-      (should (equal (magit-toplevel "repo")
-                     (magit-toplevel (expand-file-name "repo/")))))))
+   (let ((find-file-visit-truename nil))
+     (should (equal (magit-toplevel "repo/")
+                    (magit-toplevel (expand-file-name "repo/"))))
+     (should (equal (magit-toplevel "repo")
+                    (magit-toplevel (expand-file-name "repo/")))))))
 
 (ert-deftest magit-toplevel:basic ()
   (let ((find-file-visit-truename nil))
     (magit-with-test-directory
-      (magit-git "init" "repo")
-      (magit-test-magit-toplevel)
-      (should (equal (magit-toplevel   "repo/.git/")
-                     (expand-file-name "repo/")))
-      (should (equal (magit-toplevel   "repo/.git/objects/")
-                     (expand-file-name "repo/")))
-      (should (equal (magit-toplevel   "repo-link/.git/")
-                     (expand-file-name "repo-link/")))
-      (should (equal (magit-toplevel   "repo-link/.git/objects/")
-                     ;; We could theoretically return "repo-link/"
-                     ;; here by going up until `--git-dir' gives us
-                     ;; "." .  But that would be a bit risky and Magit
-                     ;; never goes there anyway, so it's not worth it.
-                     ;; But in the doc-string we say we cannot do it.
-                     (expand-file-name "repo/"))))))
+     (magit-git "init" "repo")
+     (magit-test-magit-toplevel)
+     (should (equal (magit-toplevel   "repo/.git/")
+                    (expand-file-name "repo/")))
+     (should (equal (magit-toplevel   "repo/.git/objects/")
+                    (expand-file-name "repo/")))
+     (should (equal (magit-toplevel   "repo-link/.git/")
+                    (expand-file-name "repo-link/")))
+     (should (equal (magit-toplevel   "repo-link/.git/objects/")
+                    ;; We could theoretically return "repo-link/"
+                    ;; here by going up until `--git-dir' gives us
+                    ;; "." .  But that would be a bit risky and Magit
+                    ;; never goes there anyway, so it's not worth it.
+                    ;; But in the doc-string we say we cannot do it.
+                    (expand-file-name "repo/"))))))
 
 (ert-deftest magit-toplevel:tramp ()
   (cl-letf* ((find-file-visit-truename nil)
@@ -88,17 +88,17 @@
 (ert-deftest magit-toplevel:submodule ()
   (let ((find-file-visit-truename nil))
     (magit-with-test-directory
-      (magit-git "init" "remote")
-      (let ((default-directory (expand-file-name "remote/")))
-        (magit-git "commit" "-m" "init" "--allow-empty"))
-      (magit-git "init" "super")
-      (setq default-directory (expand-file-name "super/"))
-      (magit-git "submodule" "add" "../remote" "repo/")
-      (magit-test-magit-toplevel)
-      (should (equal (magit-toplevel   ".git/modules/repo/")
-                     (expand-file-name "repo/")))
-      (should (equal (magit-toplevel   ".git/modules/repo/objects/")
-                     (expand-file-name "repo/"))))))
+     (magit-git "init" "remote")
+     (let ((default-directory (expand-file-name "remote/")))
+       (magit-git "commit" "-m" "init" "--allow-empty"))
+     (magit-git "init" "super")
+     (setq default-directory (expand-file-name "super/"))
+     (magit-git "submodule" "add" "../remote" "repo/")
+     (magit-test-magit-toplevel)
+     (should (equal (magit-toplevel   ".git/modules/repo/")
+                    (expand-file-name "repo/")))
+     (should (equal (magit-toplevel   ".git/modules/repo/objects/")
+                    (expand-file-name "repo/"))))))
 
 (defun magit-test-magit-toplevel ()
   ;; repo
@@ -177,54 +177,54 @@
 
 (ert-deftest magit-get-boolean ()
   (magit-with-test-repository
-    (magit-git "config" "a.b" "true")
-    (should     (magit-get-boolean "a.b"))
-    (should     (magit-get-boolean "a" "b"))
-    (magit-git "config" "a.b" "false")
-    (should-not (magit-get-boolean "a.b"))
-    (should-not (magit-get-boolean "a" "b"))
-    ;; Multiple values, last one wins.
-    (magit-git "config" "--add" "a.b" "true")
-    (should     (magit-get-boolean "a.b"))
-    (let ((magit--refresh-cache (list (cons 0 0))))
+   (magit-git "config" "a.b" "true")
+   (should     (magit-get-boolean "a.b"))
+   (should     (magit-get-boolean "a" "b"))
+   (magit-git "config" "a.b" "false")
+   (should-not (magit-get-boolean "a.b"))
+   (should-not (magit-get-boolean "a" "b"))
+   ;; Multiple values, last one wins.
+   (magit-git "config" "--add" "a.b" "true")
+   (should     (magit-get-boolean "a.b"))
+   (let ((magit--refresh-cache (list (cons 0 0))))
      (should    (magit-get-boolean "a.b")))))
 
 (ert-deftest magit-get-{current|next}-tag ()
   (magit-with-test-repository
-    (magit-git "commit" "-m" "1" "--allow-empty")
-    (should (equal (magit-get-current-tag) nil))
-    (should (equal (magit-get-next-tag)    nil))
-    (magit-git "tag" "1")
-    (should (equal (magit-get-current-tag) "1"))
-    (should (equal (magit-get-next-tag)    nil))
-    (magit-git "commit" "-m" "2" "--allow-empty")
-    (magit-git "tag" "2")
-    (should (equal (magit-get-current-tag) "2"))
-    (should (equal (magit-get-next-tag)    nil))
-    (magit-git "commit" "-m" "3" "--allow-empty")
-    (should (equal (magit-get-current-tag) "2"))
-    (should (equal (magit-get-next-tag)    nil))
-    (magit-git "commit" "-m" "4" "--allow-empty")
-    (magit-git "tag" "4")
-    (magit-git "reset" "HEAD~")
-    (should (equal (magit-get-current-tag) "2"))
-    (should (equal (magit-get-next-tag)    "4"))))
+   (magit-git "commit" "-m" "1" "--allow-empty")
+   (should (equal (magit-get-current-tag) nil))
+   (should (equal (magit-get-next-tag)    nil))
+   (magit-git "tag" "1")
+   (should (equal (magit-get-current-tag) "1"))
+   (should (equal (magit-get-next-tag)    nil))
+   (magit-git "commit" "-m" "2" "--allow-empty")
+   (magit-git "tag" "2")
+   (should (equal (magit-get-current-tag) "2"))
+   (should (equal (magit-get-next-tag)    nil))
+   (magit-git "commit" "-m" "3" "--allow-empty")
+   (should (equal (magit-get-current-tag) "2"))
+   (should (equal (magit-get-next-tag)    nil))
+   (magit-git "commit" "-m" "4" "--allow-empty")
+   (magit-git "tag" "4")
+   (magit-git "reset" "HEAD~")
+   (should (equal (magit-get-current-tag) "2"))
+   (should (equal (magit-get-next-tag)    "4"))))
 
 (ert-deftest magit-list-{|local-|remote-}branch-names ()
   (magit-with-test-repository
-    (magit-git "commit" "-m" "init" "--allow-empty")
-    (magit-git "update-ref" "refs/remotes/foobar/master" "master")
-    (magit-git "update-ref" "refs/remotes/origin/master" "master")
-    (should (equal (magit-list-branch-names)
-                   (list "master" "foobar/master" "origin/master")))
-    (should (equal (magit-list-local-branch-names)
-                   (list "master")))
-    (should (equal (magit-list-remote-branch-names)
-                   (list "foobar/master" "origin/master")))
-    (should (equal (magit-list-remote-branch-names "origin")
-                   (list "origin/master")))
-    (should (equal (magit-list-remote-branch-names "origin" t)
-                   (list "master")))))
+   (magit-git "commit" "-m" "init" "--allow-empty")
+   (magit-git "update-ref" "refs/remotes/foobar/master" "master")
+   (magit-git "update-ref" "refs/remotes/origin/master" "master")
+   (should (equal (magit-list-branch-names)
+                  (list "master" "foobar/master" "origin/master")))
+   (should (equal (magit-list-local-branch-names)
+                  (list "master")))
+   (should (equal (magit-list-remote-branch-names)
+                  (list "foobar/master" "origin/master")))
+   (should (equal (magit-list-remote-branch-names "origin")
+                  (list "origin/master")))
+   (should (equal (magit-list-remote-branch-names "origin" t)
+                  (list "master")))))
 
 (ert-deftest magit-process:match-prompt-nil-when-no-match ()
   (should (null (magit-process-match-prompt '("^foo: ?$") "bar: "))))
@@ -265,45 +265,186 @@
 
 (ert-deftest magit-status:file-sections ()
   (magit-with-test-repository
-    (cl-flet ((modify (file) (with-temp-file file
-                               (insert (make-temp-name "content")))))
-      (modify "file")
-      (modify "file with space")
-      (modify "file with äöüéλ")
-      (should (magit-test-get-section '(untracked) "file"))
-      (should (magit-test-get-section '(untracked) "file with space"))
-      (should (magit-test-get-section '(untracked) "file with äöüéλ"))
-      (magit-stage-modified t)
-      (should (magit-test-get-section '(staged) "file"))
-      (should (magit-test-get-section '(staged) "file with space"))
-      (should (magit-test-get-section '(staged) "file with äöüéλ"))
-      (magit-git "add" ".")
-      (modify "file")
-      (modify "file with space")
-      (modify "file with äöüéλ")
-      (should (magit-test-get-section '(unstaged) "file"))
-      (should (magit-test-get-section '(unstaged) "file with space"))
-      (should (magit-test-get-section '(unstaged) "file with äöüéλ")))))
+   (cl-flet ((modify (file) (with-temp-file file
+                              (insert (make-temp-name "content")))))
+     (modify "file")
+     (modify "file with space")
+     (modify "file with äöüéλ")
+     (should (magit-test-get-section '(untracked) "file"))
+     (should (magit-test-get-section '(untracked) "file with space"))
+     (should (magit-test-get-section '(untracked) "file with äöüéλ"))
+     (magit-stage-modified t)
+     (should (magit-test-get-section '(staged) "file"))
+     (should (magit-test-get-section '(staged) "file with space"))
+     (should (magit-test-get-section '(staged) "file with äöüéλ"))
+     (magit-git "add" ".")
+     (modify "file")
+     (modify "file with space")
+     (modify "file with äöüéλ")
+     (should (magit-test-get-section '(unstaged) "file"))
+     (should (magit-test-get-section '(unstaged) "file with space"))
+     (should (magit-test-get-section '(unstaged) "file with äöüéλ")))))
 
 (ert-deftest magit-status:log-sections ()
   (magit-with-test-repository
-    (magit-git "commit" "-m" "common" "--allow-empty")
-    (magit-git "commit" "-m" "unpulled" "--allow-empty")
-    (magit-git "remote" "add" "origin" "/origin")
-    (magit-git "update-ref" "refs/remotes/origin/master" "master")
-    (magit-git "branch" "--set-upstream-to=origin/master")
-    (magit-git "reset" "--hard" "HEAD~")
-    (magit-git "commit" "-m" "unpushed" "--allow-empty")
-    (should (magit-test-get-section
-             '(unpulled . "..@{upstream}")
-             (magit-rev-parse "--short" "origin/master")))
-    (should (magit-test-get-section
-             '(unpushed . "@{upstream}..")
-             (magit-rev-parse "--short" "master")))))
+   (magit-git "commit" "-m" "common" "--allow-empty")
+   (magit-git "commit" "-m" "unpulled" "--allow-empty")
+   (magit-git "remote" "add" "origin" "/origin")
+   (magit-git "update-ref" "refs/remotes/origin/master" "master")
+   (magit-git "branch" "--set-upstream-to=origin/master")
+   (magit-git "reset" "--hard" "HEAD~")
+   (magit-git "commit" "-m" "unpushed" "--allow-empty")
+   (should (magit-test-get-section
+            '(unpulled . "..@{upstream}")
+            (magit-rev-parse "--short" "origin/master")))
+   (should (magit-test-get-section
+            '(unpushed . "@{upstream}..")
+            (magit-rev-parse "--short" "master")))))
+
+;;; PGP signatures
+
+(ert-deftest magit-verify:parse-output ()
+  "Test the output parser for gpg --status-fd format used by git
+verify-[tag|commit] --raw"
+
+  ;; No data
+  (should-not (magit-verify--parse-output nil))
+
+  ;; Corrupted signature
+  (should-error (magit-verify--parse-output
+                 (list
+                  "[GNUPG:] NODATA 4"
+                  "[GNUPG:] FAILURE gpg-exit 33554433")))
+
+  ;; Good signature, not expired, key not expired
+  (let ((sig (magit-verify--parse-output
+              (list
+               "[GNUPG:] NEWSIG key@badsig.example.com"
+               "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+               "[GNUPG:] SIG_ID Ak/49yzkCJ7W0kXLieg5q03MuMY 2018-05-19 1526721941"
+               "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+               "[GNUPG:] GOODSIG 7A2E132C20E0EAF8 Normal Badsig <key@badsig.example.com>"
+               "[GNUPG:] VALIDSIG 75741BBB0494201426D349C47A2E132C20E0EAF8 2018-05-19 1526721941 0 4 0 1 8 01 75741BBB0494201426D349C47A2E132C20E0EAF8"
+               "[GNUPG:] TRUST_UNDEFINED 0 pgp"))))
+    (should (= 1 (length sig)))
+    (setq sig (car sig))
+    (should (oref sig sig-validity))
+    (should (string= (oref sig key-fingerprint) "75741BBB0494201426D349C47A2E132C20E0EAF8"))
+    (should (string= (oref sig key-uid) "key@badsig.example.com"))
+    (should (string= (oref sig key-name) "Normal Badsig"))
+    (should-not (oref sig key-comment))
+    (should (equal (oref sig key-validity) 'undefined))
+    (should-not (oref sig key-expired))
+    (should-not (oref sig sig-expired)))
+
+  ;; Good EXPIRED signature, key not expired.
+  (let ((sig (magit-verify--parse-output
+              (list
+               "[GNUPG:] NEWSIG key@badsig.example.com"
+               "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+               "[GNUPG:] SIG_ID iIATwONP94YrWiQVZb2qegtCJUs 2010-01-01 1262305000"
+               "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+               "[GNUPG:] EXPSIG 7A2E132C20E0EAF8 Normal Badsig <key@badsig.example.com>"
+               "[GNUPG:] VALIDSIG 75741BBB0494201426D349C47A2E132C20E0EAF8 2010-01-01 1262305000 1262391400 4 0 1 8 01 75741BBB0494201426D349C47A2E132C20E0EAF8"
+               "[GNUPG:] TRUST_UNDEFINED 0 pgp"))))
+    (should (= 1 (length sig)))
+    (setq sig (car sig))
+    (should (oref sig sig-validity))
+    (should (string= (oref sig key-fingerprint) "75741BBB0494201426D349C47A2E132C20E0EAF8"))
+    (should (string= (oref sig key-uid) "key@badsig.example.com"))
+    (should (string= (oref sig key-name) "Normal Badsig"))
+    (should-not (oref sig key-comment))
+    (should (equal (oref sig key-validity) 'undefined))
+    (should-not (oref sig key-expired))
+    (should (oref sig sig-expired)))
+
+  ;; Good signature, key EXPIRED
+  (let ((sig (magit-verify--parse-output
+              (list
+               "[GNUPG:] NEWSIG expired@badsig.example.com"
+               "[GNUPG:] KEYEXPIRED 1325376017"
+               "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+               "[GNUPG:] KEYEXPIRED 1325376017"
+               "[GNUPG:] SIG_ID T5GuioUtYjuC+u/qR8ROkaapQBc 2010-01-01 1262305000"
+               "[GNUPG:] KEYEXPIRED 1325376017"
+               "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+               "[GNUPG:] EXPKEYSIG FB2B6F167A81BDC5 Expired Badsig <expired@badsig.example.com>"
+               "[GNUPG:] VALIDSIG 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 2010-01-01 1262305000 0 4 0 1 8 01 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5"
+               "[GNUPG:] VERIFICATION_COMPLIANCE_MODE 23"))))
+    (should (= 1 (length sig)))
+    (setq sig (car sig))
+    (should (oref sig sig-validity))
+    (should (string= (oref sig key-fingerprint) "04F19E43F5FD42CB0264605EFB2B6F167A81BDC5"))
+    (should (string= (oref sig key-uid) "expired@badsig.example.com"))
+    (should (string= (oref sig key-name) "Expired Badsig"))
+    (should-not (oref sig key-comment))
+    (should-not (oref sig key-validity))
+    (should (oref sig key-expired))
+    (should-not (oref sig sig-expired)))
+
+  ;; Good EXPIRED signature by EXPIRED key
+  (let ((sig (magit-verify--parse-output
+              (list
+               "[GNUPG:] NEWSIG expired@badsig.example.com"
+               "[GNUPG:] KEYEXPIRED 1325376017"
+               "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+               "[GNUPG:] KEYEXPIRED 1325376017"
+               "[GNUPG:] SIG_ID A55c0YZw9Q1luZtywPlBz+eb0Ew 2010-01-01 1262305000"
+               "[GNUPG:] KEYEXPIRED 1325376017"
+               "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+               "[GNUPG:] EXPSIG FB2B6F167A81BDC5 Expired Badsig <expired@badsig.example.com>"
+               "[GNUPG:] VALIDSIG 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 2010-01-01 1262305000 1262391400 4 0 1 8 01 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5"
+               "[GNUPG:] VERIFICATION_COMPLIANCE_MODE 23"))))
+    (should (= 1 (length sig)))
+    (setq sig (car sig))
+    (should (oref sig sig-validity))
+    (should (string= (oref sig key-fingerprint) "04F19E43F5FD42CB0264605EFB2B6F167A81BDC5"))
+    (should (string= (oref sig key-uid) "expired@badsig.example.com"))
+    (should (string= (oref sig key-name) "Expired Badsig"))
+    (should-not (oref sig key-comment))
+    (should-not (oref sig key-validity))
+    (should (oref sig key-expired))
+    (should (oref sig sig-expired)))
+
+  ;; Bad signature from valid key
+
+  ;;  Invalid_KEXP_SEXP.txt
+  "[GNUPG:] NEWSIG expired@badsig.example.com"
+  "[GNUPG:] KEYEXPIRED 1325376017"
+  "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+  "[GNUPG:] KEYEXPIRED 1325376017"
+  "[GNUPG:] KEYEXPIRED 1325376017"
+  "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+  "[GNUPG:] BADSIG FB2B6F167A81BDC5 Expired Badsig <expired@badsig.example.com>"
+  "[GNUPG:] VERIFICATION_COMPLIANCE_MODE 23"
+  ;; Invalid_KEXP_SOK.txt
+  "[GNUPG:] NEWSIG expired@badsig.example.com"
+  "[GNUPG:] KEYEXPIRED 1325376017"
+  "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+  "[GNUPG:] KEYEXPIRED 1325376017"
+  "[GNUPG:] KEYEXPIRED 1325376017"
+  "[GNUPG:] KEY_CONSIDERED 04F19E43F5FD42CB0264605EFB2B6F167A81BDC5 0"
+  "[GNUPG:] BADSIG FB2B6F167A81BDC5 Expired Badsig <expired@badsig.example.com>"
+  "[GNUPG:] VERIFICATION_COMPLIANCE_MODE 23"
+  ;; Invalid_KOK_SEXP.txt
+  "[GNUPG:] NEWSIG key@badsig.example.com"
+  "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+  "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+  "[GNUPG:] BADSIG 7A2E132C20E0EAF8 Normal Badsig <key@badsig.example.com>"
+  ;; Invalid_kok_sok.txt
+  "[GNUPG:] NEWSIG key@badsig.example.com"
+  "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+  "[GNUPG:] KEY_CONSIDERED 75741BBB0494201426D349C47A2E132C20E0EAF8 0"
+  "[GNUPG:] BADSIG 7A2E132C20E0EAF8 Normal Badsig <key@badsig.example.com>"
+  ;; Valid_KEXP_SOK.txt
+  ;; Valid_KOK_SEXP.txt
+  ;; Valid_KOK_SOK.txt
+
+
 
 ;;; magit-tests.el ends soon
-(provide 'magit-tests)
-;; Local Variables:
-;; indent-tabs-mode: nil
-;; End:
+  (provide 'magit-tests)
+  ;; Local Variables:
+  ;; indent-tabs-mode: nil
+  ;; End:
 ;;; magit-tests.el ends here


### PR DESCRIPTION
This PR adds two functions, `magit-verify-commit` and `magit-verify-tag`, for verifying the PGP signature of commits and tags.  Both take an object ID (a commit ID or a tag name, respectively) and return either nil (if object is unsigned, or signature is invalid) or a list with the following elements:

 1. The full key fingerprint; (string)
 2. The key's primary UID; (string)
 3. The signature validity; (bool, non-nil means valid) [see note below]
 4. The key's owner trust; (a symbol, or nil if *never*) [see note below]
 5. The key's expiration status (non nil means expired)
 5. The signature's expiration status (non nil means expired)
  
Note: fields 3 and 4 are never nil by default, because invalid signatures don't return a list, but nil --- this allows to use the return value of these functions as a boolean.  Yet the functions take an optional `include-invalid` argument which overrides this behavior.

The implementation tries to be reasonably paranoid, and should fail rather than returning false positives.   

This PR still lacks:
 
 - [ ] An UI exposing the new functionality 
 - [ ] Tests
 - [ ] Documentation
 
I'm willing to add all that, but I wanted to get an early review of
the base implementation.  

Thanks!