### PR TITLE
Offer rev pointers as completion candidates

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -631,9 +631,7 @@ the upstream isn't ahead of the current branch) show."
 
 (defun magit-log-read-revs (&optional use-current)
   (or (and use-current (--when-let (magit-get-current-branch) (list it)))
-      (let ((collection `(,@(and (file-exists-p (magit-git-dir "FETCH_HEAD"))
-                                 (list "FETCH_HEAD"))
-                          ,@(magit-list-refnames))))
+      (let ((collection (magit-list-refnames nil t)))
         (split-string
          (magit-completing-read-multiple "Log rev,s" collection
                                          "\\(\\.\\.\\.?\\|[, ]\\)"


### PR DESCRIPTION
Requested in #3765.  Not sure this is the way to go.

We don't want to offer any pointers that don't actually exist, so we have to check whether the respective files exist.  There are more such pointers; anyone know of a complete list?

`FETCH_HEAD` and `ORIG_HEAD` actually aren't symbolic refs, which is why I used the term "pointer".  Any better names (including for the new function)?