### PR TITLE
Fix magit-status "Merge:" header commit+ref order

### DIFF
--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -485,11 +485,11 @@ arguments are for internal use only."
         (insert (format "%-10s" (or keyword (if rebase "Rebase: " "Merge: "))))
         (insert
          (if-let ((upstream (or upstream (magit-get-upstream-branch branch))))
-             (concat upstream " "
-                     (and magit-status-show-hashes-in-headers
+             (concat (and magit-status-show-hashes-in-headers
                           (concat (propertize (magit-rev-format "%h" upstream)
                                               'face 'magit-hash)
                                   " "))
+                     upstream " "
                      (funcall magit-log-format-message-function upstream
                               (funcall magit-log-format-message-function nil
                                        (or (magit-rev-format "%s" upstream)


### PR DESCRIPTION
To be consistent with the "Head:" ordering when `magit-status-show-hashes-in-headers` is enabled (seems to have happened in 86c095ab)

Before:
![image](https://user-images.githubusercontent.com/179915/55436312-2bfd9480-5559-11e9-994f-3cad5757e4c6.png)

After:
![image](https://user-images.githubusercontent.com/179915/55436517-c362e780-5559-11e9-9a2a-d0c5af8a79b1.png)

Haven't looked into adding a regression test yet but I can if necessary.