### PR TITLE
git-commit-setup-font-lock: Don't fail in non-existent directory

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -421,7 +421,9 @@ This is only used if Magit is available."
   ;; cygwin git will pass a cygwin path (/cygdrive/c/foo/.git/...),
   ;; try to handle this in window-nt Emacs.
   (--when-let
-      (and (string-match-p git-commit-filename-regexp buffer-file-name)
+      (and (or (string-match-p git-commit-filename-regexp buffer-file-name)
+               (if (boundp 'git-rebase-filename-regexp)
+                   (string-match-p git-rebase-filename-regexp buffer-file-name)))
            (not (file-accessible-directory-p
                  (file-name-directory buffer-file-name)))
            (if (require 'magit-git nil t)

--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -792,7 +792,11 @@ Added to `font-lock-extend-region-functions'."
   (setq-local comment-end-skip "\n")
   (setq-local comment-use-syntax nil)
   (setq-local git-commit--branch-name-regexp
-              (if (featurep 'magit-git)
+              (if (and (featurep 'magit-git)
+                       ;; When using cygwin git, we may end up in a
+                       ;; non-existing directory, which would cause
+                       ;; any git calls to signal an error.
+                       (file-accessible-directory-p default-directory))
                   (progn
                     ;; Make sure the below functions are available.
                     (require 'magit)


### PR DESCRIPTION
Should fix #3491. I think we should additionally move the cygwin filename hack from `git-commit-setup` to `find-file-not-found-functions`, but I want to make sure just the `git-commit-setup-font-lock` change on its own will fix the original problem.