### PR TITLE
Add default directory option for magit-clone

### DIFF
--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -48,6 +48,12 @@ If t, then set without asking.  If nil, then don't set.  If
                  (const :tag "ask" ask)
                  (const :tag "don't set" nil)))
 
+(defcustom magit-clone-default-dir nil
+  "Default directory to use for `magit-clone'. If nil then the
+  current directory is used."
+  :group 'magit-commands
+  :type 'string)
+
 ;;; Commands
 
 ;;;###autoload
@@ -57,7 +63,7 @@ Then show the status buffer for the new repository."
   (interactive
    (let  ((url (magit-read-string-ns "Clone repository")))
      (list url (read-directory-name
-                "Clone to: " nil nil nil
+                "Clone to: " magit-clone-default-dir nil nil
                 (and (string-match "\\([^/:]+?\\)\\(/?\\.git\\)?$" url)
                      (match-string 1 url))))))
   (setq directory (file-name-as-directory (expand-file-name directory)))


### PR DESCRIPTION
Adds option to specify default directory for `magit-clone`.  I usually clone all of my repos to the same base repository and rarely to the directory I'm currently in.  Adding this option allows the user to specify which directory they'd like to serve as the default if any.
