### PR TITLE
Add missing require for magit-gitignore

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -577,7 +577,8 @@ For X11 something like ~/.xinitrc should work.\n"
     (require 'magit-extras)
     (require 'git-rebase)
     (require 'magit-imenu)
-    (require 'magit-bookmark)))
+    (require 'magit-bookmark)
+    (require 'magit-gitignore)))
 
 (eval-after-load 'bookmark
   '(require 'magit-bookmark))


### PR DESCRIPTION
Without it, pressing "i" or "I" in magit-status shows an error message:

    Wrong type argument: commandp, magit-gitignore