### PR TITLE
Unconditionally initialize fringe bitmaps

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -1123,7 +1123,7 @@ the %s(1) manpage.
 
 ;;; Bitmaps
 
-(when (window-system)
+(when (fboundp 'define-fringe-bitmap)
   (define-fringe-bitmap 'magit-fringe-bitmap+
     [#b00000000
      #b00011000


### PR DESCRIPTION
This allows the bitmaps to be shown when emacs is started with `emacs --daemon` and a graphical emacsclient frame is later created.

(I realize this may not be the right solution, but figure it's simple enough that I might as well start by putting it out there.)