### PR TITLE
Add support for `git rebase --rebase-merges'

### DIFF
--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -56,6 +56,9 @@
 ;;   x        Add a script to be run with the commit at point
 ;;            being checked out.
 ;;   z        Add noop action at point.
+;;   l        Add a label at point.
+;;   t        Add a reset action after the commit at point.
+;;   M        Add a merge action at point.
 ;;
 ;;   SPC      Show the commit at point in another buffer.
 ;;   RET      Show the commit at point in another buffer and

--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -157,6 +157,7 @@
     (define-key map (kbd "e") 'git-rebase-edit)
     (define-key map (kbd "l") 'git-rebase-label)
     (define-key map (kbd "m") 'git-rebase-edit)
+    (define-key map (kbd "M") 'git-rebase-merge)
     (define-key map (kbd "f") 'git-rebase-fixup)
     (define-key map (kbd "q") 'undefined)
     (define-key map (kbd "r") 'git-rebase-reword)
@@ -423,6 +424,19 @@ input remove the command on the current line, if any."
   (git-rebase-insert-at-point-with-args
    "\\(t\\|reset\\) \\(.*\\)" "reset"
    (lambda (initial) (read-from-minibuffer "Reset to label: ")) nil arg))
+
+(defun git-rebase-merge (rev)
+  "Add a merge command to be inserted before the proceeding commit.
+
+REV is the commit to be merged."
+  (interactive (list (magit-read-branch-or-commit "Insert revision")))
+  (goto-char (line-beginning-position))
+  (let ((inhibit-read-only t)
+        (label (read-from-minibuffer "Label: "))
+        (commit-message (read-from-minibuffer "Message for merge commit: ")))
+    (insert (concat "merge " (if (y-or-n-p "Reword the commit message? ")
+                                 "-c "
+                               "-C ") rev " # " commit-message "\n"))))
 
 (defun git-rebase-noop (&optional arg)
   "Add noop action at point.

--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -470,7 +470,7 @@ running 'man git-rebase' at the command line) for details."
   (setq git-rebase-comment-re (concat "^" (regexp-quote comment-start)))
   (setq git-rebase-line
         (concat "^\\(" (regexp-quote comment-start) "? *"
-                "\\(?:[fprse]\\|pick\\|reword\\|edit\\|squash\\|fixup\\|exec\\|noop\\)\\) "
+                "\\(?:[fprsetlm]\\|pick\\|reword\\|edit\\|squash\\|fixup\\|exec\\|noop\\|reset\\|label\\|merge\\)\\) "
                 "\\(?:\\([^ \n]+\\) \\(.*\\)\\)?"))
   (setq font-lock-defaults (list (git-rebase-mode-font-lock-keywords) t t))
   (unless git-rebase-show-instructions
@@ -517,11 +517,19 @@ running 'man git-rebase' at the command line) for details."
        (1 'font-lock-keyword-face)
        (2 'git-rebase-hash)
        (3 'git-rebase-description))
-      ("^\\(exec\\) \\(.*\\)"
+      ("^\\([xlt]\\|exec\\|label\\|reset\\) \\(.*\\)"
        (1 'font-lock-keyword-face)
        (2 'git-rebase-description))
       ("^\\(noop\\)"
        (1 'font-lock-keyword-face))
+      ("^\\(m\\|merge\\) \\(-[Cc]\\) \\([^ \n]+\\) \\(.*\\)"
+       (1 'font-lock-keyword-face)
+       (2 'font-lock-keyword-face)
+       (3 'git-rebase-hash)
+       (4 'git-rebase-description))
+      ("^\\(m\\|merge\\) \\(.*\\)"
+       (1 'font-lock-keyword-face)
+       (2 'git-rebase-description))
       (git-rebase-match-comment-line 0 'font-lock-comment-face)
       (,(concat git-rebase-comment-re " *" action-re)
        0 'git-rebase-killed-action t)

--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -155,10 +155,12 @@
            (define-key map (kbd   "k") 'git-rebase-kill-line)
            (define-key map (kbd "C-k") 'git-rebase-kill-line)))
     (define-key map (kbd "e") 'git-rebase-edit)
+    (define-key map (kbd "l") 'git-rebase-label)
     (define-key map (kbd "m") 'git-rebase-edit)
     (define-key map (kbd "f") 'git-rebase-fixup)
     (define-key map (kbd "q") 'undefined)
     (define-key map (kbd "r") 'git-rebase-reword)
+    (define-key map (kbd "t") 'git-rebase-reset)
     (define-key map (kbd "w") 'git-rebase-reword)
     (define-key map (kbd "s") 'git-rebase-squash)
     (define-key map (kbd "x") 'git-rebase-exec)
@@ -397,6 +399,30 @@ input remove the command on the current line, if any."
   (git-rebase-insert-at-point-with-args
    "\\(e\\|exec\\) \\(.*\\)" "exec"
    (lambda (initial) (read-shell-command "Execute: " initial)) nil arg))
+
+(defun git-rebase-label (arg)
+  "Add a label command to be inserted before the proceeding commit.
+
+If there already is such a command on the current line, then edit
+that instead.  With a prefix argument (ARG) insert a new command
+even when there already is one on the current line.  With empty
+input remove the command on the current line, if any."
+  (interactive "P")
+  (git-rebase-insert-at-point-with-args
+   "\\(l\\|label\\) \\(.*\\)" "label"
+   (lambda (initial) (read-from-minibuffer "Label: " initial)) t arg))
+
+(defun git-rebase-reset (arg)
+  "Add a reset command to be inserted after the proceeding commit.
+
+If there already is such a command on the current line, then edit
+that instead.  With a prefix argument (ARG) insert a new command
+even when there already is one on the current line.  With empty
+input remove the command on the current line, if any."
+  (interactive "P")
+  (git-rebase-insert-at-point-with-args
+   "\\(t\\|reset\\) \\(.*\\)" "reset"
+   (lambda (initial) (read-from-minibuffer "Reset to label: ")) nil arg))
 
 (defun git-rebase-noop (&optional arg)
   "Add noop action at point.

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -570,7 +570,9 @@ START has to be selected from a list of recent commits."
           (setq commit (concat commit "^"))
         (setq args (cons "--root" args)))))
   (when (and commit (not noassert))
-    (setq commit (magit-rebase-interactive-assert commit delay-edit-confirm)))
+    (setq commit (magit-rebase-interactive-assert
+                  commit delay-edit-confirm
+                  (--some (string-prefix-p "--rebase-merges" it) args))))
   (if (and commit (not confirm))
       (let ((process-environment process-environment))
         (when editor
@@ -586,7 +588,8 @@ START has to be selected from a list of recent commits."
 (defvar magit--rebase-published-symbol nil)
 (defvar magit--rebase-public-edit-confirmed nil)
 
-(defun magit-rebase-interactive-assert (since &optional delay-edit-confirm)
+(defun magit-rebase-interactive-assert
+    (since &optional delay-edit-confirm rebase-merges)
   (let* ((commit (if (string-suffix-p "^" since)
                      ;; If SINCE is "REV^", then the user selected
                      ;; "REV", which is the first commit that will
@@ -611,7 +614,8 @@ START has to be selected from a list of recent commits."
           (concat m1 "%i public branches" m2)
           nil branches))
       (push (magit-toplevel) magit--rebase-public-edit-confirmed)))
-  (if (magit-git-lines "rev-list" "--merges" (concat since "..HEAD"))
+  (if (and (magit-git-lines "rev-list" "--merges" (concat since "..HEAD"))
+           (not rebase-merges))
       (magit-read-char-case "Proceed despite merge in rebase range?  " nil
         (?c "[c]ontinue" since)
         (?s "[s]elect other" nil)

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -467,6 +467,7 @@ This discards all changes made since the sequence started."
               (?A "Autostash"                "--autostash")
               (?i "Interactive"              "--interactive")
               (?h "Disable hooks"            "--no-verify"))
+  :options  '((?r "Rebase merges" "--rebase-merges=" magit-rebase-merges-select-mode))
   :actions  '((lambda ()
                 (concat (propertize "Rebase " 'face 'magit-popup-heading)
                         (propertize (or (magit-get-current-branch) "HEAD")
@@ -495,6 +496,11 @@ This discards all changes made since the sequence started."
 
 (defun magit-git-rebase (target args)
   (magit-run-git-sequencer "rebase" target args))
+
+(defun magit-rebase-merges-select-mode (&rest _ignore)
+  (magit-read-char-case nil t
+    (?n "[n]o-rebase-cousins" "no-rebase-cousins")
+    (?r "[r]ebase-cousins" "rebase-cousins")))
 
 ;;;###autoload
 (defun magit-rebase-onto-pushremote (args)


### PR DESCRIPTION
``git rebase --rebase-merges`` is a new mode to rebase merge commits properly, even with interactive rebase.  It adds three new commands, ``label``, ``reset``, and ``merge``.  The goal is to make it as easy and convenient to handle todo files generated by ``git rebase -ir`` as more traditional todo files without ``--rebase-merges`` (i.e. what exists today in magit).

This mode first came out in git 2.18, I hope it’s not a problem to advertise or support such recent features in magit.