### PR TITLE
magit-branch-delete: Don't abort when preserving PR remotes

### DIFF
--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -602,7 +602,8 @@ defaulting to the branch at point."
             (if (and (= (length refspecs) 1)
                      (magit-confirm 'delete-pr-remote
                        (format "Also delete remote %s (%s)" remote
-                               "no pull-request branch remains")))
+                               "no pull-request branch remains")
+                       nil t))
                 (magit-call-git "remote" "rm" remote)
               (magit-call-git "config" "--unset" variable
                               (regexp-quote refspec)))))))))


### PR DESCRIPTION
Currently if you delete the only local branch from a pull request remote, you are prompted to also delete the remote corresponding to that PR. However if you press `n` at this prompt, deletion of the branch is aborted. Solution: pass `t` as the value of the `noabort` parameter to `magit-confirm` for the prompt in question.

As an aside: at this point I've been using Magit daily for over five years. Thank you for the continued dedication and hard work put into this project.