### PR TITLE
git-rebase-mode-show-keybindings: Get bindings from mode map

### DIFF
--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -781,7 +781,8 @@ By default, this is the same except for the \"pick\" command."
                (format "%-8s"
                        (mapconcat #'key-description
                                   (--remove (eq (elt it 0) 'menu-bar)
-                                            (reverse (where-is-internal cmd)))
+                                            (reverse (where-is-internal
+                                                      cmd git-rebase-mode-map)))
                                   ", "))
                t t nil 2))))))))
 


### PR DESCRIPTION
I noticed that the lower lines of the rebase buffer (which showed the keybindings for pick, reword, edit, squash, fixup, and exec) almost always had a strikethrough with no keybinding, even though the key worked in the buffer. I started investigating and it seemed pretty weird-- when I edebugged `git-rebase-mode-show-keybindings` and watched it populate the buffer, it worked just fine and all the bindings were there, but then when I tried to rebase without edebug again they would be crossed out again.

Eventually, this behavior bagan to make sense to me when I carefully read the docstring of `where-is-internal`. For its second argument, which is optional, the docstring reads:

```
If KEYMAP is a keymap, search only KEYMAP and the global keymap.
If KEYMAP is nil, search all the currently active keymaps, except
 for ‘overriding-local-map’ (which is ignored).
If KEYMAP is a list of keymaps, search only those keymaps.
```

So I think what's happening is that when the hooks are run for `git-rebase-mode` (including `git-rebase-show-keybindings`, the rebase buffer isn't reliably in a user-facing window, and when this happens the keybindings aren't visible (the mode map isn't "active" according to the docstring above). Passing in `git-rebase-mode-map` directly here, as this commit does, seems to fix this.