### PR TITLE
enable signoff during merge

### DIFF
--- a/lisp/magit-merge.el
+++ b/lisp/magit-merge.el
@@ -40,8 +40,9 @@
 (magit-define-popup magit-merge-popup
   "Popup console for merge commands."
   :man-page "git-merge"
-  :switches '((?f "Fast-forward only" "--ff-only")
-              (?n "No fast-forward"   "--no-ff"))
+  :switches '((?f "Fast-forward only"      "--ff-only")
+              (?n "No fast-forward"        "--no-ff")
+              (?o "Add Signed-off-by line" "--signoff"))
   :options  '((?s "Strategy" "--strategy="))
   :actions  '((?m "Merge"                  magit-merge-plain)
               (?p "Preview merge"          magit-merge-preview)


### PR DESCRIPTION
 - git supports signoff during merge
 - signoff description copied from magit-commit.el
 - aligned the strings in the switches block
 - manually tested locally

The `strategy` key in merge is `s` and the `signoff` key in `commit` is `s`, so I used `o` from `signOff` in `merge`. This probably merits some discussion.

Is there a test somewhere I need to add to?
Is there a way to check that a specifically supported version of git is installed before showing this particular switch?
Is there a contributor agreement I should be aware of?