### PR TITLE
Improve handling of upstream and push-remote

### DIFF
--- a/lisp/magit-fetch.el
+++ b/lisp/magit-fetch.el
@@ -82,20 +82,24 @@ the push-remote can be changed before fetching from it."
       (magit-git-fetch remote args))))
 
 ;;;###autoload (autoload 'magit-fetch-from-upstream "magit-fetch" nil t)
-(define-suffix-command magit-fetch-from-upstream (args &optional set)
-  "Fetch from the upstream repository of the current branch.
+(define-suffix-command magit-fetch-from-upstream (remote args)
+  "Fetch from the \"current\" remote, usually the upstream.
 
-When `magit-remote-set-if-missing' is non-nil and
-the upstream is not configured, then read the upstream from
-the user, set it, and then fetch from it.  With a prefix argument
-the upstream can be changed before fetching from it."
-  :if 'magit--upstream-suffix-predicate
-  :description 'magit--upstream-suffix-description
-  (interactive (list (magit-fetch-arguments)
-                     (magit--transfer-maybe-read-upstream "fetch from")))
-  (magit--transfer-upstream set
-    (lambda (_ upstream)
-      (magit-git-fetch (car (magit-split-branch-name upstream)) args))))
+If the upstream is configured for the current branch and names
+an existing remote, then use that.  Otherwise try to use another
+remote: If only a single remote is configured, then use that.
+Otherwise if a remote named \"origin\" exists, then use that.
+
+If no remote can be determined, then this command is not available
+from the `magit-fetch' transient prefix and invoking it directly
+results in an error."
+  :if          (lambda () (magit-get-current-remote t))
+  :description (lambda () (magit-get-current-remote t))
+  (interactive (list (magit-get-current-remote t)
+                     (magit-fetch-arguments)))
+  (unless remote
+    (error "The \"current\" remote could not be determined"))
+  (magit-git-fetch remote args))
 
 ;;;###autoload
 (defun magit-fetch-other (remote args)

--- a/lisp/magit-fetch.el
+++ b/lisp/magit-fetch.el
@@ -69,11 +69,9 @@ Ignored for Git versions before v2.8.0."
 (define-suffix-command magit-fetch-from-pushremote (args &optional set)
   "Fetch from the push-remote of the current branch.
 
-When `magit-remote-set-if-missing' is non-nil and
-the push-remote is not configured, then read the push-remote from
-the user, set it, and then fetch from it.  With a prefix argument
-the push-remote can be changed before fetching from it."
-  :if 'magit--pushbranch-suffix-predicate
+When the push-remote is not configured, then read the push-remote
+from the user, set it, and then fetch from it.  With a prefix
+argument the push-remote can be changed before fetching from it."
   :description 'magit--pushbranch-suffix-description
   (interactive (list (magit-fetch-arguments)
                      (magit--transfer-maybe-read-pushremote "fetch from")))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1355,10 +1355,11 @@ according to the branch type.  LAX is for internal use only."
 
 (defun magit-get-current-remote (&optional allow-unnamed)
   (or (magit-get-upstream-remote nil allow-unnamed)
-      (let ((remotes (magit-list-remotes)))
-        (if (= (length remotes) 1)
-            (car remotes)
-          (car (member "origin" remotes))))))
+      (when-let ((remotes (magit-list-remotes))
+                 (remote (if (= (length remotes) 1)
+                             (car remotes)
+                           (car (member "origin" remotes)))))
+        (propertize remote 'face 'magit-branch-remote))))
 
 (defun magit-get-push-remote (&optional branch)
   (when-let ((remote

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1368,6 +1368,11 @@ according to the branch type.  LAX is for internal use only."
   (and remote (string-match-p "\\(\\`\\.\\{0,2\\}/\\|[:@]\\)" remote)
        merge  (string-prefix-p "refs/" merge)))
 
+(defun magit--valid-upstream-p (remote merge)
+  (and (or (equal remote ".")
+           (member remote (magit-list-remotes)))
+       (string-prefix-p "refs/" merge)))
+
 (defun magit-get-current-remote (&optional allow-unnamed)
   (or (magit-get-upstream-remote nil allow-unnamed)
       (when-let ((remotes (magit-list-remotes))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1281,6 +1281,9 @@ The amount of time spent searching is limited by
     prev))
 
 (defun magit-set-upstream-branch (branch upstream)
+  "Set UPSTREAM as the upstream of BRANCH.
+If UPSTREAM is nil, then unset BRANCH's upstream.
+Otherwise UPSTREAM has to be an existing branch."
   (if upstream
       (magit-call-git "branch" "--set-upstream-to" upstream branch)
     (magit-call-git "branch" "--unset-upstream" branch)))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1298,34 +1298,20 @@ remote-tracking branch ref."
   (when-let ((branch (or branch (magit-get-current-branch))))
     (magit-ref-fullname (concat branch "@{upstream}"))))
 
-(defun magit-get-upstream-branch (&optional branch lax)
+(defun magit-get-upstream-branch (&optional branch)
   "Return the name of the upstream branch of BRANCH.
 It BRANCH is nil, then return the upstream of the current branch
 if any, nil otherwise.  If the upstream is not configured, the
 configured remote is an url, or the named branch does not exist,
 then return nil.  I.e.  return the name of an existing local or
 remote-tracking branch.  The returned string is colorized
-according to the branch type.  LAX is for internal use only."
-  (when-let ((branch (or branch (magit-get-current-branch))))
-    (if-let ((upstream (magit-ref-abbrev (concat branch "@{upstream}"))))
-        (propertize upstream 'face
-                    (if (equal (magit-get "branch" branch "remote") ".")
-                        'magit-branch-local
-                      'magit-branch-remote))
-      (and lax
-           (when-let ((remote (magit-get "branch" branch "remote"))
-                      (merge  (magit-get "branch" branch "merge")))
-             (and (string-prefix-p "refs/heads/" merge)
-                  (let ((upstream (substring merge 11)))
-                    (cond ((string-equal remote ".")
-                           (propertize upstream 'face 'magit-branch-local))
-                          ((string-match-p "[@:]" remote)
-                           (list remote
-                                 (propertize upstream
-                                             'face 'magit-branch-remote)))
-                          (t
-                           (propertize (concat remote "/" upstream)
-                                       'face 'magit-branch-remote))))))))))
+according to the branch type."
+  (when-let ((branch (or branch (magit-get-current-branch)))
+             (upstream (magit-ref-abbrev (concat branch "@{upstream}"))))
+    (propertize upstream 'face
+                (if (equal (magit-get "branch" branch "remote") ".")
+                    'magit-branch-local
+                  'magit-branch-remote))))
 
 (defun magit-get-indirect-upstream-branch (branch &optional force)
   (let ((remote (magit-get "branch" branch "remote")))
@@ -1460,7 +1446,6 @@ the name of a remote and REF is the ref local to the remote."
 (defun magit-split-branch-name (branch)
   (cond ((member branch (magit-list-local-branch-names))
          (cons "." branch))
-        ((consp branch) branch)
         ((string-match "/" branch)
          (or (-some (lambda (remote)
                       (and (string-match (format "\\`\\(%s\\)/\\(.+\\)\\'" remote)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1343,11 +1343,15 @@ according to the branch type.  LAX is for internal use only."
                 (magit-rev-ancestor-p upstream branch)
                 upstream)))))
 
-(defun magit-get-upstream-remote (&optional branch non-local)
+(defun magit-get-upstream-remote (&optional branch allow-unnamed)
   (when-let ((branch (or branch (magit-get-current-branch)))
              (remote (magit-get "branch" branch "remote")))
-    (and (not (and non-local (equal remote ".")))
-         (propertize remote 'face 'magit-branch-remote))))
+    (and (not (equal remote "."))
+         (cond ((member remote (magit-list-remotes))
+                (propertize remote 'face 'magit-branch-remote))
+               ((and allow-unnamed
+                     (string-match-p "\\(\\`.\\{0,2\\}/\\|[:@]\\)" remote))
+                (propertize remote 'face 'bold))))))
 
 (defun magit-get-current-remote ()
   (or (magit-get-upstream-remote nil t)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1353,8 +1353,8 @@ according to the branch type.  LAX is for internal use only."
                      (string-match-p "\\(\\`.\\{0,2\\}/\\|[:@]\\)" remote))
                 (propertize remote 'face 'bold))))))
 
-(defun magit-get-current-remote ()
-  (or (magit-get-upstream-remote nil t)
+(defun magit-get-current-remote (&optional allow-unnamed)
+  (or (magit-get-upstream-remote nil allow-unnamed)
       (let ((remotes (magit-list-remotes)))
         (if (= (length remotes) 1)
             (car remotes)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1303,13 +1303,15 @@ The amount of time spent searching is limited by
                       (cond ((string-equal remote ".")
                              (propertize upstream 'face 'magit-branch-local))
                             ((string-match-p "[@:]" remote)
-                             (propertize (concat remote " " upstream)
-                                         'face 'magit-branch-remote))
+                             (list remote
+                                   (propertize upstream
+                                               'face 'magit-branch-remote)))
                             (t
                              (propertize (concat remote "/" upstream)
                                          'face 'magit-branch-remote)))))
                 (and (or (not verify)
-                         (magit-rev-verify upstream))
+                         (and (stringp upstream)
+                              (magit-rev-verify upstream)))
                      upstream))))))
 
 (defun magit-get-indirect-upstream-branch (branch &optional force)
@@ -1403,9 +1405,7 @@ as into its upstream."
 (defun magit-split-branch-name (branch)
   (cond ((member branch (magit-list-local-branch-names))
          (cons "." branch))
-        ((string-match " " branch)
-         (pcase-let ((`(,url ,branch) (split-string branch " ")))
-           (cons url branch)))
+        ((consp branch) branch)
         ((string-match "/" branch)
          (or (-some (lambda (remote)
                       (and (string-match (format "\\`\\(%s\\)/\\(.+\\)\\'" remote)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -2099,15 +2099,18 @@ and this option only controls what face is used.")
                                (magit-get-previous-branch)
                                (car atrev)))))
 
-(defun magit-read-upstream-branch (&optional branch prompt)
+(defun magit-read-upstream-branch (&optional branch prompt allow-missing)
   (unless branch
     (setq branch (or (magit-get-current-branch)
                      (error "Need a branch to set its upstream"))))
   (magit-completing-read
    (or prompt (format "Change upstream of %s to" branch))
-   (-union (--map (concat it "/" branch)
-                  (magit-list-remotes))
-           (delete branch (magit-list-branch-names)))
+   (let ((branches (delete branch (magit-list-branch-names))))
+     (if allow-missing
+         (-union (--map (concat it "/" branch)
+                        (magit-list-remotes))
+                 branches)
+       branches))
    nil nil nil 'magit-revision-history
    (or (let ((r (magit-remote-branch-at-point))
              (l (magit-branch-at-point)))
@@ -2117,6 +2120,9 @@ and this option only controls what face is used.")
        (let ((r (magit-branch-p "origin/master"))
              (l (and (not (equal branch "master"))
                      (magit-branch-p "master"))))
+         (unless allow-missing
+           (unless (magit-branch-p r) (setq r nil))
+           (unless (magit-branch-p l) (setq l nil)))
          (if magit-prefer-remote-upstream (or r l) (or l r)))
        (let ((previous (magit-get-previous-branch)))
          (and (not (equal previous branch)) previous)))))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1353,6 +1353,18 @@ according to the branch type.  LAX is for internal use only."
                      (string-match-p "\\(\\`.\\{0,2\\}/\\|[:@]\\)" remote))
                 (propertize remote 'face 'bold))))))
 
+(defun magit-get-unnamed-upstream (&optional branch)
+  (when-let ((branch (or branch (magit-get-current-branch)))
+             (remote (magit-get "branch" branch "remote"))
+             (merge  (magit-get "branch" branch "merge")))
+    (and (magit--unnamed-upstream-p remote merge)
+         (list (propertize remote 'face 'bold)
+               (propertize merge  'face 'magit-branch-remote)))))
+
+(defun magit--unnamed-upstream-p (remote merge)
+  (and remote (string-match-p "\\(\\`\\.\\{0,2\\}/\\|[:@]\\)" remote)
+       merge  (string-prefix-p "refs/" merge)))
+
 (defun magit-get-current-remote (&optional allow-unnamed)
   (or (magit-get-upstream-remote nil allow-unnamed)
       (when-let ((remotes (magit-list-remotes))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -2113,7 +2113,7 @@ and this option only controls what face is used.")
        branches))
    nil nil nil 'magit-revision-history
    (or (let ((r (magit-remote-branch-at-point))
-             (l (magit-branch-at-point)))
+             (l (magit-local-branch-at-point)))
          (when (and l (equal l branch))
            (setq l nil))
          (if magit-prefer-remote-upstream (or r l) (or l r)))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1709,7 +1709,7 @@ configured or if the upstream is not behind of the current branch,
 then show the last `magit-log-section-commit-count' commits."
   (let ((upstream (magit-get-upstream-branch)))
     (if (or (not upstream)
-            (string-match-p " " upstream)
+            (consp upstream)
             (magit-rev-ancestor-p "HEAD" upstream))
         (magit-insert-recent-commits 'unpushed "@{upstream}..")
       (magit-insert-unpushed-to-upstream))))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -33,9 +33,9 @@
 (require 'magit-diff)
 
 (declare-function magit-blob-visit "magit-files" (blob-or-file line))
-(declare-function magit--insert-head-branch-header "magit-status"
+(declare-function magit-insert-head-branch-header "magit-status"
                   (&optional branch))
-(declare-function magit--insert-upstream-branch-header "magit-status"
+(declare-function magit-insert-upstream-branch-header "magit-status"
                   (&optional branch pull keyword))
 (declare-function magit-read-file-from-rev "magit-files"
                   (rev prompt &optional default))
@@ -1570,10 +1570,10 @@ Type \\[magit-cherry-pick] to apply the commit at point.
 
 (defun magit-insert-cherry-headers ()
   "Insert headers appropriate for `magit-cherry-mode' buffers."
-  (magit--insert-head-branch-header (nth 1 magit-refresh-args))
-  (magit--insert-upstream-branch-header (nth 1 magit-refresh-args)
-                                        (nth 0 magit-refresh-args)
-                                        "Upstream: ")
+  (magit-insert-head-branch-header (nth 1 magit-refresh-args))
+  (magit-insert-upstream-branch-header (nth 1 magit-refresh-args)
+                                       (nth 0 magit-refresh-args)
+                                       "Upstream: ")
   (insert ?\n))
 
 (defun magit-insert-cherry-commits ()

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1665,7 +1665,7 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
 
 (defun magit-insert-unpulled-from-upstream ()
   "Insert commits that haven't been pulled from the upstream yet."
-  (when-let ((upstream (magit-get-upstream-branch nil t)))
+  (when-let ((upstream (magit-get-upstream-branch)))
     (magit-insert-section (unpulled "..@{upstream}" t)
       (magit-insert-heading
         (format (propertize "Unpulled from %s:" 'face 'magit-section-heading)
@@ -1709,7 +1709,6 @@ configured or if the upstream is not behind of the current branch,
 then show the last `magit-log-section-commit-count' commits."
   (let ((upstream (magit-get-upstream-branch)))
     (if (or (not upstream)
-            (consp upstream)
             (magit-rev-ancestor-p "HEAD" upstream))
         (magit-insert-recent-commits 'unpushed "@{upstream}..")
       (magit-insert-unpushed-to-upstream))))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1570,11 +1570,16 @@ Type \\[magit-cherry-pick] to apply the commit at point.
 
 (defun magit-insert-cherry-headers ()
   "Insert headers appropriate for `magit-cherry-mode' buffers."
-  (magit-insert-head-branch-header (nth 1 magit-refresh-args))
-  (magit-insert-upstream-branch-header (nth 1 magit-refresh-args)
-                                       (nth 0 magit-refresh-args)
-                                       "Upstream: ")
-  (insert ?\n))
+  (let* ((branch (propertize (cadr magit-refresh-args) 'face
+                             'magit-branch-local))
+         (upstream (car magit-refresh-args))
+         (upstream (propertize upstream 'face
+                               (if (magit-local-branch-p upstream)
+                                   'magit-branch-local
+                                 'magit-branch-remote))))
+    (magit-insert-head-branch-header branch)
+    (magit-insert-upstream-branch-header branch upstream "Upstream: ")
+    (insert ?\n)))
 
 (defun magit-insert-cherry-commits ()
   "Insert commit sections into a `magit-cherry-mode' buffer."

--- a/lisp/magit-obsolete.el
+++ b/lisp/magit-obsolete.el
@@ -37,9 +37,6 @@
 (define-obsolete-function-alias 'magit-dispatch-popup
   'magit-dispatch "Magit 2.91.0")
 
-(define-obsolete-variable-alias 'magit-push-current-set-remote-if-missing
-  'magit-remote-set-if-missing "Magit 2.91.0")
-
 (defun magit--magit-popup-warning ()
   (display-warning 'magit "\
 Magit no longer uses Magit-Popup.

--- a/lisp/magit-pull.el
+++ b/lisp/magit-pull.el
@@ -75,12 +75,6 @@
 (defun magit-pull-arguments ()
   (transient-args 'magit-pull))
 
-(defun magit-git-pull (source args)
-  (run-hooks 'magit-credential-hook)
-  (pcase-let ((`(,remote . ,branch)
-               (magit-split-branch-name source)))
-    (magit-run-git-with-editor "pull" args remote branch)))
-
 ;;;###autoload (autoload 'magit-pull-from-pushremote "magit-pull" nil t)
 (define-suffix-command magit-pull-from-pushremote (args)
   "Pull from the push-remote of the current branch.
@@ -159,7 +153,10 @@ the upstream."
   "Pull from a branch read in the minibuffer."
   (interactive (list (magit-read-remote-branch "Pull" nil nil nil t)
                      (magit-pull-arguments)))
-  (magit-git-pull source args))
+  (run-hooks 'magit-credential-hook)
+  (pcase-let ((`(,remote . ,branch)
+               (magit-get-tracked source)))
+    (magit-run-git-with-editor "pull" args remote branch)))
 
 ;;; _
 (provide 'magit-pull)

--- a/lisp/magit-pull.el
+++ b/lisp/magit-pull.el
@@ -85,11 +85,10 @@
 (define-suffix-command magit-pull-from-pushremote (args &optional set)
   "Pull from the push-remote of the current branch.
 
-When `magit-remote-set-if-missing' is non-nil and
-the push-remote is not configured, then read the push-remote from
-the user, set it, and then pull from it.  With a prefix argument
-the push-remote can be changed before pulling from it."
-  :if 'magit--pushbranch-suffix-predicate
+When the push-remote is not configured, then read the push-remote
+from the user, set it, and then pull from it.  With a prefix
+argument the push-remote can be changed before pulling from it."
+  :if 'magit-get-current-branch
   :description 'magit--pushbranch-suffix-description
   (interactive (list (magit-pull-arguments)
                      (magit--transfer-maybe-read-pushremote "pull from")))
@@ -101,11 +100,10 @@ the push-remote can be changed before pulling from it."
 (define-suffix-command magit-pull-from-upstream (args &optional set)
   "Pull from the upstream of the current branch.
 
-When `magit-remote-set-if-missing' is non-nil and
-the upstream is not configured, then read the upstream from
+When the upstream is not configured, then read the upstream from
 the user, set it, and then pull from it.  With a prefix argument
 the upstream can be changed before pulling from it."
-  :if 'magit--upstream-suffix-predicate
+  :if 'magit-get-current-branch
   :description 'magit--upstream-suffix-description
   (interactive (list (magit-pull-arguments)
                      (magit--transfer-maybe-read-upstream "pull from")))

--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -67,10 +67,14 @@
 
 (defun magit-git-push (branch target args)
   (run-hooks 'magit-credential-hook)
-  (pcase-let ((`(,remote . ,target)
+  ;; If the remote branch already exists, then we do not have to
+  ;; qualify the target, which we prefer to avoid doing because
+  ;; using the default namespace is wrong in obscure cases.
+  (pcase-let ((namespace (if (magit-get-tracked target) "" "refs/heads/"))
+              (`(,remote . ,target)
                (magit-split-branch-name target)))
     (magit-run-git-async "push" "-v" args remote
-                         (format "%s:refs/heads/%s" branch target))))
+                         (format "%s:%s%s" branch namespace target))))
 
 ;;;###autoload (autoload 'magit-push-current-to-pushremote "magit-push" nil t)
 (define-suffix-command magit-push-current-to-pushremote (args)

--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -99,8 +99,17 @@ user, set it, and then push to it.  With a prefix argument the
 upstream can be changed before pushed to it."
   :if 'magit--upstream-suffix-predicate
   :description (lambda () (magit--upstream-suffix-description t))
-  (interactive (list (magit-push-arguments)
-                     (magit--transfer-maybe-read-upstream "push")))
+  (interactive
+   (list (magit-push-arguments)
+         (and (magit--transfer-set-upstream-p current-prefix-arg)
+              (let ((branches (-union (--map (concat it "/" branch)
+                                             (magit-list-remotes))
+                                      (magit-list-remote-branch-names))))
+                (magit-completing-read
+                 "Set upstream and push there"
+                 branches nil nil nil 'magit-revision-history
+                 (or (car (member (magit-remote-branch-at-point) branches))
+                     (car (member "origin/master" branches))))))))
   (magit--transfer-upstream set
     (lambda (current upstream)
       (magit-git-push current upstream args))))

--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -43,9 +43,8 @@
    ("-F" "Force"            ("-f" "--force"))
    ("-h" "Disable hooks"    "--no-verify")
    ("-n" "Dry run"          ("-n" "--dry-run"))
-   ("-u" "Set upstream"     "--set-upstream"
-    :if-nil magit-remote-set-if-missing)
-   (7 "-t" "Follow tags" "--follow-tags")]
+   (5 "-u" "Set upstream"   "--set-upstream")
+   (7 "-t" "Follow tags"    "--follow-tags")]
   [:if magit-get-current-branch
    :description (lambda ()
                   (format (propertize "Push %s to" 'face 'transient-heading)
@@ -77,11 +76,10 @@
 (define-suffix-command magit-push-current-to-pushremote (args &optional set)
   "Push the current branch to its push-remote.
 
-When `magit-remote-set-if-missing' is non-nil and
-the push-remote is not configured, then read the push-remote from
-the user, set it, and then push to it.  With a prefix argument
-the push-remote can be changed before pushed to it."
-  :if 'magit--pushbranch-suffix-predicate
+When the push-remote is not configured, then read the push-remote
+from the user, set it, and then push to it.  With a prefix
+argument the push-remote can be changed before pushed to it."
+  :if 'magit-get-current-branch
   :description (lambda () (magit--pushbranch-suffix-description t))
   (interactive (list (magit-push-arguments)
                      (magit--transfer-maybe-read-pushremote "push")))
@@ -93,11 +91,10 @@ the push-remote can be changed before pushed to it."
 (define-suffix-command magit-push-current-to-upstream (args &optional set)
   "Push the current branch to its upstream branch.
 
-When `magit-remote-set-if-missing' is non-nil and
-the upstream is not configured, then read the upstream from the
-user, set it, and then push to it.  With a prefix argument the
-upstream can be changed before pushed to it."
-  :if 'magit--upstream-suffix-predicate
+When the upstream is not configured, then read the upstream from
+the user, set it, and then push to it.  With a prefix argument
+the upstream can be changed before pushed to it."
+  :if 'magit-get-current-branch
   :description (lambda () (magit--upstream-suffix-description t))
   (interactive
    (list (magit-push-arguments)

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -417,7 +417,10 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
 
 (defun magit--upstream-suffix-description (&optional pushp)
   (if-let ((upstream (magit-get-upstream-branch)))
-      (cond ((magit-rev-verify upstream) upstream)
+      (cond ((consp upstream)
+             (pcase-let ((`(,url ,ref) upstream))
+               (insert ref " from " (propertize url 'face 'bold) " ")))
+            ((magit-rev-verify upstream) upstream)
             (pushp (concat upstream ", creating it"))
             ;; This shouldn't happen often and even if it does, then
             ;; transfering would still succeed iff the branch exists

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -394,7 +394,7 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
       (progn
         (when upstream
           (magit-set-upstream-branch current upstream))
-        (if-let ((upstream (or upstream (magit-get-upstream-branch current))))
+        (if-let ((upstream (or upstream (magit-get-upstream-branch current t))))
             (funcall fn current upstream)
           (user-error "No upstream is configured for %s" current)))
     (user-error "No branch is checked out")))
@@ -403,7 +403,7 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
   (when-let ((current (magit-get-current-branch)))
     (or change
         (and magit-remote-set-if-missing
-             (not (magit-get-upstream-branch current))))))
+             (not (magit-get-upstream-branch current t))))))
 
 (defun magit--transfer-maybe-read-upstream (action)
   (and (magit--transfer-set-upstream-p current-prefix-arg)
@@ -412,11 +412,11 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
 
 (defun magit--upstream-suffix-predicate ()
   (when-let ((current (magit-get-current-branch)))
-    (or (magit-get-upstream-branch current)
+    (or (magit-get-upstream-branch current t)
         magit-remote-set-if-missing)))
 
 (defun magit--upstream-suffix-description (&optional pushp)
-  (if-let ((upstream (magit-get-upstream-branch)))
+  (if-let ((upstream (magit-get-upstream-branch nil t)))
       (cond ((consp upstream)
              (pcase-let ((`(,url ,ref) upstream))
                (insert ref " from " (propertize url 'face 'bold) " ")))

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -312,7 +312,6 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
   :choices '("--no-tags" "--tags"))
 
 ;;; Transfer Utilities
-;;;; Push-Remote
 
 (defun magit--push-remote-variable (&optional branch short)
   (unless branch
@@ -358,42 +357,6 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
            (concat (magit--push-remote-variable branch)
                    ", after setting that")))))
 
-;;;; Upstream
-
-(defun magit--transfer-upstream (upstream fn)
-  (declare (indent defun))
-  (if-let ((current (magit-get-current-branch)))
-      (progn
-        (when upstream
-          (magit-set-upstream-branch current upstream))
-        (if-let ((upstream (or upstream (magit-get-upstream-branch current t))))
-            (funcall fn current upstream)
-          (user-error "No upstream is configured for %s" current)))
-    (user-error "No branch is checked out")))
-
-(defun magit--transfer-set-upstream-p (&optional change)
-  (when-let ((current (magit-get-current-branch)))
-    (or change (not (magit-get-upstream-branch current t)))))
-
-(defun magit--transfer-maybe-read-upstream (action)
-  (and (magit--transfer-set-upstream-p current-prefix-arg)
-       (magit-read-upstream-branch
-        nil (format "Set upstream and %s there" action))))
-
-(defun magit--upstream-suffix-description (&optional pushp)
-  (if-let ((upstream (magit-get-upstream-branch nil t)))
-      (cond ((consp upstream)
-             (pcase-let ((`(,url ,ref) upstream))
-               (insert ref " from " (propertize url 'face 'bold) " ")))
-            ((magit-rev-verify upstream) upstream)
-            (pushp (concat upstream ", creating it"))
-            ;; This shouldn't happen often and even if it does, then
-            ;; transfering would still succeed iff the branch exists
-            ;; on the remote (only the tracking branch is missing).
-            (t (concat upstream ", which appears to be missing")))
-    (and (magit--transfer-set-upstream-p)
-         (concat (propertize "@{upstream}" 'face 'bold)
-                 ", after setting that"))))
 
 ;;; _
 (provide 'magit-remote)

--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -213,7 +213,7 @@ Only one letter is shown, the first that applies."
 
 (defun magit-repolist-column-unpulled-from-upstream (_id)
   "Insert number of upstream commits not in the current branch."
-  (--when-let (magit-get-upstream-branch nil t)
+  (--when-let (magit-get-upstream-branch)
     (let ((n (cadr (magit-rev-diff-count "HEAD" it))))
       (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
 
@@ -225,7 +225,7 @@ Only one letter is shown, the first that applies."
 
 (defun magit-repolist-column-unpushed-to-upstream (_id)
   "Insert number of commits in the current branch but not its upstream."
-  (--when-let (magit-get-upstream-branch nil t)
+  (--when-let (magit-get-upstream-branch)
     (let ((n (car (magit-rev-diff-count "HEAD" it))))
       (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
 

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -547,11 +547,11 @@ This discards all changes made since the sequence started."
 (define-suffix-command magit-rebase-onto-pushremote (args &optional set)
   "Rebase the current branch onto its push-remote branch.
 
-When `magit-remote-set-if-missing' is non-nil and
-the push-remote is not configured, then read the push-remote from
-the user, set it, and then rebase onto it.  With a prefix argument
-the push-remote can be changed before rebasing onto to it."
-  :if 'magit--pushbranch-suffix-predicate
+When the push-remote is not configured, then read the push-remote
+from the user, set it, and then rebase onto it.  With a prefix
+argument the push-remote can be changed before rebasing onto to
+it."
+  :if 'magit-get-current-branch
   :description 'magit--pushbranch-suffix-description
   (interactive (list (magit-rebase-arguments)
                      (magit--transfer-maybe-read-pushremote "rebase onto")))
@@ -563,11 +563,10 @@ the push-remote can be changed before rebasing onto to it."
 (define-suffix-command magit-rebase-onto-upstream (args &optional set)
   "Rebase the current branch onto its upstream branch.
 
-When `magit-remote-set-if-missing' is non-nil and
-the upstream is not configured, then read the upstream from the
-user, set it, and then rebase onto it.  With a prefix argument
-the upstream can be changed before rebasing onto it."
-  :if 'magit--upstream-suffix-predicate
+When the upstream is not configured, then read the upstream from
+the user, set it, and then rebase onto it.  With a prefix
+argument the upstream can be changed before rebasing onto it."
+  :if 'magit-get-current-branch
   :description 'magit--upstream-suffix-description
   (interactive (list (magit-rebase-arguments)
                      (magit--transfer-maybe-read-upstream "rebase onto")))

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -544,7 +544,7 @@ This discards all changes made since the sequence started."
   (magit-run-git-sequencer "rebase" args target))
 
 ;;;###autoload (autoload 'magit-rebase-onto-pushremote "magit-sequence" nil t)
-(define-suffix-command magit-rebase-onto-pushremote (args &optional set)
+(define-suffix-command magit-rebase-onto-pushremote (args)
   "Rebase the current branch onto its push-remote branch.
 
 When the push-remote is not configured, then read the push-remote
@@ -552,12 +552,11 @@ from the user, set it, and then rebase onto it.  With a prefix
 argument the push-remote can be changed before rebasing onto to
 it."
   :if 'magit-get-current-branch
-  :description 'magit--pushbranch-suffix-description
-  (interactive (list (magit-rebase-arguments)
-                     (magit--transfer-maybe-read-pushremote "rebase onto")))
-  (magit--transfer-pushremote set
-    (lambda (_ __ remote/branch)
-      (magit-git-rebase remote/branch args))))
+  :description 'magit-pull--pushbranch-description
+  (interactive (list (magit-rebase-arguments)))
+  (pcase-let ((`(,branch ,remote)
+               (magit--select-push-remote "rebase onto that")))
+    (magit-git-rebase (concat remote "/" branch) args)))
 
 ;;;###autoload (autoload 'magit-rebase-onto-upstream "magit-sequence" nil t)
 (define-suffix-command magit-rebase-onto-upstream (args)

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -478,25 +478,25 @@ detached `HEAD'."
                            (magit-get-unnamed-upstream branch))))
     (magit--insert-upstream-branch-header branch upstream)))
 
-(defun magit--insert-upstream-branch-header (branch pull &optional keyword)
-  (magit-insert-section (branch pull)
+(defun magit--insert-upstream-branch-header (branch upstream &optional keyword)
+  (magit-insert-section (branch upstream)
     (let ((rebase (magit-get "branch" branch "rebase")))
       (pcase rebase
         ("true")
         ("false" (setq rebase nil))
         (_       (setq rebase (magit-get-boolean "pull.rebase"))))
       (insert (format "%-10s" (or keyword (if rebase "Rebase: " "Merge: ")))))
-    (if (consp pull)
-        (pcase-let ((`(,url ,ref) pull))
+    (if (consp upstream)
+        (pcase-let ((`(,url ,ref) upstream))
           (insert ref " from " (propertize url 'face 'bold) " "))
       (when-let ((hash (and magit-status-show-hashes-in-headers
-                            (magit-rev-format "%h" pull))))
+                            (magit-rev-format "%h" upstream))))
         (insert (propertize hash 'face 'magit-hash) " "))
-      (insert pull " ")
-      (if (magit-rev-verify pull)
-          (insert (funcall magit-log-format-message-function pull
+      (insert upstream " ")
+      (if (magit-rev-verify upstream)
+          (insert (funcall magit-log-format-message-function upstream
                            (funcall magit-log-format-message-function nil
-                                    (or (magit-rev-format "%s" pull)
+                                    (or (magit-rev-format "%s" upstream)
                                         "(no commit message)"))))
         (insert (propertize "is missing" 'face 'font-lock-warning-face))))
     (insert ?\n)))

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -499,21 +499,20 @@ arguments are for internal use only."
           (insert (propertize "is missing" 'face 'font-lock-warning-face))))
       (insert ?\n))))
 
-(cl-defun magit-insert-push-branch-header
-    (&optional (branch (magit-get-current-branch))
-               (push   (magit-get-push-branch branch)))
+(defun magit-insert-push-branch-header ()
   "Insert a header line about the branch the current branch is pushed to."
-  (when push
-    (magit-insert-section (branch push)
+  (when-let ((branch (magit-get-current-branch))
+             (target (magit-get-push-branch branch)))
+    (magit-insert-section (branch target)
       (insert (format "%-10s" "Push: "))
       (--when-let (and magit-status-show-hashes-in-headers
-                       (magit-rev-format "%h" push))
+                       (magit-rev-format "%h" target))
         (insert (propertize it 'face 'magit-hash) ?\s))
-      (insert (propertize push 'face 'magit-branch-remote) ?\s)
-      (if (magit-rev-verify push)
-          (insert (funcall magit-log-format-message-function push
+      (insert (propertize target 'face 'magit-branch-remote) ?\s)
+      (if (magit-rev-verify target)
+          (insert (funcall magit-log-format-message-function target
                            (funcall magit-log-format-message-function nil
-                                    (or (magit-rev-format "%s" push)
+                                    (or (magit-rev-format "%s" target)
                                         "(no commit message)"))))
         (insert (propertize "is missing" 'face 'font-lock-warning-face)))
       (insert ?\n))))

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -485,9 +485,9 @@ detached `HEAD'."
         ("false" (setq rebase nil))
         (_       (setq rebase (magit-get-boolean "pull.rebase"))))
       (insert (format "%-10s" (or keyword (if rebase "Rebase: " "Merge: ")))))
-    (if (string-match-p " " pull)
-        (pcase-let ((`(,url ,branch) (split-string pull " ")))
-          (insert branch " from " url " "))
+    (if (consp pull)
+        (pcase-let ((`(,url ,ref) pull))
+          (insert ref " from " (propertize url 'face 'bold) " "))
       (when-let ((hash (and magit-status-show-hashes-in-headers
                             (magit-rev-format "%h" pull))))
         (insert (propertize hash 'face 'magit-hash) " "))

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -444,9 +444,9 @@ the status buffer causes this section to disappear again."
 ;;;; Reference Headers
 
 (defun magit-insert-head-branch-header (&optional branch)
-  "Insert a header line about BRANCH.
-When BRANCH is nil, use the current branch or, if none, the
-detached `HEAD'."
+  "Insert a header line about the current branch.
+If `HEAD' is detached, then insert information about that commit
+instead.  The optional BRANCH argument is for internal use only."
   (let ((branch (or branch (magit-get-current-branch)))
         (output (magit-rev-format "%h %s" (or branch "HEAD"))))
     (string-match "^\\([^ ]+\\) \\(.*\\)" output)
@@ -470,7 +470,9 @@ detached `HEAD'."
           (insert ?\n))))))
 
 (defun magit-insert-upstream-branch-header (&optional branch upstream keyword)
-  "Insert a header line about branch usually pulled into current branch."
+  "Insert a header line about the upstream of the current branch.
+If no branch is checked out, then insert nothing.  The optional
+arguments are for internal use only."
   (when-let ((branch (or branch (magit-get-current-branch)))
              (upstream (or upstream
                            (magit-get-upstream-branch branch)

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -474,7 +474,8 @@ detached `HEAD'."
 (defun magit-insert-upstream-branch-header ()
   "Insert a header line about branch usually pulled into current branch."
   (when-let ((branch (magit-get-current-branch))
-             (upstream (magit-get-upstream-branch branch t)))
+             (upstream (or (magit-get-upstream-branch branch)
+                           (magit-get-unnamed-upstream branch))))
     (magit--insert-upstream-branch-header branch upstream)))
 
 (defun magit--insert-upstream-branch-header (branch pull &optional keyword)

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -474,7 +474,7 @@ detached `HEAD'."
 (defun magit-insert-upstream-branch-header ()
   "Insert a header line about branch usually pulled into current branch."
   (when-let ((branch (magit-get-current-branch))
-             (upstream (magit-get-upstream-branch branch)))
+             (upstream (magit-get-upstream-branch branch t)))
     (magit--insert-upstream-branch-header branch upstream)))
 
 (defun magit--insert-upstream-branch-header (branch pull &optional keyword)


### PR DESCRIPTION
The most important user visible changes are:

* `b u` can only be used to select an existing branch as the upstream. `p u` has to be used to push to a new remote upstream.

* The headers about the upstream and push-remote in the status buffer now display more information when these remotes are not completely usable, explaining why that is so.

* The descriptions of "configure upstream/push-remote before operating on it" are more informative now when the remotes are not completely usable, but not as informative as the status buffer headers.

* Only `p u` "push to upstream" can be used to create a configured but so far non-existent upstream/push-remote. All other commands that can "configure upstream/push-remote before operating on it" can now only use a branch that is known to exist.

* `f u` now falls back to operate on the only remote or the remote named "origin" if the upstream is not configured. It can no longer be used to configure the upstream.