### PR TITLE
Fixing git error while trying to stash

### DIFF
--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -299,7 +299,7 @@ branch or `HEAD' as the string-point."
           (unless (eq keep t)
             (if (eq keep 'index)
                 (magit-call-git "checkout" "--" ".")
-              (magit-call-git "reset" "--hard" "HEAD"))
+              (magit-call-git "reset" "--hard" "HEAD" "--"))
             (when untracked
               (magit-call-git "clean" "--force" "-d"
                               (and (eq untracked 'all) "-x")))))

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -653,7 +653,7 @@ These sections can be expanded to show the respective commits."
   (with-temp-file (expand-file-name ".git" worktree)
     (insert "gitdir: " (file-relative-name gitdir worktree) "\n"))
   (let ((default-directory worktree))
-    (magit-call-git "reset" "--hard" "HEAD")))
+    (magit-call-git "reset" "--hard" "HEAD" "--")))
 
 ;;; _
 (provide 'magit-submodule)


### PR DESCRIPTION
Hello!
I recently started getting errors from git when trying to make stash(Magit shortcut: **z z**):

```
128 git … reset --hard HEAD
fatal: ambiguous argument 'HEAD': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

My PR is  attempt to fix this.
I'm not a sophisticated git user, so comments and corrections are welcome.