### PR TITLE
magit-diff.el: Inhibit buffer-list-update-hook in diff-hunk-region-patch routine.

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2878,10 +2878,11 @@ last (visual) lines of the region."
               ((equal op (match-string-no-properties 1))
                (push (concat " " (match-string-no-properties 2)) patch)))
         (forward-line)))
-    (with-temp-buffer
-      (insert (mapconcat 'identity (reverse patch) ""))
-      (diff-fixup-modifs (point-min) (point-max))
-      (setq patch (buffer-string)))
+    (let ((buffer-list-update-hook nil)) ; #3759
+      (with-temp-buffer
+        (insert (mapconcat #'identity (reverse patch) ""))
+        (diff-fixup-modifs (point-min) (point-max))
+        (setq patch (buffer-string))))
     patch))
 
 ;;; _


### PR DESCRIPTION
This change eliminates a strange feedback loop that occurs when buffer-list-update-hook is used to make a debounced (idle-timer based) call while a region is active in magit. See also the discussion in #3738.