### PR TITLE
Fix harmless typo in documentation: "turn of" => "turn off"

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-259-g0d59db318+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-275-g3e73ff19d+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-259-g0d59db318+1).
+This manual is for Magit version 2.90.1 (v2.90.1-275-g3e73ff19d+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -3572,7 +3572,7 @@ transient using the default binding.
 
 Note that not all of the following suffixes are available at all
 times.  For example if ~magit-blame-mode~ is not enabled, then the
-command whose purpose is to turn of that mode would not be of any
+command whose purpose is to turn off that mode would not be of any
 use and therefore isn't available.
 
 - Key: C-c M-g b, magit-blame-addition

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-259-g0d59db318+1)
+@subtitle for version 2.90.1 (v2.90.1-275-g3e73ff19d+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-259-g0d59db318+1).
+This manual is for Magit version 2.90.1 (v2.90.1-275-g3e73ff19d+1).
 
 @quotation
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -4868,7 +4868,7 @@ temporary buffer until a suffix is invoked.
 
 Note that not all of the following suffixes are available at all
 times.  For example if @code{magit-blame-mode} is not enabled, then the
-command whose purpose is to turn of that mode would not be of any
+command whose purpose is to turn off that mode would not be of any
 use and therefore isn't available.
 
 @table @asis


### PR DESCRIPTION
Fix harmless typo in documentation (magit.org): "turn of" => "turn off".