### PR TITLE
diff: Add basic support for --color-moved

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -124,6 +124,10 @@ c47913461 * Rename magit-{push-current-set-remote => remote-set}-if-missing
 - New command ~git-rebase-break~ inserts a "break" action in the
   rebase to-do sequence (available as of Git v2.20).  #3762
 
+- The ~--color-moved~ diff argument is supported now, but isn't
+  available from the diff transients by default.  To enable it
+  use "C-x l" in those transients.  #3424
+
 ** Fixes since v2.90.0
 
 - Bumped the minimal required version of ~git-commit~ to the correct

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1696,14 +1696,12 @@ is set in `magit-mode-setup'."
 
 (defun magit-insert-diff (rev-or-range)
   "Insert the diff into this `magit-diff-mode' buffer."
-  (let ((magit-git-global-arguments
-         (remove "--literal-pathspecs" magit-git-global-arguments)))
-    (magit--insert-diff
-      "diff" rev-or-range "-p" "--no-prefix"
-      (and (member "--stat" (nth 2 magit-refresh-args)) "--numstat")
-      (nth 1 magit-refresh-args)
-      (nth 2 magit-refresh-args) "--"
-      (nth 3 magit-refresh-args))))
+  (magit--insert-diff
+    "diff" rev-or-range "-p" "--no-prefix"
+    (and (member "--stat" (nth 2 magit-refresh-args)) "--numstat")
+    (nth 1 magit-refresh-args)
+    (nth 2 magit-refresh-args) "--"
+    (nth 3 magit-refresh-args)))
 
 (defvar magit-file-section-map
   (let ((map (make-sparse-keymap)))
@@ -1756,7 +1754,9 @@ is set in `magit-mode-setup'."
 
 (defun magit--insert-diff (&rest args)
   (declare (indent 0))
-  (magit-git-wash #'magit-diff-wash-diffs args))
+  (let ((magit-git-global-arguments
+         (remove "--literal-pathspecs" magit-git-global-arguments)))
+    (magit-git-wash #'magit-diff-wash-diffs args)))
 
 (defun magit-diff-wash-diffs (args &optional limit)
   (when (member "--stat" args)
@@ -2053,13 +2053,11 @@ Staging and applying changes is documented in info node
 
 (defun magit-insert-revision-diff (rev)
   "Insert the diff into this `magit-revision-mode' buffer."
-  (let ((magit-git-global-arguments
-         (remove "--literal-pathspecs" magit-git-global-arguments)))
-    (magit--insert-diff
-      "show" "-p" "--cc" "--format=" "--no-prefix"
-      (and (member "--stat" (nth 2 magit-refresh-args)) "--numstat")
-      (nth 2 magit-refresh-args) (concat rev "^{commit}") "--"
-      (nth 3 magit-refresh-args))))
+  (magit--insert-diff
+    "show" "-p" "--cc" "--format=" "--no-prefix"
+    (and (member "--stat" (nth 2 magit-refresh-args)) "--numstat")
+    (nth 2 magit-refresh-args) (concat rev "^{commit}") "--"
+    (nth 3 magit-refresh-args)))
 
 (defun magit-insert-revision-tag (rev)
   "Insert tag message and headers into a revision buffer.

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1698,7 +1698,7 @@ is set in `magit-mode-setup'."
   "Insert the diff into this `magit-diff-mode' buffer."
   (let ((magit-git-global-arguments
          (remove "--literal-pathspecs" magit-git-global-arguments)))
-    (magit-git-wash #'magit-diff-wash-diffs
+    (magit--insert-diff
       "diff" rev-or-range "-p" "--no-prefix"
       (and (member "--stat" (nth 2 magit-refresh-args)) "--numstat")
       (nth 1 magit-refresh-args)
@@ -1753,6 +1753,10 @@ is set in `magit-mode-setup'."
           "\\([0-9]+\\|Bin\\(?: +[0-9]+ -> [0-9]+ bytes\\)?$\\) ?"
           "\\(\\+*\\)"   ; add
           "\\(-*\\)$"))  ; del
+
+(defun magit--insert-diff (&rest args)
+  (declare (indent 0))
+  (magit-git-wash #'magit-diff-wash-diffs args))
 
 (defun magit-diff-wash-diffs (args &optional limit)
   (when (member "--stat" args)
@@ -2051,7 +2055,7 @@ Staging and applying changes is documented in info node
   "Insert the diff into this `magit-revision-mode' buffer."
   (let ((magit-git-global-arguments
          (remove "--literal-pathspecs" magit-git-global-arguments)))
-    (magit-git-wash #'magit-diff-wash-diffs
+    (magit--insert-diff
       "show" "-p" "--cc" "--format=" "--no-prefix"
       (and (member "--stat" (nth 2 magit-refresh-args)) "--numstat")
       (nth 2 magit-refresh-args) (concat rev "^{commit}") "--"
@@ -2334,7 +2338,7 @@ or a ref which is not a branch, then it inserts nothing."
   "Insert section showing unstaged changes."
   (magit-insert-section (unstaged)
     (magit-insert-heading "Unstaged changes:")
-    (magit-git-wash #'magit-diff-wash-diffs
+    (magit--insert-diff
       "diff" magit-diff-section-arguments "--no-prefix"
       "--" magit-diff-section-file-args)))
 
@@ -2356,7 +2360,7 @@ or a ref which is not a branch, then it inserts nothing."
   (unless (magit-bare-repo-p)
     (magit-insert-section (staged)
       (magit-insert-heading "Staged changes:")
-      (magit-git-wash #'magit-diff-wash-diffs
+      (magit--insert-diff
         "diff" "--cached" magit-diff-section-arguments "--no-prefix"
         "--" magit-diff-section-file-args))))
 

--- a/lisp/magit-merge.el
+++ b/lisp/magit-merge.el
@@ -212,7 +212,7 @@ then also remove the respective remote branch."
                                           rev
                                           (or branch "HEAD")))
     (magit-insert-section (diffbuf)
-      (magit-git-wash #'magit-diff-wash-diffs
+      (magit--insert-diff
         "merge-tree" (magit-git-string "merge-base" head rev) head rev))))
 
 ;;;###autoload

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -456,7 +456,7 @@ instead of \"Stashes:\"."
 (defun magit-stash-insert-section (commit range message &optional files)
   (magit-insert-section (commit commit)
     (magit-insert-heading message)
-    (magit-git-wash #'magit-diff-wash-diffs
+    (magit--insert-diff
       "diff" range "-p" "--no-prefix"
       (nth 2 magit-refresh-args)
       "--" (or files (nth 3 magit-refresh-args)))))


### PR DESCRIPTION
The infix argument is on level 5 of the diff transients for now.  It
has to be made available by the user for each transient using "C-x l".

For now the colors specified in `ansi-color-map` are used.