### PR TITLE
magit-diff-type: Guard rev-eq call to fix range edge case

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -101,3 +101,7 @@
   ~magit-commit-instant-fixup~ point was no longer placed on the same
   commit as was at point in the buffer from which the command was
   invoked.  #3674
+
+- ~magit-diff-type~ falsely concluded that a diff buffer showed
+  unstaged changes when diffing a range where the right side resolves
+  to the same commit as ~HEAD~.  #3666

--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -286,7 +286,7 @@ does."
   (interactive
    (let ((arg (magit-read-other-branch-or-commit "Checkout")))
      (list arg
-           (and (not (magit-rev-verify-commit arg))
+           (and (not (magit-commit-p arg))
                 (magit-read-starting-point "Create and checkout branch" arg)))))
   (when (string-match "\\`heads/\\(.+\\)" arg)
     (setq arg (match-string 1 arg)))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1090,7 +1090,7 @@ for a revision."
     (when module
       (setq default-directory
             (expand-file-name (file-name-as-directory module))))
-    (unless (magit-rev-verify-commit rev)
+    (unless (magit-commit-p rev)
       (user-error "%s is not a commit" rev))
     (magit-mode-setup #'magit-revision-mode rev nil args files)))
 
@@ -2122,12 +2122,12 @@ or a ref which is not a branch, then it inserts nothing."
                             (`quicker  ; false negatives (number-less hashes)
                              (and (>= (length text) 7)
                                   (string-match-p "[0-9]" text)
-                                  (magit-rev-verify-commit text)))
+                                  (magit-commit-p text)))
                             (`quick    ; false negatives (short hashes)
                              (and (>= (length text) 7)
-                                  (magit-rev-verify-commit text)))
+                                  (magit-commit-p text)))
                             (`slow
-                             (magit-rev-verify-commit text)))
+                             (magit-commit-p text)))
                       (put-text-property beg (point) 'face 'magit-hash)
                       (let ((end (point)))
                         (goto-char beg)

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -627,7 +627,7 @@ above."
                                  (match-string 1 r)
                                r)))
                           ((eq major-mode 'magit-status-mode) "HEAD"))))
-      (when (magit-rev-verify-commit rev)
+      (when (magit-commit-p rev)
         (setq rev (magit-rev-parse rev))
         (push (list rev default-directory) magit-revision-stack)
         (kill-new (message "%s" rev))))))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1007,7 +1007,7 @@ string \"true\", otherwise return nil."
 (defun magit-rev-verify (rev)
   (magit-git-string-p "rev-parse" "--verify" rev))
 
-(defun magit-rev-verify-commit (rev)
+(defun magit-commit-p (rev)
   "Return full hash for REV if it names an existing commit."
   (magit-rev-verify (concat rev "^{commit}")))
 
@@ -1909,7 +1909,7 @@ and this option only controls what face is used.")
 (defun magit-thingatpt--git-revision ()
   (--when-let (bounds-of-thing-at-point 'git-revision)
     (let ((text (buffer-substring-no-properties (car it) (cdr it))))
-      (and (magit-rev-verify-commit text) text))))
+      (and (magit-commit-p text) text))))
 
 ;;; Completion
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1005,7 +1005,7 @@ string \"true\", otherwise return nil."
   (equal (magit-git-str "rev-parse" args) "true"))
 
 (defun magit-rev-verify (rev)
-  (magit-rev-parse-safe "--verify" rev))
+  (magit-git-string-p "rev-parse" "--verify" rev))
 
 (defun magit-rev-verify-commit (rev)
   "Return full hash for REV if it names an existing commit."

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1017,8 +1017,8 @@ string \"true\", otherwise return nil."
 
 (defun magit-rev-eq (a b)
   "Return t if A and B refer to the same commit."
-  (let ((a (magit-rev-verify a))
-        (b (magit-rev-verify b)))
+  (let ((a (magit-commit-p a))
+        (b (magit-commit-p b)))
     (and a b (equal a b))))
 
 (defun magit-rev-ancestor-p (a b)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -957,6 +957,7 @@ string \"true\", otherwise return nil."
   (magit-rev-verify (concat rev "^{commit}")))
 
 (defun magit-rev-equal (a b)
+  "Return t if there are no differences between the commits A and B."
   (magit-git-success "diff" "--quiet" a b))
 
 (defun magit-rev-eq (a b)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -961,6 +961,7 @@ string \"true\", otherwise return nil."
   (magit-git-success "diff" "--quiet" a b))
 
 (defun magit-rev-eq (a b)
+  "Return t if A and B refer to the same commit."
   (let ((a (magit-rev-verify a))
         (b (magit-rev-verify b)))
     (and a b (equal a b))))

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -620,8 +620,11 @@ Magit status buffer."
                             'face 'magit-section-heading))))
       (magit-insert-heading)
       (when errlog
-        (insert-file-contents errlog)
-        (goto-char (1- (point-max))))
+        (if (bufferp errlog)
+            (insert (with-current-buffer errlog
+                      (buffer-substring-no-properties (point-min) (point-max))))
+          (insert-file-contents errlog)
+          (goto-char (1- (point-max)))))
       (insert "\n"))))
 
 (defun magit-process-truncate-log ()

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -755,7 +755,7 @@ If no such sequence is in progress, do nothing."
             patch commit)
         (while patches
           (setq patch (pop patches))
-          (setq commit (magit-rev-verify-commit
+          (setq commit (magit-commit-p
                         (cadr (split-string (magit-file-line patch)))))
           (cond ((and commit patches)
                  (magit-sequence-insert-commit


### PR DESCRIPTION
```
As of 296f8dc7 (magit-diff-type: Fix case when the HEAD is used as
RANGE, 2018-09-13), we use `magit-rev-eq' to check whether RANGE
resolves to HEAD to avoid classifying `git diff HEAD'-equivalent
output as `committed'.

That fix introduced another edge case.  `magit-rev-eq' calls
`magit-rev-verify' on each argument, which returns the first line of
`git rev-parse --verify'.  In the case of a range A..B, the standard
output spans multiple lines, with first line being B's hash and the
second being "^A-hash".  This means that `(magit-rev-eq "A..B"
"HEAD")', where B resolves to "HEAD", will return true, and
`magit-diff-type' will incorrectly classify the diff as either
`unstaged' or `staged'.

Avoid this misclassification by confirming that RANGE isn't actually a
range before passing it to `magit-rev-eq'.  An alternative would be to
update `magit-rev-eq' so that it doesn't get confused by a range, but
`magit-diff-type' is the only caller that appears to pass it a range.
```

---

I think the fix is obviously correct.  I'm opening a PR in case there are objections about the level at which this should be fixed (e.g., within `magit-rev-eq` itself or even deeper).