### PR TITLE
doc typo: magit-revision-show-gravatar→magit-revision-show-gravatars

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.0
+#+SUBTITLE: for version 2.90.0 (v2.90.0-4-g13b32ae1c+1)
 #+BIND: ox-texinfo+-before-export-hook ox-texinfo+-update-version-strings
 
 #+TEXINFO_DEFFN: t
@@ -23,7 +23,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.0.
+This manual is for Magit version 2.90.0 (v2.90.0-4-g13b32ae1c+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2018 Jonas Bernoulli <jonas@bernoul.li>
@@ -2999,7 +2999,7 @@ These commands are available in diff buffers.
   - ~all~ Show related local and remote branches.
   - ~mixed~ Show all containing branches and local merged branches.
 
-- User Option: magit-revision-show-gravatar
+- User Option: magit-revision-show-gravatars
 
   Whether to show gravatar images in revision buffers.
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.0
+@subtitle for version 2.90.0 (v2.90.0-4-g13b32ae1c+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.0.
+This manual is for Magit version 2.90.0 (v2.90.0-4-g13b32ae1c+1).
 
 @quotation
 Copyright (C) 2015-2018 Jonas Bernoulli <jonas@@bernoul.li>
@@ -4085,7 +4085,7 @@ Whether to show related branches in revision buffers.
 @end itemize
 @end defopt
 
-@defopt magit-revision-show-gravatar
+@defopt magit-revision-show-gravatars
 
 Whether to show gravatar images in revision buffers.
 


### PR DESCRIPTION
wrong variable name

(needs .texi; I get `Cannot open load file: No such file or directory, org-man` when I try to make it)