### PR TITLE
use value of magit-log-select-arguments instead of --graph

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -296,7 +296,7 @@ depending on the value of option `magit-commit-squash-confirm'."
               "" "true" nil t)))
         (format "Type %%p on a commit to %s into it,"
                 (substring option 2))
-        nil nil (list "--graph"))
+        nil nil magit-log-select-arguments)
       (when magit-commit-show-diff
         (let ((magit-display-buffer-noselect t))
           (apply #'magit-diff-staged nil (magit-diff-arguments)))))))


### PR DESCRIPTION
It has huge performance implications in large repos.

I've defined `magit-log-select-arguments '("-n256")` but when using git commit fixup it was always showing up the log graph.

This PR tries to use the value of `magit-log-select-arguments` instead of the hardcoded `--graph`