### PR TITLE
Use libgit if possible and desired (r2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   allow_failures:
     - env: EMACS_VERSION=master
 install:
+  # TODO libgit
   - $CURL -O https://github.com/npostavs/emacs-travis/releases/download/bins/emacs-bin-${EMACS_VERSION}.tar.gz
   - tar -xaf emacs-bin-${EMACS_VERSION}.tar.gz -C /
   - export EMACS=/tmp/emacs/bin/emacs

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ bump-versions-1:
         (async-version \"$(ASYNC_VERSION)\")\
         (dash-version \"$(DASH_VERSION)\")\
         (git-commit-version \"$(GIT_COMMIT_VERSION)\")\
+        (libgit-version \"$(LIBGIT_VERSION)\")\
         (transient-version \"$(TRANSIENT_VERSION)\")\
         (with-editor-version \"$(WITH_EDITOR_VERSION)\"))\
         $$set_package_requires)"
@@ -231,6 +232,7 @@ bump-snapshots:
         (async-version \"$(ASYNC_MELPA_SNAPSHOT)\")\
         (dash-version \"$(DASH_MELPA_SNAPSHOT)\")\
         (git-commit-version \"$(GIT_COMMIT_MELPA_SNAPSHOT)\")\
+        (libgit-version \"$(LIBGIT_MELPA_SNAPSHOT)\")\
         (transient-version \"$(TRANSIENT_MELPA_SNAPSHOT)\")\
         (with-editor-version \"$(WITH_EDITOR_MELPA_SNAPSHOT)\"))\
         $$set_package_requires)"

--- a/default.mk
+++ b/default.mk
@@ -101,12 +101,14 @@ VERSION ?= $(shell test -e $(TOP).git && git describe --tags --abbrev=0 | cut -c
 ASYNC_VERSION       = 1.9.3
 DASH_VERSION        = 2.14.1
 GIT_COMMIT_VERSION  = 2.91.0
+LIBGIT_VERSION      = 0
 TRANSIENT_VERSION   = 0
 WITH_EDITOR_VERSION = 2.8.0
 
 ASYNC_MELPA_SNAPSHOT       = 20180527
 DASH_MELPA_SNAPSHOT        = 20180910
 GIT_COMMIT_MELPA_SNAPSHOT  = 20181104
+LIBGIT_MELPA_SNAPSHOT      = 0
 TRANSIENT_MELPA_SNAPSHOT   = 0
 WITH_EDITOR_MELPA_SNAPSHOT = 20181103
 
@@ -129,6 +131,13 @@ DASH_DIR ?= $(shell \
   sort | tail -n 1)
 ifeq "$(DASH_DIR)" ""
   DASH_DIR = $(TOP)../dash
+endif
+
+LIBGIT_DIR ?= $(shell \
+  find -L $(ELPA_DIR) -maxdepth 1 -regex '.*/libgit-[.0-9]*' 2> /dev/null | \
+  sort | tail -n 1)
+ifeq "$(LIBGIT_DIR)" ""
+  LIBGIT_DIR = $(TOP)../libgit
 endif
 
 TRANSIENT_DIR ?= $(shell \
@@ -159,10 +168,12 @@ LOAD_PATH = -L $(TOP)/lisp
 
 ifdef CYGPATH
   LOAD_PATH += -L $(shell cygpath --mixed $(DASH_DIR))
+  LOAD_PATH += -L $(shell cygpath --mixed $(LIBGIT_DIR))
   LOAD_PATH += -L $(shell cygpath --mixed $(TRANSIENT_DIR))
   LOAD_PATH += -L $(shell cygpath --mixed $(WITH_EDITOR_DIR))
 else
   LOAD_PATH += -L $(DASH_DIR)
+  LOAD_PATH += -L $(LIBGIT_DIR)
   LOAD_PATH += -L $(TRANSIENT_DIR)
   LOAD_PATH += -L $(WITH_EDITOR_DIR)
 endif

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -12,7 +12,9 @@ all: lisp
 git-commit.elc:
 magit-utils.elc:
 magit-section.elc:	magit-utils.elc
-magit-git.elc:		magit-utils.elc magit-section.elc
+magit-libgit.elc:
+magit-git.elc:		magit-utils.elc magit-section.elc \
+			magit-libgit.elc
 magit-mode.elc:		magit-section.elc magit-git.elc
 magit-margin.elc:	magit-section.elc magit-mode.elc
 magit-process.elc:	magit-utils.elc magit-section.elc \

--- a/lisp/magit-core.el
+++ b/lisp/magit-core.el
@@ -39,6 +39,9 @@
 (require 'magit-transient)
 (require 'magit-autorevert)
 
+(when (magit--libgit-available-p)
+  (require 'magit-libgit))
+
 (defgroup magit nil
   "Controlling Git from Emacs."
   :link '(url-link "https://magit.vc")

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -788,11 +788,12 @@ is non-nil, in which case return nil."
           (and (not noerror)
                (signal 'magit-outside-git-repo default-directory))))))
 
-(defun magit-bare-repo-p (&optional noerror)
+(cl-defgeneric magit-bare-repo-p ()
   "Return t if the current repository is bare.
 If it is non-bare, then return nil.  If `default-directory'
 isn't below a Git repository, then signal an error unless
-NOERROR is non-nil, in which case return nil."
+NOERROR is non-nil, in which case return nil.")
+(cl-defmethod  magit-bare-repo-p (&context (gitimpl git) &optional noerror)
   (and (magit--assert-default-directory noerror)
        (condition-case nil
            (magit-rev-parse-true "--is-bare-repository")

--- a/lisp/magit-libgit.el
+++ b/lisp/magit-libgit.el
@@ -1,0 +1,59 @@
+;;; magit-libgit.el --- Libgit functionality       -*- lexical-binding: t -*-
+
+;; Copyright (C) 2010-2018  The Magit Project Contributors
+;;
+;; You should have received a copy of the AUTHORS.md file which
+;; lists all contributors.  If not, see http://magit.vc/authors.
+
+;; Author: Jonas Bernoulli <jonas@bernoul.li>
+;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
+
+;; Magit is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; Magit is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+;; License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Magit.  If not, see http://www.gnu.org/licenses.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'dash)
+(require 'subr-x)
+
+(require 'magit-git)
+
+(if (eq (magit--git-implementation) 'libgit)
+    (condition-case err
+        (require 'libgit)
+      (error
+       (setq magit-inhibit-libgit 'error)
+       (message "Error while loading `magit-libgit': %S" err)))
+  ;; If `libegit2' isn't available, then this file is compiled
+  ;; anyway.  Don't spew warnings.  Sort alphabetically.
+  (declare-function libgit-repository-bare-p "libegit2")
+  (declare-function libgit-repository-open "libegit2")
+  )
+
+;;; Utilities
+
+(defun magit-libgit-repo (&optional directory)
+  (and-let* ((default-directory
+               (let ((magit-inhibit-libgit t))
+                 (magit-gitdir directory))))
+    (magit--with-refresh-cache
+        (cons default-directory 'magit-libgit-repo)
+      (libgit-repository-open default-directory))))
+
+;;; Methods
+
+;;; _
+(provide 'magit-libgit)
+;;; magit-libgit.el ends here
+

--- a/lisp/magit-libgit.el
+++ b/lisp/magit-libgit.el
@@ -53,6 +53,13 @@
 
 ;;; Methods
 
+(cl-defmethod magit-bare-repo-p (&context (gitimpl libgit) &optional noerror)
+  (and (magit--assert-default-directory noerror)
+       (if-let ((repo (magit-libgit-repo)))
+           (libgit-repository-bare-p repo)
+         (unless noerror
+           (signal 'magit-outside-git-repo default-directory)))))
+
 ;;; _
 (provide 'magit-libgit)
 ;;; magit-libgit.el ends here

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1390,7 +1390,8 @@ repository's Magit buffers."
                      :key #'car :test #'equal)))
   (dolist (buffer (magit-mode-get-buffers))
     (with-current-buffer buffer
-      (setq magit-section-visibility-cache nil))))
+      (setq magit-section-visibility-cache nil)))
+  (setq magit--libgit-available-p eieio-unbound))
 
 ;;; Utilities
 

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -738,10 +738,11 @@ See info node `(magit)Debugging Tools' for more information."
                          (cond
                           (path
                            (list (file-name-directory path)))
-                          ((not (member lib '("transient")))
+                          ((not (member lib '("libgit" "transient")))
                            (error "Cannot find mandatory dependency %s" lib)))))
                      '(;; Like `LOAD_PATH' in `default.mk'.
                        "dash"
+                       "libgit"
                        "transient"
                        "with-editor"
                        ;; Obviously `magit' itself is needed too.


### PR DESCRIPTION
This replaces #3622.

This uses generic functions to prevent `magit-git.el` and `magit-libgit.el` depending on one another. Thanks @luismbo for the suggestion.

/cc @TheBB