### PR TITLE
add --gpg-sign to all popups where it can be correctly used

### DIFF
--- a/lisp/magit-merge.el
+++ b/lisp/magit-merge.el
@@ -37,7 +37,8 @@
   :man-page "git-merge"
   :switches '((?f "Fast-forward only" "--ff-only")
               (?n "No fast-forward"   "--no-ff"))
-  :options  '((?s "Strategy" "--strategy="))
+  :options  '((?s "Strategy"       "--strategy=")
+              (?S "Sign using gpg" "--gpg-sign=" magit-read-gpg-secret-key))
   :actions  '((?m "Merge"                  magit-merge)
               (?p "Preview merge"          magit-merge-preview)
               (?e "Merge and edit message" magit-merge-editmsg) nil

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -564,6 +564,7 @@ prefix argument fetch all remotes."
                    magit-cycle-branch*rebase
                    magit-pull-format-branch*rebase)
                (?C "variables..." magit-branch-config-popup))
+  :options '((?S "Sign using gpg" "--gpg-sign=" magit-read-gpg-secret-key))
   :actions '((lambda ()
                (--if-let (magit-get-current-branch)
                    (concat

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -125,7 +125,9 @@ This discards all changes made since the sequence started."
               (?x "Reference cherry in commit message" "-x")
               (?F "Attempt fast-forward"               "--ff"))
   :options  '((?s "Strategy"                        "--strategy=")
-              (?m "Replay merge relative to parent" "--mainline="))
+              (?m "Replay merge relative to parent" "--mainline=")
+              (?S "Sign using gpg"                  "--gpg-sign="
+                  magit-read-gpg-secret-key))
   :actions  '("Apply here"
               (?A "Pick"    magit-cherry-pick)
               (?a "Apply"   magit-cherry-apply)
@@ -381,7 +383,9 @@ without prompting."
                   "--committer-date-is-author-date")
               (?D "Use committer date as author date" "--ignore-date"))
   :options  '((?p "Remove leading slashes from paths" "-p"
-                  magit-popup-read-number))
+                  magit-popup-read-number)
+              (?S "Sign using gpg"                    "--gpg-sign="
+                  magit-read-gpg-secret-key))
   :actions  '((?m "Apply maildir"     magit-am-apply-maildir)
               (?w "Apply patches"     magit-am-apply-patches)
               (?a "Apply plain patch" magit-patch-apply-popup))
@@ -460,6 +464,7 @@ This discards all changes made since the sequence started."
               (?A "Autostash"                "--autostash")
               (?i "Interactive"              "--interactive")
               (?h "Disable hooks"            "--no-verify"))
+  :options  '((?S "Sign using gpg" "--gpg-sign=" magit-read-gpg-secret-key))
   :actions  '((lambda ()
                 (concat (propertize "Rebase " 'face 'magit-popup-heading)
                         (propertize (or (magit-get-current-branch) "HEAD")


### PR DESCRIPTION
Currently the only popup where --gpg-sign is present is the commit popup. This adds --gpg-sign to all relevant popups, which are merge, pull, cherry-pick, am, and rebase.