### PR TITLE
Spelling fixes to the manual.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -28,6 +28,6 @@ Please summarize the changes made in the commits.  Explain why you are making th
 How to update the manual
 =================================================================
 
-If you make changes to the manual, then edit only "magit.org".  Do not manually edit "magit.texi".  The latter has to be generate from the former.  If you want to do that yourself, then follow the instructions at [2].  Otherwise a maintainer will do it and amend that to your commit.
+If you make changes to the manual, then edit only "magit.org".  Do not manually edit "magit.texi".  The latter has to be generated from the former.  If you want to do that yourself, then follow the instructions at [2].  Otherwise a maintainer will do it and amend that to your commit.
 
   [2]: https://github.com/magit/magit/wiki/Documentation-tools-and-conventions

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.13.0 (2.13.0-349-gca1a696dd+1)
+#+SUBTITLE: for version 2.13.0 (2.13.0-350-gc3d8c5763+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -23,7 +23,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.13.0 (2.13.0-349-gca1a696dd+1).
+This manual is for Magit version 2.13.0 (2.13.0-350-gc3d8c5763+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2018 Jonas Bernoulli <jonas@bernoul.li>
@@ -2910,7 +2910,7 @@ These commands are available in diff buffers.
   variable ~magit-diff--tab-width-cache~.  Set that to nil to invalidate
   the cache.
 
-  - ~nil~ Never ajust tab width.  Use `tab-width's value from the Magit
+  - ~nil~ Never adjust tab width.  Use `tab-width's value from the Magit
     buffer itself instead.
 
   - ~t~ If the corresponding file-visiting buffer exits, then use
@@ -3196,7 +3196,7 @@ information on how to use Ediff itself, see info:ediff.
   Whether to show the remote prefix in lists of remote branches.
 
   Showing the prefix is redundant because the name of the remote is
-  already shown in the heading preceeding the list of its branches.
+  already shown in the heading preceding the list of its branches.
 
 - User Option: magit-refs-primary-column-width
 
@@ -4692,7 +4692,7 @@ man:git-config Also see [[man:git-branch]], [[man:git-checkout]] and [[*Pushing]
   ~magit-read-starting-point~, which includes all commands that change
   the upstream and many which create new branches.
 
-*** Auxillary Branch Commands
+*** Auxiliary Branch Commands
 
 These commands are not available from the branch popup by default.
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.13.0 (2.13.0-349-gca1a696dd+1)
+@subtitle for version 2.13.0 (2.13.0-350-gc3d8c5763+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.13.0 (2.13.0-349-gca1a696dd+1).
+This manual is for Magit version 2.13.0 (2.13.0-350-gc3d8c5763+1).
 
 @quotation
 Copyright (C) 2015-2018 Jonas Bernoulli <jonas@@bernoul.li>
@@ -217,7 +217,7 @@ Branching
 * The Two Remotes::
 * The Branch Popup::
 * The Branch Config Popup::
-* Auxillary Branch Commands::
+* Auxiliary Branch Commands::
 
 
 Rebasing
@@ -3967,7 +3967,7 @@ the cache.
 
 @itemize
 @item
-@code{nil} Never ajust tab width.  Use `tab-width's value from the Magit
+@code{nil} Never adjust tab width.  Use `tab-width's value from the Magit
 buffer itself instead.
 
 
@@ -4336,7 +4336,7 @@ commit counts.
 Whether to show the remote prefix in lists of remote branches.
 
 Showing the prefix is redundant because the name of the remote is
-already shown in the heading preceeding the list of its branches.
+already shown in the heading preceding the list of its branches.
 @end defopt
 
 @defopt magit-refs-primary-column-width
@@ -5623,7 +5623,7 @@ To show no diff while committing remove @code{magit-commit-diff} from
 * The Two Remotes::
 * The Branch Popup::
 * The Branch Config Popup::
-* Auxillary Branch Commands::
+* Auxiliary Branch Commands::
 @end menu
 
 @node The Two Remotes
@@ -6323,8 +6323,8 @@ This affects all commands that use @code{magit-read-upstream-branch} or
 the upstream and many which create new branches.
 @end defopt
 
-@node Auxillary Branch Commands
-@subsection Auxillary Branch Commands
+@node Auxiliary Branch Commands
+@subsection Auxiliary Branch Commands
 
 These commands are not available from the branch popup by default.
 


### PR DESCRIPTION
Fix single-letter spelling mistakes in the manual.

> The latter has to be generate[d] from the former.

Please note that your GitHub PR template also has a spelling mistake, above.
