### PR TITLE
magit-revision-filter-files-on-follow: New option

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -128,6 +128,11 @@ c47913461 * Rename magit-{push-current-set-remote => remote-set}-if-missing
   available from the diff transients by default.  To enable it
   use "C-x l" in those transients.  #3424
 
+- Added new option ~magit-revision-filter-files-on-follow~ that
+  controls whether a revision buffer shown from a log shares the log's
+  file restriction despite ~--follow~ being in the log arguments.
+  #3680
+
 ** Fixes since v2.90.0
 
 - Bumped the minimal required version of ~git-commit~ to the correct

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-319-g4e4f6203+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-324-g3200eecc+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-319-g4e4f6203+1).
+This manual is for Magit version 2.90.1 (v2.90.1-324-g3200eecc+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -3122,10 +3122,21 @@ The diffs shown in the revision buffer may be automatically restricted
 to a subset of the changed files.  If the revision buffer is displayed
 from a log buffer, the revision buffer will share the same file
 restriction as that log buffer (also see the command
-~magit-diff-toggle-file-filter~).  Note, however, that the log's file
-restriction will be ignored when ~magit-log-arguments~ includes
-~--follow~.  In this case, the ~--patch~ argument of the log transient
-can be used to show the file-restricted diffs inline.
+~magit-diff-toggle-file-filter~).
+
+- User Option: magit-revision-filter-files-on-follow
+
+  Whether showing a commit from a log buffer honors the log's file
+  filter when the log arguments include ~--follow~.
+
+  When this option is nil, displaying a commit from a log ignores the
+  log's file filter if the log arguments include ~--follow~.  Doing so
+  avoids showing an empty diff in revision buffers for commits before
+  a rename event.  In such cases, the ~--patch~ argument of the log
+  transient can be used to show the file-restricted diffs inline.
+
+  Set this option to non-nil to keep the log's file restriction even
+  if ~--follow~ is present in the log arguments.
 
 If the revision buffer is not displayed from a log buffer, the file
 restriction is determined by the file restriction in the repository's

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-319-g4e4f6203+1)
+@subtitle for version 2.90.1 (v2.90.1-324-g3200eecc+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-319-g4e4f6203+1).
+This manual is for Magit version 2.90.1 (v2.90.1-324-g3200eecc+1).
 
 @quotation
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -4253,10 +4253,22 @@ The diffs shown in the revision buffer may be automatically restricted
 to a subset of the changed files.  If the revision buffer is displayed
 from a log buffer, the revision buffer will share the same file
 restriction as that log buffer (also see the command
-@code{magit-diff-toggle-file-filter}).  Note, however, that the log's file
-restriction will be ignored when @code{magit-log-arguments} includes
-@code{--follow}.  In this case, the @code{--patch} argument of the log transient
-can be used to show the file-restricted diffs inline.
+@code{magit-diff-toggle-file-filter}).
+
+@defopt magit-revision-filter-files-on-follow
+
+Whether showing a commit from a log buffer honors the log's file
+filter when the log arguments include @code{--follow}.
+
+When this option is nil, displaying a commit from a log ignores the
+log's file filter if the log arguments include @code{--follow}.  Doing so
+avoids showing an empty diff in revision buffers for commits before
+a rename event.  In such cases, the @code{--patch} argument of the log
+transient can be used to show the file-restricted diffs inline.
+
+Set this option to non-nil to keep the log's file restriction even
+if @code{--follow} is present in the log arguments.
+@end defopt
 
 If the revision buffer is not displayed from a log buffer, the file
 restriction is determined by the file restriction in the repository's

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -455,6 +455,24 @@ a good reason to include a long line in the body sometimes."
   :type '(choice (const   :tag "Don't fill" nil)
                  (integer :tag "Fill if longer than")))
 
+(defcustom magit-revision-filter-files-on-follow nil
+  "Whether to honor file filter if log arguments include --follow.
+
+When a commit is displayed from a log buffer, the resulting
+revision buffer usually shares the log's file arguments,
+restricting the diff to those files.  However, there's a
+complication when the log arguments include --follow: if the log
+follows a file across a rename event, keeping the file
+restriction would mean showing an empty diff in revision buffers
+for commits before the rename event.
+
+When this option is nil, the revision buffer ignores the log's
+filter if the log arguments include --follow.  If non-nil, the
+log's file filter is always honored."
+  :package-version '(magit . "2.91.0")
+  :group 'magit-revision
+  :type 'boolean)
+
 ;;;; Diff Sections
 
 (defcustom magit-diff-section-arguments '("--no-ext-diff")
@@ -1103,7 +1121,9 @@ be committed."
 (defun magit-show-commit--arguments ()
   (pcase-let ((`(,args ,diff-files) (magit-diff-arguments)))
     (list args (if (derived-mode-p 'magit-log-mode)
-                   (and (not (member "--follow" (nth 1 magit-refresh-args)))
+                   (and (or magit-revision-filter-files-on-follow
+                            (not (member "--follow"
+                                         (nth 1 magit-refresh-args))))
                         (nth 2 magit-refresh-args))
                  diff-files))))
 


### PR DESCRIPTION
Let the user configure which ugliness they prefer when showing a
commit from a log that uses --follow: empty diffs or ignoring the
log's file restriction.

Closes #3680.