### PR TITLE
Added keywords for pkg file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,8 @@ define set_package_requires
      (dash ,dash-version)
      (git-commit ,git-commit-version)
      (transient ,transient-version)
-     (with-editor ,with-editor-version)))))
+     (with-editor ,with-editor-version))
+   :keywords '("git" "tools" "vc")))) ;'
   (goto-char (point-min))
   (re-search-forward " \"A")
   (goto-char (match-beginning 0))

--- a/lisp/magit-pkg.el
+++ b/lisp/magit-pkg.el
@@ -5,4 +5,6 @@
     (dash "20180910")
     (git-commit "20181104")
     (transient "0")
-    (with-editor "20181103")))
+    (with-editor "20181103"))
+  :keywords
+  '("git" "tools" "vc"))


### PR DESCRIPTION
make bump-version will now add 
``` lisp
  :keywords
  '("git" "tools" "vc")
```
to `lisp/magit-pkg.el`