### PR TITLE
magit-insert-head-branch-header: Error on failed magit-rev-format

### DIFF
--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -449,6 +449,8 @@ the status buffer causes this section to disappear again."
 When BRANCH is nil, use the current branch or, if none, the
 detached `HEAD'."
   (let ((output (magit-rev-format "%h %s" (or branch "HEAD"))))
+    (unless output
+      (error "Magit: Failed to get header line"))
     (string-match "^\\([^ ]+\\) \\(.*\\)" output)
     (magit-bind-match-strings (commit summary) output
       (when (equal summary "")


### PR DESCRIPTION
Fixes #3444 and #3276 (kinda)

If a repo is corrupt, magit-rev-format will return nil, and
string-match will raise a type error. This is confusing, making it
sound like something went wrong with Magit, when the true issue is
more dire. The error message in this commit is vague, but it at least
hints that something has gone wrong at the Git level. I don't think
it's possible to get any more specific while remaining unobtrusive.