### PR TITLE
magit-apply-el: Add hooks for staging and unstaging.

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3706,6 +3706,16 @@ You can also use Ediff to stage and unstage.  See [[*Ediffing]].
   and defaults to the commit at point.  If there is no commit at
   point, then it defaults to ~HEAD~.
 
+- User Option: magit-post-stage-hook
+
+  Hook run after staging commands.
+  Hook functions will be called with a list of all currently staged files.
+
+- User Option: magit-post-unstage-hook
+
+  Hook run after unstaging commands.
+  Hook functions will be called with a list of all currently unstaged files.
+
 *** Staging from File-Visiting Buffers
 
 Fine-grained un-/staging has to be done from the status or a diff

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3706,12 +3706,12 @@ You can also use Ediff to stage and unstage.  See [[*Ediffing]].
   and defaults to the commit at point.  If there is no commit at
   point, then it defaults to ~HEAD~.
 
-- User Option: magit-post-stage-hook
+- User Option: magit-post-stage-functions
 
   Hook run after staging commands.
   Hook functions will be called with a list of all currently staged files.
 
-- User Option: magit-post-unstage-hook
+- User Option: magit-post-unstage-functions
 
   Hook run after unstaging commands.
   Hook functions will be called with a list of all currently unstaged files.

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -271,7 +271,10 @@ requiring confirmation."
                                       nil t nil nil default)
              default))))
   (magit-with-toplevel
-    (magit-stage-1 nil (list file))))
+    (magit-stage-1 nil (list file))
+    (when magit-post-stage-functions
+      (let ((staged-files (magit-staged-files)))
+        (run-hook-with-args 'magit-post-stage-functions staged-files)))))
 
 ;;;###autoload
 (defun magit-stage-modified (&optional all)
@@ -284,7 +287,10 @@ ignored) files."
   (when (magit-anything-staged-p)
     (magit-confirm 'stage-all-changes))
   (magit-with-toplevel
-    (magit-stage-1 (if all "--all" "-u"))))
+    (magit-stage-1 (if all "--all" "-u"))
+    (when magit-post-stage-functions
+      (let ((staged-files (magit-staged-files)))
+        (run-hook-with-args 'magit-post-stage-functions staged-files)))))
 
 (defun magit-stage-1 (arg &optional files)
   (magit-wip-commit-before-change files " before stage")
@@ -386,7 +392,10 @@ without requiring confirmation."
                                       nil t nil nil default)
              default))))
   (magit-with-toplevel
-    (magit-unstage-1 (list file))))
+    (magit-unstage-1 (list file))
+    (when magit-post-unstage-functions
+      (let ((unstaged-files (magit-unstaged-files)))
+        (run-hook-with-args 'magit-post-unstage-functions unstaged-files)))))
 
 (defun magit-unstage-1 (files)
   (magit-wip-commit-before-change files " before unstage")
@@ -404,7 +413,11 @@ without requiring confirmation."
     (magit-confirm 'unstage-all-changes))
   (magit-wip-commit-before-change nil " before unstage")
   (magit-run-git "reset" "HEAD" "--")
-  (magit-wip-commit-after-apply nil " after unstage"))
+  (magit-wip-commit-after-apply nil " after unstage")
+  (when magit-post-unstage-functions
+    (magit-with-toplevel
+      (let ((unstaged-files (magit-unstaged-files)))
+        (run-hook-with-args 'magit-post-unstage-functions unstaged-files)))) )
 
 ;;;; Discard
 

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -91,14 +91,14 @@ rejected reversals."
   :group 'magit-commands
   :type 'boolean)
 
-(defcustom magit-post-stage-hook nil
+(defcustom magit-post-stage-functions nil
   "Hook run after staging commands.
 Hook functions will be called with a list of all currently staged files."
   :package-version '(magit . "2.13.0")
   :group 'magit-commands
   :type 'hook)
 
-(defcustom magit-post-unstage-hook nil
+(defcustom magit-post-unstage-functions nil
   "Hook run after unstaging commands.
 Hook functions will be called with a list of all currently unstaged files."
   :package-version '(magit . "2.13.0")
@@ -251,7 +251,7 @@ at point, stage the file but not its content."
     (call-interactively 'magit-stage-file))
   (magit-with-toplevel
     (let ((staged-files (magit-staged-files)))
-      (run-hook-with-args 'magit-post-stage-hook staged-files))))
+      (run-hook-with-args 'magit-post-stage-functions staged-files))))
 
 ;;;###autoload
 (defun magit-stage-file (file)
@@ -366,7 +366,7 @@ ignored) files."
       (`(undefined     ,_  ,_) (user-error "Cannot unstage this change")))
     (magit-with-toplevel
       (let ((unstaged-files (magit-unstaged-files)))
-        (run-hook-with-args 'magit-post-unstage-hook unstaged-files)))))
+        (run-hook-with-args 'magit-post-unstage-functions unstaged-files)))))
 
 ;;;###autoload
 (defun magit-unstage-file (file)

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -249,9 +249,10 @@ at point, stage the file but not its content."
         (`(committed     ,_  ,_) (user-error "Cannot stage committed changes"))
         (`(undefined     ,_  ,_) (user-error "Cannot stage this change")))
     (call-interactively 'magit-stage-file))
-  (magit-with-toplevel
-    (let ((staged-files (magit-staged-files)))
-      (run-hook-with-args 'magit-post-stage-functions staged-files))))
+  (when magit-post-stage-functions
+    (magit-with-toplevel
+      (let ((staged-files (magit-staged-files)))
+        (run-hook-with-args 'magit-post-stage-functions staged-files)))))
 
 ;;;###autoload
 (defun magit-stage-file (file)
@@ -364,9 +365,10 @@ ignored) files."
                                    (magit-reverse-in-index)
                                  (user-error "Cannot unstage committed changes")))
       (`(undefined     ,_  ,_) (user-error "Cannot unstage this change")))
-    (magit-with-toplevel
-      (let ((unstaged-files (magit-unstaged-files)))
-        (run-hook-with-args 'magit-post-unstage-functions unstaged-files)))))
+    (when magit-post-unstage-functions
+      (magit-with-toplevel
+        (let ((unstaged-files (magit-unstaged-files)))
+          (run-hook-with-args 'magit-post-unstage-functions unstaged-files))))))
 
 ;;;###autoload
 (defun magit-unstage-file (file)

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -91,6 +91,20 @@ rejected reversals."
   :group 'magit-commands
   :type 'boolean)
 
+(defcustom magit-post-stage-hook nil
+  "Hook run after staging commands.
+Hook functions will be called with a list of all currently staged files."
+  :package-version '(magit . "2.13.0")
+  :group 'magit-commands
+  :type 'hook)
+
+(defcustom magit-post-unstage-hook nil
+  "Hook run after unstaging commands.
+Hook functions will be called with a list of all currently unstaged files."
+  :package-version '(magit . "2.13.0")
+  :group 'magit-commands
+  :type 'hook)
+
 ;;; Commands
 ;;;; Apply
 
@@ -234,7 +248,10 @@ at point, stage the file but not its content."
         (`(staged        ,_  ,_) (user-error "Already staged"))
         (`(committed     ,_  ,_) (user-error "Cannot stage committed changes"))
         (`(undefined     ,_  ,_) (user-error "Cannot stage this change")))
-    (call-interactively 'magit-stage-file)))
+    (call-interactively 'magit-stage-file))
+  (magit-with-toplevel
+    (let ((staged-files (magit-staged-files)))
+      (run-hook-with-args 'magit-post-stage-hook staged-files))))
 
 ;;;###autoload
 (defun magit-stage-file (file)
@@ -346,7 +363,10 @@ ignored) files."
       (`(committed     ,_  ,_) (if magit-unstage-committed
                                    (magit-reverse-in-index)
                                  (user-error "Cannot unstage committed changes")))
-      (`(undefined     ,_  ,_) (user-error "Cannot unstage this change")))))
+      (`(undefined     ,_  ,_) (user-error "Cannot unstage this change")))
+    (magit-with-toplevel
+      (let ((unstaged-files (magit-unstaged-files)))
+        (run-hook-with-args 'magit-post-unstage-hook unstaged-files)))))
 
 ;;;###autoload
 (defun magit-unstage-file (file)


### PR DESCRIPTION
As discussed in https://github.com/magit/magit/issues/3496#issuecomment-401170175 I have implemented a hook for staging commands.

I went with the option of passing the list of (un)staged files to the hooks because that is what I think such a hook will most likely need anyway. If you don't like the performance implications of that choice I am fine with running the hooks without that information.