### PR TITLE
magit-reverse-files: Extend binary file check

### DIFF
--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -644,7 +644,14 @@ so causes the change to be applied to the index as well."
 
 (defun magit-reverse-files (sections args)
   (pcase-let ((`(,binaries ,sections)
-               (let ((bs (magit-binary-files "--cached")))
+               (let ((bs (magit-binary-files
+                          (cond ((derived-mode-p 'magit-revision-mode)
+                                 (let ((rev (car magit-refresh-args)))
+                                   (format "%s^..%s" rev rev)))
+                                ((derived-mode-p 'magit-diff-mode)
+                                 (car magit-refresh-args))
+                                (t
+                                 "--cached")))))
                  (--separate (member (oref it value) bs)
                              sections))))
     (magit-confirm-files 'reverse (--map (oref it value) sections))

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -586,7 +586,7 @@ without requiring confirmation."
       (when new-files
         (magit-call-git "add"   "--" new-files)
         (magit-call-git "reset" "--" new-files))
-      (let ((binaries (magit-staged-binary-files)))
+      (let ((binaries (magit-binary-files "--cached")))
         (when binaries
           (setq sections
                 (--remove (member (oref it value) binaries)
@@ -644,7 +644,7 @@ so causes the change to be applied to the index as well."
 
 (defun magit-reverse-files (sections args)
   (pcase-let ((`(,binaries ,sections)
-               (let ((bs (magit-staged-binary-files)))
+               (let ((bs (magit-binary-files "--cached")))
                  (--separate (member (oref it value) bs)
                              sections))))
     (magit-confirm-files 'reverse (--map (oref it value) sections))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -742,11 +742,12 @@ tracked file."
                    (and nomodules "--ignore-submodules")
                    (magit-headish) "--" files))
 
-(defun magit-staged-binary-files ()
+(defun magit-binary-files (&rest args)
   (--mapcat (and (string-match "^-\t-\t\\(.+\\)" it)
                  (list (match-string 1 it)))
-            (magit-git-items "diff" "-z" "--cached"
-                             "--numstat" "--ignore-submodules")))
+            (apply #'magit-git-items
+                   "diff" "-z" "--numstat" "--ignore-submodules"
+                   args)))
 
 (defun magit-unmerged-files ()
   (magit-git-items "diff-files" "-z" "--name-only" "--diff-filter=U"))


### PR DESCRIPTION
Provide a more informative error message when a user tries to reverse binary files from a revision or diff buffer.

Closes #3625. 