### PR TITLE
Fix typo in `magit-cherry-pick:--mainline`

### DIFF
--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -164,7 +164,7 @@ This discards all changes made since the sequence started."
   :class 'transient-option
   :shortarg "-m"
   :argument "--mainline="
-  :reader 'transient-read-natural-number-N+)
+  :reader 'transient-read-number-N+)
 
 (defun magit-cherry-pick-read-args (prompt)
   (list (or (nreverse (magit-region-values 'commit))


### PR DESCRIPTION
The transient library doesn't have a function called `transient-read-natural-number-N+`.  This seems to be a typo for `transient-read-number-N+`, which does exist, and makes `A - m` work as expected rather than suddenly closing the transient.