### PR TITLE
magit-dispatch: Add Cherries

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -250,6 +250,7 @@ and/or `magit-branch-remote-head'."
     ("W" "Format patches" magit-patch)
     ("X" "Reset"          magit-reset)]
    [("y" "Show Refs"      magit-show-refs)
+    ("Y" "Cherries"       magit-cherry)
     ("z" "Stash"          magit-stash)
     ("!" "Run"            magit-run)
     ("%" "Worktree"       magit-worktree)]]


### PR DESCRIPTION
The key `Y` (`magit-cherry`) is bound in the magit status buffer, but not the dispatch transient. It is applicable to both scenarios. I often find my self going `c-x M-g Y` only to have it tell me that it is unbound. Seems it should be made available. 
