### PR TITLE
magit-dired-jump: Don't append slash to directory

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -126,12 +126,11 @@ like pretty much every other keymap:
 With a prefix argument, visit in another window.  If there
 is no file at point, then instead visit `default-directory'."
   (interactive "P")
-  (dired-jump other-window (if-let (file (magit-file-at-point))
-                               (progn (setq file (expand-file-name file))
-                                      (if (file-directory-p file)
-                                          (concat file "/.")
-                                        file))
-                             (concat default-directory "/."))))
+  (dired-jump other-window
+              (when-let (file (magit-file-at-point))
+                (expand-file-name (if (file-directory-p file)
+                                      (file-name-as-directory file)
+                                    file)))))
 
 ;;;###autoload
 (defun magit-dired-log (&optional follow)


### PR DESCRIPTION
1. `make emacs-Q`
2. <kbd>C-x</kbd><kbd>g</kbd>
3. <kbd>C-M-i</kbd>
   * Expected result: Pop to Dired buffer visiting Magit's directory.
   * Actual result: Pop to Dired buffer visiting parent of Magit's directory.

This is caused by `magit-dired-jump` appending `"/."` to directory names, which `dired-jump` expands to a file, rather than directory, name. A subsequent `file-name-directory` yields the parent, rather than current, directory.

Given that `dired-jump` defaults to `default-directory`, I think directory name manipulation can be removed from `magit-dired-jump` altogether, as in the proposed patch.