### PR TITLE
fix spinoff/spinout shortcuts

### DIFF
--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -218,11 +218,11 @@ has to be used to view and change branch related variables."
     (6 "o" "new orphan"      magit-branch-orphan)]
    [""
     ("c" "new branch"        magit-branch-and-checkout)
-    ("s" "new spin-out"      magit-branch-spinout)
+    ("s" "new spin-off"      magit-branch-spinoff)
     (5 "w" "new worktree"    magit-worktree-checkout)]
    ["Create"
     ("n" "new branch"        magit-branch-create)
-    ("S" "new spin-off"      magit-branch-spinoff)
+    ("S" "new spin-out"      magit-branch-spinout)
     (5 "W" "new worktree"    magit-worktree-branch)]
    ["Do"
     ("C" "configure..."      magit-branch-configure)


### PR DESCRIPTION
This PR fixes the `spin-off` and `spin-out` shortcut.
As stated in the manual since the [`spin-out` command](https://github.com/magit/magit/commit/b10bf92a2e5d2f7443656c482b27d58b49f3be9f#diff-67c0d4a7440114596845f478f8ed4877R4436), the shortcut should be `b S`, but [this commit](https://github.com/magit/magit/commit/b10bf92a2e5d2f7443656c482b27d58b49f3be9f#diff-7cd00c1c77155001edfa4602112b9195R217) overwrite the `b s` command which was previously used for `spin-off`.

I noticed this behavior by trying to `spin-off`with `b s` after having upgraded my Magit (the branch was not checked out).

I've also moved the `spin-out` command in the `Create` column. 