### PR TITLE
Fix unquoted apostrophe in code sample

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -114,7 +114,7 @@ instead of every time Ido is invoked, so now you can modify it
 like pretty much every other keymap:
 
   (define-key ido-common-completion-map
-    (kbd \"C-x g\") 'ido-enter-magit-status)"
+    (kbd \"C-x g\") \\='ido-enter-magit-status)"
   (interactive)
   (with-no-warnings ; FIXME these are internal variables
     (setq ido-exit 'fallback fallback 'magit-status))


### PR DESCRIPTION
The change fixes the documentation string of ido-enter-magit-status, where 
an apostrophe in a code sample is written as-is, which renders it as 
RIGHT SINGLE QUOTATION MARK in the Help buffer (making the code
snippet invalid).


No need to update the manual.
