### PR TITLE
magit-clone: execute magit-credential-hook

### DIFF
--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -75,6 +75,7 @@ Then show the status buffer for the new repository."
                 nil nil
                 (and (string-match "\\([^/:]+?\\)\\(/?\\.git\\)?$" url)
                      (match-string 1 url))))))
+  (run-hooks 'magit-credential-hook)
   (setq directory (file-name-as-directory (expand-file-name directory)))
   (magit-run-git-async "clone" repository
                        (magit-convert-filename-for-git directory))


### PR DESCRIPTION
The git clone command need credentials in order to perform on private repositories.