### PR TITLE
 Change order and initial visibility of logs in status buffer

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1554,7 +1554,7 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
 (defun magit-insert-unpulled-from-upstream ()
   "Insert commits that haven't been pulled from the upstream yet."
   (when (magit-git-success "rev-parse" "@{upstream}")
-    (magit-insert-section (unpulled "..@{upstream}")
+    (magit-insert-section (unpulled "..@{upstream}" t)
       (magit-insert-heading
         (format (propertize "Unpulled from %s:" 'face 'magit-section-heading)
                 (magit-get-upstream-branch)))
@@ -1573,7 +1573,7 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
                            magit-status-sections-hook)
                      (memq 'magit-insert-unpulled-from-upstream-or-recent
                            magit-status-sections-hook)))
-      (magit-insert-section (unpulled (concat ".." it))
+      (magit-insert-section (unpulled (concat ".." it) t)
         (magit-insert-heading
           (format (propertize "Unpulled from %s:" 'face 'magit-section-heading)
                   (propertize it 'face 'magit-branch-remote)))
@@ -1604,7 +1604,7 @@ then show the last `magit-log-section-commit-count' commits."
 (defun magit-insert-unpushed-to-upstream ()
   "Insert commits that haven't been pushed to the upstream yet."
   (when (magit-git-success "rev-parse" "@{upstream}")
-    (magit-insert-section (unpushed "@{upstream}.." t)
+    (magit-insert-section (unpushed "@{upstream}..")
       (magit-insert-heading
         (format (propertize "Unmerged into %s:" 'face 'magit-section-heading)
                 (magit-get-upstream-branch)))
@@ -1617,7 +1617,8 @@ Show the last `magit-log-section-commit-count' commits."
          (range (and (magit-rev-verify start)
                      (concat start "..HEAD"))))
     (magit-insert-section ((eval (or type 'recent))
-                           (or value range))
+                           (or value range)
+                           t)
       (magit-insert-heading "Recent commits")
       (magit-insert-log range
                         (cons (format "-n%d" magit-log-section-commit-count)
@@ -1637,7 +1638,7 @@ Show the last `magit-log-section-commit-count' commits."
                            magit-status-sections-hook)
                      (memq 'magit-insert-unpushed-to-upstream-or-recent
                            magit-status-sections-hook)))
-      (magit-insert-section (unpushed (concat it ".."))
+      (magit-insert-section (unpushed (concat it "..") t)
         (magit-insert-heading
           (format (propertize "Unpushed to %s:" 'face 'magit-section-heading)
                   (propertize it 'face 'magit-branch-remote)))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1598,40 +1598,26 @@ then show the last `magit-log-section-commit-count' commits."
   (let ((upstream (magit-rev-parse "@{upstream}")))
     (if (or (not upstream)
             (magit-rev-ancestor-p "HEAD" upstream))
-        (magit-insert-recent-commits
-         (--if-let (and magit-insert-section--oldroot
-                        (magit-get-section
-                         '((unpushed . "@{upstream}..")
-                           (status))
-                         magit-insert-section--oldroot))
-             (oref it hidden)
-           nil))
-      (magit-insert-unpushed-to-upstream
-       (--if-let (and magit-insert-section--oldroot
-                      (magit-get-section
-                       `((recent . ,(format "HEAD~%s..HEAD"
-                                            magit-log-section-commit-count))
-                         (status))
-                       magit-insert-section--oldroot))
-           (oref it hidden)
-         t)))))
+        (magit-insert-recent-commits 'unpushed "@{upstream}..")
+      (magit-insert-unpushed-to-upstream))))
 
-(defun magit-insert-unpushed-to-upstream (&optional collapse)
+(defun magit-insert-unpushed-to-upstream ()
   "Insert commits that haven't been pushed to the upstream yet."
   (when (magit-git-success "rev-parse" "@{upstream}")
-    (magit-insert-section (unpushed "@{upstream}.." collapse)
+    (magit-insert-section (unpushed "@{upstream}.." t)
       (magit-insert-heading
         (format (propertize "Unmerged into %s:" 'face 'magit-section-heading)
                 (magit-get-upstream-branch)))
       (magit-insert-log "@{upstream}.." magit-log-section-arguments))))
 
-(defun magit-insert-recent-commits (&optional collapse)
+(defun magit-insert-recent-commits (&optional type value)
   "Insert section showing recent commits.
 Show the last `magit-log-section-commit-count' commits."
   (let* ((start (format "HEAD~%s" magit-log-section-commit-count))
          (range (and (magit-rev-verify start)
                      (concat start "..HEAD"))))
-    (magit-insert-section (recent range collapse)
+    (magit-insert-section ((eval (or type 'recent))
+                           (or value range))
       (magit-insert-heading "Recent commits")
       (magit-insert-log range
                         (cons (format "-n%d" magit-log-section-commit-count)

--- a/lisp/magit-merge.el
+++ b/lisp/magit-merge.el
@@ -103,8 +103,12 @@ that the respective pull-request (if any) won't get stuck on some
 obsolete version of the commits that are being merged.  Finally
 if `magit-branch-pull-request' was used to create the merged
 branch, then also remove the respective remote branch."
-  (interactive (list (magit-read-other-branch
-                      (format "Merge `%s' into" (magit-get-current-branch)))
+  (interactive (list (magit-read-other-local-branch
+                      (format "Merge `%s' into" (magit-get-current-branch))
+                      nil
+                      (let ((branch (cdr (magit-split-branch-name
+                                          (magit-get-upstream-branch)))))
+                        (and (magit-branch-p branch) branch)))
                      (magit-merge-arguments)))
   (let ((current (magit-get-current-branch)))
     (when (zerop (magit-call-git "checkout" branch))

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -437,6 +437,7 @@ starts complicating other things, then it will be removed."
     (define-key map "Z" 'magit-stash-popup)
     (define-key map ":" 'magit-git-command)
     (define-key map "!" 'magit-run-popup)
+    (define-key map (kbd "C-c C-b") 'magit-browse-thing)
     (define-key map (kbd "C-c C-c") 'magit-dispatch-popup)
     (define-key map (kbd "C-c C-e") 'magit-dispatch-popup)
     (define-key map (kbd "C-x a")   'magit-add-change-log-entry)
@@ -464,6 +465,13 @@ which visits the thing at point."
       (progn (setq magit-current-popup nil)
              (call-interactively (key-binding (this-command-keys))))
     (user-error "There is no thing at point that could be visited")))
+
+(defun magit-browse-thing ()
+  "This is a placeholder command.
+Where applicable, section-specific keymaps bind another command
+which visits the thing at point using `browse-url'."
+  (interactive)
+  (user-error "There is no thing at point that could be browsed"))
 
 (easy-menu-define magit-mode-menu magit-mode-map
   "Magit menu"

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -82,10 +82,10 @@ all."
     magit-insert-unstaged-changes
     magit-insert-staged-changes
     magit-insert-stashes
-    magit-insert-unpulled-from-upstream
-    magit-insert-unpulled-from-pushremote
+    magit-insert-unpushed-to-pushremote
     magit-insert-unpushed-to-upstream-or-recent
-    magit-insert-unpushed-to-pushremote)
+    magit-insert-unpulled-from-pushremote
+    magit-insert-unpulled-from-upstream)
   "Hook run to insert sections into a status buffer."
   :package-version '(magit . "2.12.0")
   :group 'magit-status

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -531,6 +531,14 @@ See info node `(magit)Debugging Tools' for more information."
 ;;; Startup Asserts
 
 (defun magit-startup-asserts ()
+  (when-let ((val (getenv "GIT_DIR")))
+    (setenv "GIT_DIR")
+    (message "Magit unset $GIT_DIR (was %S).  See \
+https://github.com/magit/magit/wiki/Don't-set-$GIT_DIR-and-alike" val))
+  (when-let ((val (getenv "GIT_WORK_TREE")))
+    (setenv "GIT_WORK_TREE")
+    (message "Magit unset $GIT_WORK_TREE (was %S).  See \
+https://github.com/magit/magit/wiki/Don't-set-$GIT_DIR-and-alike" val))
   (let ((version (magit-git-version)))
     (when (and version
                (version< version magit--minimal-git)


### PR DESCRIPTION
Please see the commit messages, give this a try, and then report on whether you like these changes or not.