### PR TITLE
magit--record-separated-gitdirs: Resolve symlinked gitdirs

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -447,6 +447,9 @@ absolute path is returned."
 (defun magit--record-separated-gitdir ()
   (let ((topdir (magit-toplevel))
         (gitdir (magit-git-dir)))
+    ;; Kludge: git-annex converts submodule gitdirs to symlinks. See #3599.
+    (when (file-symlink-p (directory-file-name gitdir))
+      (setq gitdir (file-truename gitdir)))
     ;; We want to delete the entry for `topdir' here, rather than within
     ;; (unless ...), in case a `--separate-git-dir' repository was switched to
     ;; the standard structure (i.e., "topdir/.git/").


### PR DESCRIPTION
git-annex converts submodule gitdir files to symlinks.  As a result,
magit-toplevel doesn't discover the correct working tree when it's
called from .git/modules/NAME.  The main user-visible effect is that
magit-diff-while-committing shows empty diffs.

We could address this by adding a kludge to magit-toplevel, but that
would mean risking regressions in a tricky and core part of the magit
codebase to work around the peculiar behavior of a third-party
program.

However, this is similar to the problem that was solved in
439ed762 (Record the working tree for separated git directories,
2017-02-05).  We can piggyback on that solution by teaching
magit--record-separated-gitdir to resolve symlinked gitdirs. In the
worst case scenario, we incorrectly identify the gitdir.  Then
magit-toplevel, when called from the correct gitdir, simply wouldn't
find a corresponding entry in magit--separated-gitdirs, and we'd end
up where we are without this change.

Fixes #3599.