### PR TITLE
magit-push: Use -t for --follow-tags

### DIFF
--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -45,7 +45,7 @@
    ("-n" "Dry run"          ("-n" "--dry-run"))
    ("-u" "Set upstream"     "--set-upstream"
     :if-nil magit-remote-set-if-missing)
-   (7 "=t" "Follow tags" "--follow-tags")]
+   (7 "-t" "Follow tags" "--follow-tags")]
   [:if magit-get-current-branch
    :description (lambda ()
                   (format (propertize "Push %s to" 'face 'transient-heading)


### PR DESCRIPTION
I believe --follow-tags should have a `-` prefix and not `=` as it doesn't set an argument.