### PR TITLE
magit-delete-remote-branch-sentinel: Decrease false positives

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -216,3 +216,7 @@ c47913461 * Rename magit-{push-current-set-remote => remote-set}-if-missing
 
 - In newer Git versions the rebase list shown in the status buffer
   could contain duplicated entries for the current commit.  1e1cd0e28
+
+- When deleting a remote branch failed, the logic for deciding whether
+  to prune the local remote-tracking ref was too loose, leading to
+  false positives.  #3650


### PR DESCRIPTION
When deleting a remote ref fails, we fall back to removing the local
remote-tracking ref because a common reason for the push to fail is
that the ref no longer exist on the remote.  But it may fail for other
reasons (e.g., can't connect to the remote or a non-zero exit of the
pre-receive hook), and we shouldn't remove the local tracking ref in
these cases.

One way to tighten the check would be to search the process buffer for
"unable to delete 'BRANCH': does not exist".  (We'd need to search for
each ref with a tailored message because we wouldn't want to remove
the remote-tracking refs for multiple refs when the push failed
because one ref does not exist.)  This method relies on the message
being stable and wouldn't work for some users because that message is
marked for translation.

Instead reach out to the remote to get a list of its branches, and
check the ref against this list.  Doing so adds an expense, but it
seems like an acceptable one given that the check is performed only on
failure and that it replaces cases where the user would need to
manually call 'git fetch --prune REMOTE' to clean up otherwise.

Although not strictly necessary, narrow the check to the specific
error code that we expect to see for the "no longer exists" failure.
The exit code for a failed connection is different, so this avoids
trying to connect to the remote with magit-remote-list-branches when
the push already failed to connect.

Fixes #3650.