### PR TITLE
magit-get-previous-branch: Add timeout

### DIFF
--- a/Documentation/RelNotes/2.13.0.txt
+++ b/Documentation/RelNotes/2.13.0.txt
@@ -44,6 +44,9 @@ Changes since v2.12.0
 
 * Added new command `magit-worktree-checkout-pull-request'.  a3d788ec
 
+* New variable `magit-get-previous-branch-timeout' limits the amount
+  of time spent in `magit-get-previous-branch'.  #3457
+
 Fixes since v2.12.0
 -------------------
 


### PR DESCRIPTION
Fixes #3457.

I somewhat arbitrarily chose 0.5 seconds as the default timeout.

By the way, I'm not sure exactly how I got my repo into a state where `magit-get-previous-branch` can take a long time (I still have it in that state currently though). I tried a test script which creates and deletes many branches, but that doesn't seem to do the trick.