### PR TITLE
Fix: (magit-describe-section-briefly) Display ident interactively

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -144,3 +144,8 @@
 - ~magit-which-function~ now simply resets Imenu's cache and then calls
   ~which-function~.  The old approach that tried to outsmart Imenu was
   broken.  #3691.
+
+- ~magit-describe-section-briefly~ did not actually display a section
+  ident when called interactively, as the docstring claimed.  Now it
+  displays the section ident, which is useful in
+  ~magit-status-initial-section~.

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -678,11 +678,11 @@ Sections at higher levels are hidden."
 
 ;;;; Auxiliary
 
-(defun magit-describe-section-briefly (section &optional message ident)
+(defun magit-describe-section-briefly (section &optional ident)
   "Show information about the section at point.
 With a prefix argument show the section identity instead of the
 section lineage.  This command is intended for debugging purposes."
-  (interactive (list (magit-current-section) t))
+  (interactive (list (magit-current-section) current-prefix-arg))
   (let ((str (format "#<%s %S %S %s-%s>"
                      (eieio-object-class section)
                      (let ((val (oref section value)))
@@ -700,7 +700,9 @@ section lineage.  This command is intended for debugging purposes."
                        (marker-position m))
                      (when-let ((m (oref section end)))
                        (marker-position m)))))
-    (if message (message "%s" str) str)))
+    (if (called-interactively-p)
+        (message "%s" str)
+      str)))
 
 (cl-defmethod cl-print-object ((section magit-section) stream)
   "Print `magit-describe-section' result of SECTION."


### PR DESCRIPTION
The interactive form and args did not match up, so using a prefix interactively did not cause the ident to be displayed, but rather the vector (which is not useful for magit-status-initial-section).