### PR TITLE
Fix revision message placement in case of risky var query

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2010,9 +2010,10 @@ or a ref which is not a branch, then it inserts nothing."
   (magit-insert-section section (commit-message)
     (oset section heading-highlight-face 'magit-diff-hunk-heading-highlight)
     (let ((beg (point)))
-      (insert (with-temp-buffer
-                (magit-rev-insert-format "%B" rev)
-                (magit-revision--wash-message)))
+      (insert (save-excursion ; The risky var query can move point.
+                (with-temp-buffer
+                  (magit-rev-insert-format "%B" rev)
+                  (magit-revision--wash-message))))
       (if (= (point) (+ beg 2))
           (progn (backward-delete-char 2)
                  (insert "(no message)\n"))


### PR DESCRIPTION
It seems a side effect of calling `hack-dir-locals-variables` can mess up the point while inserting, here's a before screenshot:

![bad-rev-highlight](https://user-images.githubusercontent.com/287742/43690071-127f1f86-98d2-11e8-819a-dc5fa9fdc8f0.png)
