### PR TITLE
magit-worktree-branch: Fix bug where start-point is ignored

### DIFF
--- a/lisp/magit-worktree.el
+++ b/lisp/magit-worktree.el
@@ -57,7 +57,7 @@
   "Create a new BRANCH and check it out in a new worktree at PATH."
   (interactive
    `(,(read-directory-name "Create worktree: ")
-     ,@(butlast (magit-branch-read-args "Create and checkout branch"))
+     ,@(magit-branch-read-args "Create and checkout branch")
      ,current-prefix-arg))
   (magit-run-git "worktree" "add" (if force "-B" "-b")
                  branch (expand-file-name path) start-point)


### PR DESCRIPTION
If `magit-worktree-branch` is called interactively, it will read a `start-point` but ignore it. Instead it will use the current branch. This PR fixes that.  