### PR TITLE
Turn off display-line-numbers-mode if on

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -546,6 +546,9 @@ Magit is documented in info node `(magit)'."
   (when (and (fboundp 'nlinum-mode)
              (bound-and-true-p global-nlinum-mode))
     (nlinum-mode -1))
+  (when (and (fboundp 'display-line-numbers-mode)
+             (bound-and-true-p global-display-line-numbers-mode))
+    (display-line-numbers-mode -1))
   (add-hook 'kill-buffer-hook 'magit-preserve-section-visibility-cache))
 
 (defvar-local magit-region-overlays nil)


### PR DESCRIPTION
`magit-mode` turns off `linum-mode` and `nlinum-mode` if they are on; in emacs 26 we now have `display-line-numbers-mode`, which should get the same treatment.