### PR TITLE
[wip] magit-explain-section

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1449,7 +1449,7 @@ Type \\[magit-cherry-pick-popup] to apply the commit at point.
 
 (defun magit-cherry-refresh-buffer (_upstream _head)
   (magit-insert-section (cherry)
-    (run-hooks 'magit-cherry-sections-hook)))
+    (magit-run-section-hook 'magit-cherry-sections-hook)))
 
 (defun magit-insert-cherry-headers ()
   "Insert headers appropriate for `magit-cherry-mode' buffers."

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -599,7 +599,7 @@ locked to its value, which is derived from MODE and ARGS."
       (funcall mode))
     (magit-display-buffer buffer)
     (with-current-buffer buffer
-      (run-hooks 'magit-mode-setup-hook) ; run-mode-hooks?
+      (run-hooks 'magit-mode-setup-hook)
       (magit-refresh-buffer))))
 
 (defvar magit-display-buffer-noselect nil

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -599,7 +599,7 @@ locked to its value, which is derived from MODE and ARGS."
       (funcall mode))
     (magit-display-buffer buffer)
     (with-current-buffer buffer
-      (run-hooks 'magit-mode-setup-hook)
+      (run-hooks 'magit-mode-setup-hook) ; run-mode-hooks?
       (magit-refresh-buffer))))
 
 (defvar magit-display-buffer-noselect nil

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -308,7 +308,7 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
   (magit-set-header-line-format
    (format "%s %s" ref (mapconcat #'identity args " ")))
   (magit-insert-section (branchbuf)
-    (run-hooks 'magit-refs-sections-hook))
+    (magit-run-section-hook 'magit-refs-sections-hook))
   (add-hook 'kill-buffer-hook 'magit-preserve-section-visibility-cache))
 
 ;;; Commands

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -603,16 +603,23 @@ Sections at higher levels are hidden."
 
 ;;;; Auxiliary
 
-(defun magit-describe-section ()
+(defun magit-describe-section (section &optional message)
   "Show information about the section at point.
 This command is intended for debugging purposes."
-  (interactive)
-  (let ((section (magit-current-section)))
-    (message "%S %S %s-%s"
-             (oref section value)
-             (magit-section-lineage section)
-             (marker-position (oref section start))
-             (marker-position (oref section end)))))
+  (interactive (list (magit-current-section) t))
+  (let ((str (format "#<magit-section %S %S %s-%s>"
+                     (oref section value)
+                     (magit-section-lineage section)
+                     (if-let (m (oref section start))
+                         (marker-position m))
+                     (if-let (m (oref section end))
+                         (marker-position m)))))
+    (if message (message "%s" str) str)))
+
+(defmethod cl-print-object ((section magit-section) stream)
+  "Print `magit-describe-section' result of SECTION."
+  ;; Used by debug and edebug as of Emacs 26.
+  (princ (magit-describe-section section) stream))
 
 ;;; Match
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -933,19 +933,15 @@ insert a newline character if necessary."
           (cons (lambda ()
                   (push magit-insert-section--current
                         header-sections))
-               (if (listp magit-insert-section-hook)
-                   magit-insert-section-hook
-                 (list magit-insert-section-hook)))))
+                (if (listp magit-insert-section-hook)
+                    magit-insert-section-hook
+                  (list magit-insert-section-hook)))))
     (magit-run-section-hook hook)
     (when header-sections
       ;; Make the first header into the parent of the rest.
       (cl-callf nreverse header-sections)
       (let* ((1st-header (pop header-sections))
              (header-parent (oref 1st-header parent)))
-        ;; Can we just assume the header sections are the only
-        ;; sections, and then we don't need the collector function in
-        ;; `magit-insert-section-hook' at all?
-        (cl-assert (equal (oref header-parent children) (cons 1st-header header-sections)))
         (oset header-parent children (list 1st-header))
         (oset 1st-header children header-sections)
         (oset 1st-header content (oref (car header-sections) start))

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -888,29 +888,33 @@ insert a newline character if necessary."
   (magit-maybe-make-margin-overlay)
   (oset magit-insert-section--current content (point-marker)))
 
-(defvar magit-insert-headers--hook nil "For internal use only.")
-(defvar magit-insert-headers--beginning nil "For internal use only.")
-
 (defun magit-insert-headers (hooks)
-  (let ((magit-insert-section-hook
-         (cons 'magit-insert-remaining-headers
+  (let* ((header-sections nil)
+         (magit-insert-section-hook
+          (cons (lambda ()
+                  (push magit-insert-section--current
+                        header-sections))
                (if (listp magit-insert-section-hook)
                    magit-insert-section-hook
-                 (list magit-insert-section-hook))))
-        (magit-insert-headers--hook hooks)
-        wrapper)
-    (setq magit-insert-headers--beginning (point))
-    (while (and (setq wrapper (pop magit-insert-headers--hook))
-                (= (point) magit-insert-headers--beginning))
-      (funcall wrapper))))
-
-(defun magit-insert-remaining-headers ()
-  (if (= (point) magit-insert-headers--beginning)
-      (magit-cancel-section)
-    (magit-insert-heading)
-    (remove-hook 'magit-insert-section-hook 'magit-insert-remaining-headers)
-    (mapc #'funcall magit-insert-headers--hook)
-    (insert "\n")))
+                 (list magit-insert-section-hook)))))
+    (cl-assert (eq hooks magit-status-headers-hook)) ; TODO: take symbol instead of value
+    (mapc #'funcall hooks)
+    (when header-sections
+      ;; Make the first header into the parent of the rest.
+      (cl-callf nreverse header-sections)
+      (let* ((1st-header (pop header-sections))
+             (header-parent (oref 1st-header parent)))
+        ;; Can we just assume the header sections are the only
+        ;; sections, and then we don't need the collector function in
+        ;; `magit-insert-section-hook' at all?
+        (cl-assert (equal (oref header-parent children) (cons 1st-header header-sections)))
+        (oset header-parent children (list 1st-header))
+        (oset 1st-header children header-sections)
+        (oset 1st-header content (oref (car header-sections) start))
+        (oset 1st-header end (oref (car (last header-sections)) end))
+        (dolist (sub-header header-sections)
+          (oset sub-header parent 1st-header))
+        (insert "\n")))))
 
 (defun magit-insert-child-count (section)
   "Modify SECTION's heading to contain number of child sections.

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -607,7 +607,7 @@ Sections at higher levels are hidden."
 
 ;;;; Auxiliary
 
-(defun magit-describe-section (section &optional message)
+(defun magit-describe-section-briefly (section &optional message)
   "Show information about the section at point.
 This command is intended for debugging purposes."
   (interactive (list (magit-current-section) t))
@@ -623,9 +623,9 @@ This command is intended for debugging purposes."
 (defmethod cl-print-object ((section magit-section) stream)
   "Print `magit-describe-section' result of SECTION."
   ;; Used by debug and edebug as of Emacs 26.
-  (princ (magit-describe-section section) stream))
+  (princ (magit-describe-section-briefly section) stream))
 
-(defun magit-explain-section (section &optional interactive-p)
+(defun magit-describe-section (section &optional interactive-p)
   "Show information about the section at point."
   (interactive (list (magit-current-section) t))
   (let ((src-section section))

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -179,8 +179,7 @@ but in the future it will also be used set the defaults."
   "Internal variable used for `magit-explain-section'.")
 
 (defclass magit-section ()
-  ((source   :initform (symbol-value 'magit--current-section-hook))
-   (type     :initform nil :initarg :type)
+  ((type     :initform nil :initarg :type)
    (value    :initform nil :initarg :value)
    (start    :initform nil :initarg :start)
    (content  :initform nil)
@@ -188,6 +187,7 @@ but in the future it will also be used set the defaults."
    (hidden   :initform nil)
    (washer   :initform nil)
    (process  :initform nil)
+   (inserter :initform (symbol-value 'magit--current-section-hook))
    (parent   :initform nil :initarg :parent)
    (children :initform nil)))
 
@@ -628,12 +628,12 @@ This command is intended for debugging purposes."
 (defun magit-describe-section (section &optional interactive-p)
   "Show information about the section at point."
   (interactive (list (magit-current-section) t))
-  (let ((src-section section))
-    (while (and src-section (not (oref src-section source)))
-      (setq src-section (oref src-section parent)))
-    (when (oref src-section source)
-      (setq section src-section)))
-  (pcase (oref section source)
+  (let ((inserter-section section))
+    (while (and inserter-section (not (oref inserter-section inserter)))
+      (setq inserter-section (oref inserter-section parent)))
+    (when (oref inserter-section inserter)
+      (setq section inserter-section)))
+  (pcase (oref section inserter)
     (`((,hook ,fun) . ,src-src)
      (help-setup-xref `(magit-explain-section ,section) interactive-p)
      (with-help-window (help-buffer)
@@ -654,7 +654,7 @@ This command is intended for debugging purposes."
          (insert ".\n\n"
                  (or (cdr (help-split-fundoc (documentation fun) fun))
                      (documentation fun))))))
-    (_ (message "section type: `%S', source unknown"
+    (_ (message "section type: `%S', inserter unknown"
                 (oref section type)))))
 
 ;;; Match

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -631,7 +631,7 @@ This command is intended for debugging purposes."
   (let ((inserter-section section))
     (while (and inserter-section (not (oref inserter-section inserter)))
       (setq inserter-section (oref inserter-section parent)))
-    (when (oref inserter-section inserter)
+    (when (and inserter-section (oref inserter-section inserter))
       (setq section inserter-section)))
   (pcase (oref section inserter)
     (`((,hook ,fun) . ,src-src)
@@ -641,19 +641,27 @@ This command is intended for debugging purposes."
          (insert (format-message
                   "The current section is inserted by `%s' from `%s'"
                   (make-text-button (symbol-name fun) nil
-                                    :type 'help-function 'help-args (list fun))
+                                    :type 'help-function
+                                    'help-args (list fun))
                   (make-text-button (symbol-name hook) nil
-                                    :type 'help-variable 'help-args (list hook))))
+                                    :type 'help-variable
+                                    'help-args (list hook))))
          (pcase-dolist (`(,hook ,fun) src-src)
            (insert (format-message
                     ",\n  called by `%s' from `%s'"
                     (make-text-button (symbol-name fun) nil
-                                      :type 'help-function 'help-args (list fun))
+                                      :type 'help-function
+                                      'help-args (list fun))
                     (make-text-button (symbol-name hook) nil
-                                      :type 'help-variable 'help-args (list hook)))))
-         (insert ".\n\n"
-                 (or (cdr (help-split-fundoc (documentation fun) fun))
-                     (documentation fun))))))
+                                      :type 'help-variable
+                                      'help-args (list hook)))))
+         (insert ".\n\n")
+         (insert
+          (format-message
+           "`%s' is "
+           (make-text-button (symbol-name fun) nil
+                             :type 'help-function 'help-args (list fun))))
+         (describe-function-1 fun))))
     (_ (message "section type: `%S', inserter unknown"
                 (oref section type)))))
 
@@ -1352,8 +1360,6 @@ again use `remove-hook'."
     (if local
         (set hook value)
       (set-default hook value))))
-
-(defvar magit--current-section-hook)
 
 (defun magit-run-section-hook (hook)
   "Run HOOK, warning about invalid entries."

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -441,7 +441,7 @@ instead of \"Stashes:\"."
            (magit-rev-format "%s" stash)))
   (setq magit-buffer-revision-hash (magit-rev-parse stash))
   (magit-insert-section (stash)
-    (run-hooks 'magit-stash-sections-hook)))
+    (magit-run-section-hook 'magit-stash-sections-hook)))
 
 (defun magit-stash-insert-section (commit range message &optional files)
   (magit-insert-section (commit commit)

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -317,7 +317,7 @@ If there is no blob buffer in the same frame, then do nothing."
 The sections are inserted by running the functions on the hook
 `magit-status-headers-hook'."
   (if (magit-rev-verify "HEAD")
-      (magit-insert-headers magit-status-headers-hook)
+      (magit-insert-headers 'magit-status-headers-hook)
     (insert "In the beginning there was darkness\n\n")))
 
 (defvar magit-error-section-map


### PR DESCRIPTION
This is my initial attempt at #3308. It seems to work okay, though the insertion function docstrings are not written with this exact use case in mind, so the `*Help*` screen reads a bit awkward.

I wasn't sure whether we should take over the `magit-describe-section` name from the current command, so I've called the new command `magit-explain-section` for now. I haven't added a keybinding yet, though I was thinking perhaps <kbd>? ?</kbd>.

I have a couple question in the code, which I'll call out through inline comments on the PR.

Any comments in general are welcome of course.
