### PR TITLE
New and improved module commands

### DIFF
--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -96,6 +96,20 @@ an alist that supports the keys `:right-align' and `:pad-right'."
                                                (symbol))
                                        (sexp   :tag "Value"))))))
 
+(defcustom magit-submodule-remove-trash-gitdirs nil
+  "Whether `magit-submodule-remove' offers to trash module gitdirs.
+
+If this is nil, then that command does not offer to do so unless
+a prefix argument is used.  When this is t, then it does offer to
+do so even without a prefix argument.
+
+In both cases the action still has to be confirmed unless that is
+disabled using the option `magit-no-confirm'.  Doing the latter
+and also setting this variable to t will lead to tears."
+  :package-version '(magit . "2.90.0")
+  :group 'magit-commands
+  :type 'boolean)
+
 ;;; Popup
 
 ;;;###autoload (autoload 'magit-submodule-popup "magit-submodule" nil t)
@@ -293,6 +307,8 @@ to recover from making a mistake here, but don't count on it."
          current-prefix-arg))
   (when (version< (magit-git-version) "2.12.0")
     (error "This command requires Git v2.12.0"))
+  (when magit-submodule-remove-trash-gitdirs
+    (setq trash-gitdirs t))
   (magit-with-toplevel
     (when-let
         ((modified

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -142,7 +142,7 @@ The value has the form ((COMMAND nil|PROMPT DEFAULT)...).
     (const abort-merge)       (const merge-dirty)
     (const drop-stashes)      (const reset-bisect)
     (const kill-process)      (const delete-unmerged-branch)
-    (const delete-pr-branch)
+    (const delete-pr-branch)  (const remove-modules)
     (const stage-all-changes) (const unstage-all-changes)
     (const safe-with-wip)))
 
@@ -251,6 +251,29 @@ Edit published history:
   To disable confirmation completely, add all three symbols here
   or set `magit-published-branches' to nil.
 
+Removing modules:
+
+  `remove-modules' When you remove the working directory of a
+  module that does not contain uncommitted changes, then that is
+  safer than doing so when there are uncommitted changes and/or
+  when you also remove the gitdir.  Still, you don't want to do
+  that by accident.
+
+  `remove-dirty-modules' When you remove the working directory of
+  a module that contains uncommitted changes, then those changes
+  are gone for good.  It is better to go to the module, inspect
+  these changes and only if appropriate discard them manually.
+
+  `trash-module-gitdirs' When you remove the gitdir of a module,
+  then all unpushed changes are gone for good.  It is very easy
+  to forget that you have some unfinished work on an unpublished
+  feature branch or even in a stash.
+
+  Actually there are some safety precautions in place, that might
+  help you out if you make an unwise choice here, but don't count
+  on it.  In case of emergency, stay calm and check the stash and
+  the `trash-directory' for traces of lost work.
+
 Various:
 
   `kill-process' There seldom is a reason to kill a process.
@@ -276,6 +299,9 @@ Global settings:
   :type `(choice (const :tag "Always require confirmation" nil)
                  (const :tag "Never require confirmation" t)
                  (set   :tag "Require confirmation except for"
+                        ;; `remove-dirty-modules' and
+                        ;; `trash-module-gitdirs' intentionally
+                        ;; omitted.
                         ,@magit--confirm-actions)))
 
 (defcustom magit-slow-confirm '(drop-stashes)


### PR DESCRIPTION
I haven't tested any of this yet but am publishing it now to prevent others from implementing and reviewing things that won't be merged.

* `magit-submodule-add: Run asynchronously` in response to #3584.

  This is a recurring pattern and should be abstracted, but there is no hurry to do so.

* `magit-submodule-remove: New command`

  The major differences to the implementations suggested in #3582 and #3583 are 
  * It refuses to do anything if there are uncommitted changes.
  * It does *not* remove the git directory of the submodule. If the gitdir is located in the working tree, then it is first moved into the gitdir of the super-repository. Removing a gitdir is very dangerous.
    * An additional command `magit-submodule-purge-gitdir` could be added which does remove a gitdir that is no longer connected to a module.
    * `magit-submodule-add` should be taught to ask the user how to deal with a gitdir that conflicts with the gitdir that is about to be added.

My `borg` package manager already does these things, but it can only deal with modules in `~/.emacs.d/lib`. But for that limited use-case this approach has worked well.