### PR TITLE
completion: Update for latest helm/ivy changes

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -439,9 +439,10 @@ acts similarly to `completing-read', except for the following:
     (setq choices (magit--completion-table choices)))
   (cl-letf (((symbol-function 'completion-pcm--all-completions)
              #'magit-completion-pcm--all-completions))
-    (completing-read prompt choices
-                     predicate require-match
-                     initial-input hist def)))
+    (let ((ivy-sort-functions-alist nil))
+      (completing-read prompt choices
+                       predicate require-match
+                       initial-input hist def))))
 
 (defvar helm-completion-in-region-default-sort-fn)
 

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -433,13 +433,13 @@ acts similarly to `completing-read', except for the following:
 (defun magit-builtin-completing-read
   (prompt choices &optional predicate require-match initial-input hist def)
   "Magit wrapper for standard `completing-read' function."
+  (unless (or (bound-and-true-p helm-mode)
+              (bound-and-true-p ivy-mode))
+    (setq prompt (magit-prompt-with-default prompt def))
+    (setq choices (magit--completion-table choices)))
   (cl-letf (((symbol-function 'completion-pcm--all-completions)
              #'magit-completion-pcm--all-completions))
-    (completing-read (if (or (bound-and-true-p helm-mode)
-                             (bound-and-true-p ivy-mode))
-                         prompt
-                       (magit-prompt-with-default prompt def))
-                     (magit--completion-table choices)
+    (completing-read prompt choices
                      predicate require-match
                      initial-input hist def)))
 

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -68,8 +68,10 @@ less well behaved than the former, more modern alternatives.
 
 If you would like to use Ivy or Helm completion with Magit but
 not enable the respective modes globally, then customize this
-option to use `ivy-completing-read'
-or `helm--completing-read-default'."
+option to use `ivy-completing-read' or
+`helm--completing-read-default'.  If you choose to use
+`ivy-completing-read', note that the items may always be shown in
+alphabetical order, depending on your version of Ivy."
   :group 'magit-essentials
   :type '(radio (function-item magit-builtin-completing-read)
                 (function-item magit-ido-completing-read)


### PR DESCRIPTION

  * Helm now handlers completion functions differently.  We need to account for that in order to get fuzzy matching.  #3476 

  * Ivy now sorts alphabetically by default.  Whether this commit (or some other fix) needs to be included depends on the outcome of abo-abo/swiper#1611