### PR TITLE
magit-diff.el:  fix font face documentation string

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -602,7 +602,7 @@ and `:slant'."
     (((class color) (background dark))
      :background "grey20"
      :foreground "grey70"))
-  "Face for lines in a diff that have been removed."
+  "Face for lines in the current context in a diff."
   :group 'magit-faces)
 
 (defface magit-diff-whitespace-warning


### PR DESCRIPTION
Fix incorrect (copy'n'paste?) doc string for
`magit-diff-context-highlight` font face
