### PR TITLE
Require at least Git v2.2.0

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -1,6 +1,8 @@
 * Magit v2.91.0 Release Notes (unreleased)
 ** Breaking changes
 
+- Dropped support for Git v2.0 and v2.1.
+
 - After some users intervened I have decided to NOT drop support for
   Emacs 25 in this release as I had intended to do.  Emacs 25 should
   remain supported for at least a few more releases.

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -181,7 +181,7 @@ bisect run'."
       (magit-insert-heading "Bisect Rest:")
       (magit-git-wash (apply-partially 'magit-log-wash-log 'bisect-vis)
         "bisect" "visualize" "git" "log"
-        "--format=%h%d%x00%s" "--decorate=full"
+        "--format=%h%x00%D%x00%s" "--decorate=full"
         (and magit-bisect-show-graph "--graph")))))
 
 (defun magit-insert-bisect-log ()

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2051,13 +2051,8 @@ Staging and applying changes is documented in info node
   "Insert the diff into this `magit-revision-mode' buffer."
   (let ((magit-git-global-arguments
          (remove "--literal-pathspecs" magit-git-global-arguments)))
-    ;; Before v2.2.0, "--format=" did not mean "no output".
-    ;; Instead the default format was used.  So use "--format=%n"
-    ;; and then delete the empty lines.
-    (magit-git-wash (lambda (args)
-                      (delete-region (point) (progn (forward-line 3) (point)))
-                      (magit-diff-wash-diffs args))
-      "show" "-p" "--cc" "--format=%n" "--no-prefix"
+    (magit-git-wash #'magit-diff-wash-diffs
+      "show" "-p" "--cc" "--format=" "--no-prefix"
       (and (member "--stat" (nth 2 magit-refresh-args)) "--numstat")
       (nth 2 magit-refresh-args) (concat rev "^{commit}") "--"
       (nth 3 magit-refresh-args))))
@@ -2206,8 +2201,7 @@ or a ref which is not a branch, then it inserts nothing."
 (defun magit-insert-revision-headers (rev)
   "Insert headers about the commit into a revision buffer."
   (magit-insert-section (headers)
-    ;; Before v2.2.0, "%D" was not supported.
-    (--when-let (magit-rev-format "%d" rev "--decorate=full")
+    (--when-let (magit-rev-format "%D" rev "--decorate=full")
       (insert (magit-format-ref-labels it) ?\s))
     (insert (propertize (magit-rev-parse (concat rev "^{commit}"))
                         'face 'magit-hash))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1749,12 +1749,6 @@ In refs buffers the displayed text is controlled by other means
 and this option only controls what face is used.")
 
 (defun magit-format-ref-labels (string)
-  ;; To support Git <2.2.0, we remove the surrounding parentheses here
-  ;; rather than specifying that STRING should be generated with Git's
-  ;; "%D" placeholder.
-  (setq string (->> string
-                    (replace-regexp-in-string "\\`\\s-*(" "")
-                    (replace-regexp-in-string ")\\s-*\\'" "")))
   (save-match-data
     (let ((regexp "\\(, \\|tag: \\|HEAD -> \\)")
           names)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1009,12 +1009,12 @@ Do not add this to a hook variable."
          (remove "--literal-pathspecs" magit-git-global-arguments)))
     (magit-git-wash (apply-partially #'magit-log-wash-log 'log)
       "log"
-      (format "--format=%s%%h%s%%x00%s%%x00%%aN%%x00%%at%%x00%%s%s"
+      (format "--format=%s%%h%%x00%s%%x00%s%%x00%%aN%%x00%%at%%x00%%s%s"
               (if (and (member "--left-right" args)
                        (not (member "--graph" args)))
                   "%m "
                 "")
-              (if (member "--decorate" args) "%d" "")
+              (if (member "--decorate" args) "%D" "")
               (if (member "--show-signature" args)
                   (progn (setq args (remove "--show-signature" args)) "%G?")
                 "")
@@ -1050,8 +1050,8 @@ Do not add this to a hook variable."
 (defconst magit-log-heading-re
   (concat "^"
           "\\(?4:[-_/|\\*o<>. ]*\\)"               ; graph
-          "\\(?1:[0-9a-fA-F]+\\)"                  ; sha1
-          "\\(?3:[^\0\n]+)\\)?\0"                  ; refs
+          "\\(?1:[0-9a-fA-F]+\\)?\0"               ; sha1
+          "\\(?3:[^\0\n]+\\)?\0"                   ; refs
           "\\(?7:[BGUXYREN]\\)?\0"                 ; gpg
           "\\(?5:[^\0\n]*\\)\0"                    ; author
           ;; Note: Date is optional because, prior to Git v2.19.0,
@@ -1074,8 +1074,8 @@ Do not add this to a hook variable."
 (defconst magit-log-bisect-vis-re
   (concat "^"
           "\\(?4:[-_/|\\*o<>. ]*\\)"               ; graph
-          "\\(?1:[0-9a-fA-F]+\\)"                  ; sha1
-          "\\(?3:[^\0\n]+)\\)?\0"                  ; refs
+          "\\(?1:[0-9a-fA-F]+\\)?\0"               ; sha1
+          "\\(?3:[^\0\n]+\\)?\0"                   ; refs
           "\\(?2:.*\\)$"))                         ; msg
 
 (defconst magit-log-bisect-log-re

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -19,7 +19,7 @@
 ;; Keywords: git tools vc
 ;; Homepage: https://github.com/magit/magit
 
-;; Magit requires at least GNU Emacs 25.1 and Git 2.0.0.
+;; Magit requires at least GNU Emacs 25.1 and Git 2.2.0.
 
 ;; Magit is free software; you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
@@ -64,7 +64,7 @@
 (require 'format-spec)
 (require 'package nil t) ; used in `magit-version'
 
-(defconst magit--minimal-git "2.0.0")
+(defconst magit--minimal-git "2.2.0")
 (defconst magit--minimal-emacs "25.1")
 
 ;;; Faces


### PR DESCRIPTION
Git v2.2 was released more than four years ago.

I announced a long time ago that I would drop support even for
versions before v2.4.  I dropped support for versions before
v2.0 more than half a year ago and nobody complained about it.

Even Debian stable has v2.11 now, and while Debian oldstable
only has v2.1, v2.11 is available from jessie-backports.