### PR TITLE
Document how to set the fringe width for the visibility indicator

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -1108,9 +1108,17 @@ certain sections can also be overwritten using the hook
 
   - ~(EXPANDABLE-BITMAP . COLLAPSIBLE-BITMAP)~
 
-    Both values have to by variables whose values are fringe
+    Both values have to be variables whose values are fringe
     bitmaps.  In this case every section that can be expanded
     or collapsed gets an indicator in the left fringe.
+
+    To provide extra padding around the indicator, set
+    ~left-fringe-width~ in ~magit-mode-hook~, e.g.:
+
+    #+BEGIN_SRC emacs-lisp
+      (add-hook 'magit-mode-hook (lambda ()
+                                   (setq left-fringe-width 20)))
+    #+END_SRC
 
   - ~(STRING . BOOLEAN)~
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -171,9 +171,12 @@ Otherwise the value has to have one of these two forms:
 
 (EXPANDABLE-BITMAP . COLLAPSIBLE-BITMAP)
 
-  Both values have to by variables whose values are fringe
+  Both values have to be variables whose values are fringe
   bitmaps.  In this case every section that can be expanded or
   collapsed gets an indicator in the left fringe.
+
+  To provide extra padding around the indicator, set
+  `left-fringe-width' in `magit-mode-hook'.
 
 (STRING . BOOLEAN)
 


### PR DESCRIPTION
Closes #3726.

I've omitted the call to `set-window-buffer` which was suggested in https://github.com/magit/magit/pull/3679#issuecomment-441747653 on the basis that, so far as I can see experimentally, it's unnecessary in this case -- `magit-mode` and its derivatives are called before the buffer is displayed, so I believe there is no need to forcibly re-display the buffer at this point.