### PR TITLE
Avoid error if gitk not found on windows-nt

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -39,7 +39,7 @@
            (let ((exe (magit-git-string
                        "-c" "alias.X=!x() { which \"$1\" | cygpath -mf -; }; x"
                        "X" "gitk.exe")))
-             (and (file-executable-p exe) exe)))
+             (and exe (file-executable-p exe) exe)))
       (executable-find "gitk") "gitk")
   "The Gitk executable."
   :group 'magit-extras


### PR DESCRIPTION
Under windows-nt, I was getting error messages on trying to use commands defined in `magit-extras.el`.  Digging in, it was the `defcustom` of `magit-gitk-executable` causing the problem.  It might be something unusual in my setup (which I'm not in front of right now), but the `which` was not finding `gitk.exe`, and a `nil` was getting through to `file-executable-p`, about which it complained.

This PR puts in a check for `nil`, which avoids the error and so fixes things for me.