### PR TITLE
Make magit-blame-echo actually echo the commit summary

### DIFF
--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -705,8 +705,7 @@ modes is toggled, then this mode also gets toggled automatically.
                                (gethash (oref (magit-current-blame-chunk)
                                               orig-rev)
                                         magit-blame-cache)))))
-          (progn (setq msg (substring msg 0 -1))
-                 (set-text-properties 0 (length msg) nil msg)
+          (progn (set-text-properties 0 (length msg) nil msg)
                  (message msg))
         (message "Commit data not available yet.  Still blaming.")))))
 

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -51,7 +51,8 @@
     (highlight
      (highlight-face   . magit-blame-highlight))
     (lines
-     (show-lines       . t)))
+     (show-lines       . t)
+     (show-message     . t)))
   "List of styles used to visualize blame information.
 
 Each entry has the form (IDENT (KEY . VALUE)...).  IDENT has
@@ -61,6 +62,9 @@ KEYs are recognized:
  `show-lines'
     Whether to prefix each chunk of lines with a thin line.
     This has no effect if `heading-format' is non-nil.
+ `show-message'
+    Whether to display a commit's summary line in the echo area
+    when crossing chunks.
  `highlight-face'
     Face used to highlight the first line of each chunk.
     If this is nil, then those lines are not highlighted.
@@ -697,7 +701,7 @@ modes is toggled, then this mode also gets toggled automatically.
 (defun magit-blame-maybe-show-message ()
   (when (magit-blame--style-get 'show-message)
     (let ((message-log-max 0))
-      (if-let ((msg (cdr (assq 'heading
+      (if-let ((msg (cdr (assoc "summary"
                                (gethash (oref (magit-current-blame-chunk)
                                               orig-rev)
                                         magit-blame-cache)))))


### PR DESCRIPTION
Hi!

`magit-blame-echo` never quite worked for me: I did get thin lines
separating chunks belonging to different commits, but no message in
the echo area.

I poked around `magit-blame.el` and found a few things that look like
impedance mismatches to me:

- `m-b-maybe-show-message` checks the current style for the
  `show-message` key, but `magit-blame-echo-style` is set to the
  `lines` visualization style, which only contains `show-lines`.

- `m-b-maybe-show-message` looks for the `'heading` symbol in the
  commit alist, but the keys returned by `m-b--commit-alist` are
  strings, the first of which is `"summary"`.

- `assq` uses `eq` to browse alists, which tests "Lisp
  object"-equality; to match on a string such as `"summary"`, one must
  use `assoc`, which uses `equal`.

This commit is pretty much "works-for-me", I didn't take the time to
consider the following issues:

- I don't know if it makes sense to shoehorn `(show-message . t)` in
  the `lines` style or if a new style should be created.

- I don't know if the alist should use symbols or strings.

- I might have misread the documentation and missed an obvious
  explanation as to why `magit-blame-echo` does not work
  out-of-the-box on my setups (Emacs 25.1, 26.1 and 27.0).

Maybe this commit is not usable as-is, in which case I should have
filed an issue instead.  On the off-chance that the commit is sound
enough, I figured a pull-request could work just as well…

Thank you for your time.
