### PR TITLE
magit-log-merged: New command

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -5,6 +5,16 @@
 - The "Version" column in ~magit-submodule-list-mode~ and
   ~magit-repolist-mode~ buffers now shows when a repository is dirty.
 
+- Added new command ~magit-log-merged~.  This command requires
+  ~git-when-merged~ (https://github.com/mhagger/git-when-merged).  It
+  isn't bound in ~magit-log-popup~ by default.  To add it, you can use
+  something like
+
+  #+BEGIN_SRC emacs-lisp
+    (magit-define-popup-action 'magit-log-popup
+      ?m "Log commit's merge" 'magit-log-merged)
+  #+END_SRC
+
 ** Fixes since v2.90.0
 
 - Staging and unstaging submodules while ~diff.submodule~'s value is ~log~

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -753,6 +753,27 @@ active, restrict the log to the lines that the region touches."
         (goto-char pos)
         (call-interactively #'magit-log-trace-definition)))))
 
+;;;###autoload
+(defun magit-log-merged (commit branch &optional args files)
+  "Show log for the merge of COMMIT into BRANCH.
+More precisely, find merge commit M that brought COMMIT into
+BRANCH, and show the log of the range \"M^..M\".  This command
+requires git-when-merged, which is available from
+https://github.com/mhagger/git-when-merged."
+  (interactive
+   (append (let ((commit (magit-read-branch-or-commit "Commit")))
+             (list commit
+                   (magit-read-other-branch "Merged into" commit)))
+           (magit-log-arguments)))
+  (unless (executable-find "git-when-merged")
+    (user-error "This command requires git-when-merged (%s)"
+                "https://github.com/mhagger/git-when-merged"))
+  (magit-git-log
+   (list (or (magit-git-string "when-merged" "--show-branch" commit branch)
+             (user-error "Could not find when %s was merged into %s"
+                         commit branch)))
+   args files))
+
 (defun magit-git-reflog (ref args)
   (require 'magit)
   (magit-mode-setup #'magit-reflog-mode ref args))


### PR DESCRIPTION
Use git-when-merged to help users ask "When was this commit merged
into this ref?" and "Assuming this commit was developed in a topic
branch, what were the other commits in that topic?".