### PR TITLE
magit-diff-inside-hunk-body-p: fix scroll in sections with no content

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2829,8 +2829,10 @@ last (visual) lines of the region."
 (defun magit-diff-inside-hunk-body-p ()
   "Return non-nil if point is inside the body of a hunk."
   (and (magit-section-match 'hunk)
-       (> (point)
-          (oref (magit-current-section) content))))
+       (or
+        (not (oref (magit-current-section) content))
+        (> (point)
+           (oref (magit-current-section) content)))))
 
 ;;; Diff Extract
 


### PR DESCRIPTION
In diff sections where the change is a file mode change, there's no
content in the section (only title) but scrolling through it is
allowed now.