### PR TITLE
On instant squash/fixup, keep commit cursor is at

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -77,3 +77,8 @@
 
 - The Custom type definition of ~magit-diff-adjust-tab-width~ was
   broken.  #3671
+
+- In the log-select buffer shown by ~magit-commit-instant-squash~ and
+  ~magit-commit-instant-fixup~ point was no longer placed on the same
+  commit as was at point in the buffer from which the command was
+  invoked.  #3674

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -317,7 +317,8 @@ depending on the value of option `magit-commit-squash-confirm'."
                 (list "--autosquash" "--autostash" "--keep-empty")
               "" "true" nil t)))
         (format "Type %%p on a commit to %s into it,"
-                (substring option 2)))
+                (substring option 2))
+        nil nil nil commit)
       (when magit-commit-show-diff
         (let ((magit-display-buffer-noselect t))
           (apply #'magit-diff-staged nil (magit-diff-arguments)))))))


### PR DESCRIPTION
Fix  #3674 by explicitly plumbing down the last optional argument to `magit-log-select`.

TL;DR: there could be a better way to do this but I couldn't find it.

I did read the code of `magit-log-goto-same-commit`, and its fallback logic did sound a little bit like what we want to use to me. However, it appears to work based on the `magit-previous-section` variable, which is only called when setting up a new buffer afaict.
