### PR TITLE
magit-log-select-arguments: add --graph to default value

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -295,8 +295,7 @@ depending on the value of option `magit-commit-squash-confirm'."
                 (list "--autosquash" "--autostash")
               "" "true" nil t)))
         (format "Type %%p on a commit to %s into it,"
-                (substring option 2))
-        nil nil (list "--graph"))
+                (substring option 2)))
       (when magit-commit-show-diff
         (let ((magit-display-buffer-noselect t))
           (apply #'magit-diff-staged nil (magit-diff-arguments)))))))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -175,7 +175,7 @@ This is useful if you use really long branch names."
 
 ;;;; Select Mode
 
-(defcustom magit-log-select-arguments '("-n256" "--decorate")
+(defcustom magit-log-select-arguments '("-n256" "--graph" "--decorate")
   "The log arguments used in `magit-log-select-mode' buffers."
   :package-version '(magit . "2.3.0")
   :group 'magit-log


### PR DESCRIPTION
And stop hard-coding `--graph' in `magit-commit-squash-internal'.
This makes it possible for users NOT to use `--graph' if that has
negative effects on performance.  On the other hand it also means
that all uses of `magit-log-select' now show the graph by default,
but the latter might actually be beneficial too.

Re #3559.