### PR TITLE
Clarify and implement other interpretation of "global" in magit-gitignore

### DIFF
--- a/lisp/magit-gitignore.el
+++ b/lisp/magit-gitignore.el
@@ -39,18 +39,22 @@
   "Popup console for gitignore commands."
   :man-page "gitignore"
   :actions '((?l "ignore locally"  magit-gitignore-locally)
-             (?g "ignore globally" magit-gitignore-globally))
+             (?g "ignore in .gitignore" magit-gitignore-globally))
   :max-action-columns 1)
 
 ;;;###autoload
 (defun magit-gitignore-globally (file-or-pattern)
-  "Instruct Git to globally ignore FILE-OR-PATTERN."
+  "Instruct Git to ignore FILE-OR-PATTERN in all checkouts of this repository.
+
+Magit will edit the .gitignore file in the project's working directory root."
   (interactive (list (magit-gitignore-read-pattern nil)))
   (magit--gitignore file-or-pattern nil))
 
 ;;;###autoload
 (defun magit-gitignore-locally (file-or-pattern)
-  "Instruct Git to locally ignore FILE-OR-PATTERN."
+  "Instruct Git to ignore FILE-OR-PATTERN in the current checkout only.
+
+Magit will edit the info/exclude file in the project's git directory."
   (interactive (list (magit-gitignore-read-pattern t)))
   (magit--gitignore file-or-pattern t))
 


### PR DESCRIPTION
I was confused that, after updating Magit, I could no longer ignore files using Magit (by asking it to place their paths in `.gitignore`). The only options were to ignore locally (which I knew to mean `info/exclude`), and globally (which I understood to have the same general meaning as `git config --global`, i.e. whatever `core.excludepath` was pointing at).

Here's an attempt to clarify this confusion, plus implement my initial interpretation to further disambiguate by presenting all reasonable options.

I did not rename `magit-gitignore-globally`, to avoid breaking users' configurations.