### PR TITLE
Autodisplay process buffer, whenever output is added to it

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -243,12 +243,13 @@ Used when `magit-process-display-mode-line-error' is non-nil."
   (setq imenu-extract-index-name-function
         'magit-imenu--process-extract-index-name-function))
 
-(defun magit-process-buffer (&optional nodisplay)
+(defun magit-process-buffer (&optional nodisplay nocreate)
   "Display the current repository's process buffer.
 
-If that buffer doesn't exist yet, then create it.
-Non-interactively return the buffer and unless
-optional NODISPLAY is non-nil also display it."
+If that buffer doesn't exist yet, then create it, unless optional
+NOCREATE is non-nil.  Non-interactively return the buffer, or nil
+if it neither existed, nor was created and unless optional
+NODISPLAY is non-nil also display it."
   (interactive)
   (let ((topdir (magit-toplevel)))
     (unless topdir
@@ -262,22 +263,24 @@ optional NODISPLAY is non-nil also display it."
                                  (and (eq major-mode 'magit-process-mode)
                                       (equal default-directory topdir)))
                                (buffer-list))
-                      (let ((default-directory topdir))
-                        (magit-generate-new-buffer 'magit-process-mode)))))
-      (with-current-buffer buffer
-        (if magit-root-section
-            (when magit-process-log-max
-              (magit-process-truncate-log))
-          (magit-process-mode)
-          (let ((inhibit-read-only t)
-                (magit-insert-section--parent  nil)
-                (magit-insert-section--oldroot nil))
-            (make-local-variable 'text-property-default-nonsticky)
-            (magit-insert-section (processbuf)
-              (insert "\n")))))
-      (unless nodisplay
-        (magit-display-buffer buffer))
-      buffer)))
+                       (and (not nocreate)
+                            (let ((default-directory topdir))
+                              (magit-generate-new-buffer 'magit-process-mode))))))
+      (when buffer
+        (with-current-buffer buffer
+          (if magit-root-section
+              (when magit-process-log-max
+                (magit-process-truncate-log))
+            (magit-process-mode)
+            (let ((inhibit-read-only t)
+                  (magit-insert-section--parent  nil)
+                  (magit-insert-section--oldroot nil))
+              (make-local-variable 'text-property-default-nonsticky)
+              (magit-insert-section (processbuf)
+                (insert "\n")))))
+        (unless nodisplay
+          (magit-display-buffer buffer))
+        buffer))))
 
 (defun magit-process-kill ()
   "Kill the process at point."

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -204,6 +204,15 @@ non-nil, then the password is read from the user instead."
   :group 'magit-process
   :type 'boolean)
 
+(defcustom magit-process-display-automatically nil
+  "Whether Magit should automatically display the process buffer.
+
+If non-nil, show the process buffer automatically (without
+focusing it), whenever Git output is appended to it."
+  :package-version '(magit . "2.13.0")
+  :group 'magit-process
+  :type 'boolean)
+
 (defface magit-process-ok
   '((t :inherit magit-section-heading :foreground "green"))
   "Face for zero exit-status."
@@ -590,6 +599,10 @@ Magit status buffer."
                   (backward-char 1))))))
 
 (defun magit-process-insert-section (pwd program args &optional errcode errlog)
+  (when magit-process-display-automatically
+    (let ((magit-display-buffer-noselect t))
+      (magit-process-buffer)))
+
   (let ((inhibit-read-only t)
         (magit-insert-section--parent magit-root-section)
         (magit-insert-section--oldroot nil))

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -333,7 +333,9 @@ This function is only aware of the last error that occur when Git
 was run for side-effects.  If, for example, an error occurs while
 generating a diff, then that error won't be inserted.  Refreshing
 the status buffer causes this section to disappear again."
-  (when magit-this-error
+  (when (and magit-this-error
+             (not (let ((buffer (magit-process-buffer t t)))
+                    (and buffer (get-buffer-window buffer)))))
     (magit-insert-section (error 'git)
       (insert (propertize (format "%-10s" "GitError! ")
                           'face 'magit-section-heading))


### PR DESCRIPTION
This pull request introduces an option, named `magit-process-display-automatically`, which can be used to enable automatic display of the process buffer, whenever there's some Git output appended to it.  Perhaps my desire for such a feature, is due to the fact that I've only just switched to Magit, after using Git through the command line and am neither proficient enough with Magit to be able to tell that it's done what I wanted it to do, nor acquainted enough with it to blindly trust it and the need for it will soon go away.

Still, Git-related errors have the potential to inflict pain, so closely monitoring operations isn't necessarily bad and having this option isn't necessarily useless, hence this PR.

This feature also made the error header (alerting the user on a Git error and advising to type `$` to display the process buffer) redundant, so I disabled its insertion when the process buffer is already visible.  This seems to make sense regardless of process buffer autodisplay, so I've left it always on, without a configuration option.

Please feel free to merge any part of this PR you see fit (or none of it, of course) and to rewrite/reimplement parts of it as necessary (or request me to do so).  My Emacs lisp is of the pick-it-up-as-you-go variety and hence, in all probability, horrible.  Likewise, please excuse any glaring problems or deficiencies of the implementation, that I might have missed, due to my limited experience with both Magit and Emacs lisp.  All I can say is, that I've been using the functionality introduced in this PR for about a week, without discovering any issues.