### PR TITLE
Quote regexp-meaningful characters in function name

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -723,7 +723,7 @@ active, restrict the log to the lines that the region touches."
   (magit-mode-setup-internal
    #'magit-log-mode
    (list (list rev)
-         (cons (format "-L:%s:%s" fn file)
+         (cons (format "-L:%s:%s" (regexp-quote fn) file)
                (cl-delete "-L" (car (magit-log-arguments))
                           :test 'string-prefix-p))
          nil)


### PR DESCRIPTION
This addresses #3523; it resolves a bug in which `magit-log-trace-definition` doesn't work with Go methods on a pointer receiver (and in general, anything for which `which-function` returns a string containing a regular expression metacharacter: the issue is that git expects a regular expression).

I was a bit concerned that `regexp-quote` might not be suited to
escaping the regular expressions git expects, but it appears to do the
right thing: escaping `[*.\?+^$` but not `(`.
