### PR TITLE
Log run time of section and header hooks

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -6978,6 +6978,10 @@ current buffer.
   (setq magit-refresh-status-buffer nil)
 #+END_SRC
 
+If showing the status buffer is slow, some of the information
+displayed can be disabled by removing hooks from
+~magit-status-headers-hook~ and ~magit-status-sections-hook~.
+
 You should also check whether any third-party packages have added
 anything to ~magit-refresh-buffer-hook~, ~magit-status-refresh-hook~,
 ~magit-pre-refresh-hook~, and ~magit-post-refresh-hook~.  If so, then

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -286,12 +286,6 @@ improve performance."
   :group 'magit-status
   :type 'boolean)
 
-(defcustom magit-refresh-verbose nil
-  "Whether to revert Magit buffers verbosely."
-  :package-version '(magit . "2.1.0")
-  :group 'magit-refresh
-  :type 'boolean)
-
 (defcustom magit-save-repository-buffers t
   "Whether to save file-visiting buffers when appropriate.
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -1626,7 +1626,8 @@ again use `remove-hook'."
     (dolist (entry entries)
       (let ((magit--current-section-hook (cons (list hook entry)
                                                magit--current-section-hook)))
-        (apply entry args)))))
+        (magit-time-it (format "section hook %S" entry)
+          (apply entry args))))))
 
 ;;; _
 (provide 'magit-section)

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -68,7 +68,8 @@ all."
              magit-insert-head-branch-header
              magit-insert-upstream-branch-header
              magit-insert-push-branch-header
-             magit-insert-tags-header))
+             magit-insert-tags-header)
+  :safe (lambda (val) (and (listp val) (cl-every 'symbolp val))))
 
 (defcustom magit-status-sections-hook
   '(magit-insert-status-headers
@@ -90,7 +91,8 @@ all."
   "Hook run to insert sections into a status buffer."
   :package-version '(magit . "2.12.0")
   :group 'magit-status
-  :type 'hook)
+  :type 'hook
+  :safe (lambda (val) (and (listp val) (cl-every 'symbolp val))))
 
 (defcustom magit-status-initial-section '(1)
   "The section point is placed on when a status buffer is created.

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -394,6 +394,12 @@ and delay of your graphical environment or operating system."
                  (const :tag "view manpage using `man'" man)
                  (const :tag "view manpage using `woman'" woman)))
 
+(defcustom magit-refresh-verbose nil
+  "Whether to revert Magit buffers verbosely."
+  :package-version '(magit . "2.1.0")
+  :group 'magit-refresh
+  :type 'boolean)
+
 ;;; User Input
 
 (defvar helm-completion-in-region-default-sort-fn)
@@ -1196,6 +1202,27 @@ FORMAT-STRING to be displayed, then don't."
 Like `message', except that `message-log-max' is bound to nil."
   (let ((message-log-max nil))
     (apply #'message format-string args)))
+
+
+(defmacro magit-time-it (nameform &rest codeform)
+  "Display messages tracking how long CODEFORM ran.
+Useful to debug slow parts of magit.  Displays a message before
+and after CODEFORM is run.
+
+Messages are only logged if `magit-refresh-verbose' is non-nil."
+  (declare (indent 1))
+  (let ((start (cl-gensym))
+        (res (cl-gensym))
+        (name (cl-gensym)))
+    `(let ((,start (current-time))
+           (,name ,nameform))
+       (when magit-refresh-verbose
+         (message "Magit running %-50.50s..." ,name))
+       (prog1 (progn ,@codeform)
+         (when magit-refresh-verbose
+           (message "Magit running %-50.50s...done (%.3fs)"
+                    ,name
+                    (float-time (time-subtract (current-time) ,start))))))))
 
 ;;; _
 (provide 'magit-utils)


### PR DESCRIPTION
I often work with large repos that make the status buffer take 6-8 seconds to render and despite reading the FAQ I couldn't figure out what was taking time.

The verbose mode only showed that refreshing the status buffer was taking time, which I already knew.

I measure run time of various parts of the refresh func and finally figured out that some of the default section hooks were taking a lot of time. When I wanted to edit those on a per-repo basis it turns out the hook lists are not local-safe.

This patchset adds:

* A macro help to convieniently measure run time of forms
* Replaces a couple of time measurements with the macro
* Makes the section/header hook lists local-safe
* Adds a little paragraph about it in the Performance section of the docs
