### PR TITLE
diff: Support --color-moved-ws

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -704,7 +704,8 @@ and `:slant'."
    (magit-diff:-C)
    ("-x" "Disallow external diff drivers" "--no-ext-diff")
    ("-s" "Show stats"                     "--stat")
-   (5 magit-diff:--color-moved)]
+   (5 magit-diff:--color-moved)
+   (5 magit-diff:--color-moved-ws)]
   ["Actions"
    [("d" "Dwim"          magit-diff-dwim)
     ("r" "Diff range"    magit-diff-range)
@@ -735,7 +736,8 @@ and `:slant'."
    ("-x" "Disallow external diff drivers" "--no-ext-diff")
    ("-s" "Show stats"                     "--stat"
     :if-derived magit-diff-mode)
-   (5 magit-diff:--color-moved)]
+   (5 magit-diff:--color-moved)
+   (5 magit-diff:--color-moved-ws)]
   ["Actions"
    [("g" "Refresh"                magit-diff-do-refresh)
     ("s" "Set defaults"           magit-diff-set-default-arguments)
@@ -877,6 +879,21 @@ and `:slant'."
     (?b "[b]locks"  "blocks")
     (?z "[z]ebra"   "zebra")
     (?Z "[Z] dimmed-zebra" "dimmed-zebra")))
+
+(define-infix-argument magit-diff:--color-moved-ws ()
+  :description "Whitespace treatment for --color-moved"
+  :class 'transient-option
+  :key "=w"
+  :argument "--color-moved-ws="
+  :reader 'magit-diff-select-color-moved-ws-mode)
+
+(defun magit-diff-select-color-moved-ws-mode (&rest _ignore)
+  (magit-read-char-case "Ignore whitespace " t
+    (?i "[i]ndentation"  "allow-indentation-change")
+    (?e "[e]nd of line"  "ignore-space-at-eol")
+    (?s "[s]pace change" "ignore-space-change")
+    (?a "[a]ll space"    "ignore-all-space")
+    (?n "[n]o"           "no")))
 
 ;;;; Diff commands
 


### PR DESCRIPTION
The diff transients gained --color-moved in 9d0e65ee (diff: Add basic
support for --color-moved, 2019-03-08).  Add the related option
--color-moved-ws.  This option, particularly its mode
allow-indentation-change, increases the number of scenarios where
--color-moved is useful.

--color-moved-ws accepts a comma-separated list of modes, so we could
read these with magit-completing-read-multiple.  But there aren't
many (if any) useful combinations, so let's instead define the reader
with the more convenient magit-read-char-case.