### PR TITLE
make magit-mode compatible with whitespace-mode

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -249,6 +249,10 @@
   now also kills all other Magit buffers associated with the current
   repository.  #3863
 
+- Magit buffers are now compatible with ~whitespace-mode~ (and other
+  modes which use font lock).  #3840
+
+
 ** Fixes since v2.90.0
 
 - Bumped the minimal required version of ~git-commit~ to the correct

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -187,7 +187,7 @@ bisect run'."
                              (and bad-line (match-string 1 bad-line)))
         (magit-insert-heading
           (propertize (or bad-line (pop lines))
-                      'face 'magit-section-heading))
+                      'font-lock-face 'magit-section-heading))
         (dolist (line lines)
           (insert line "\n"))))
     (insert "\n")))
@@ -220,7 +220,8 @@ bisect run'."
           (narrow-to-region beg (point))
           (goto-char (point-min))
           (magit-insert-section (bisect-item heading t)
-            (insert (propertize heading 'face 'magit-section-secondary-heading))
+            (insert (propertize heading 'font-lock-face
+                                'magit-section-secondary-heading))
             (magit-insert-heading)
             (magit-wash-sequence
              (apply-partially 'magit-log-wash-rev 'bisect-log

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -622,7 +622,7 @@ modes is toggled, then this mode also gets toggled automatically.
           magit-blame-separator))))
 
 (defun magit-blame--update-highlight-overlay (ov)
-  (overlay-put ov 'face (magit-blame--style-get 'highlight-face)))
+  (overlay-put ov 'font-lock-face (magit-blame--style-get 'highlight-face)))
 
 (defun magit-blame--format-string (ov format face)
   (let* ((chunk   (overlay-get ov 'magit-blame-chunk))
@@ -643,15 +643,15 @@ modes is toggled, then this mode also gets toggled automatically.
              (propertize (concat (if (string-prefix-p "\s" format) "\s" "")
                                  "Not Yet Committed"
                                  (if (string-suffix-p "\n" format) "\n" ""))
-                         'face face)
+                         'font-lock-face face)
            (magit--format-spec
-            (propertize format 'face face)
+            (propertize format 'font-lock-face face)
             (cl-flet* ((p0 (s f)
-                           (propertize s 'face (if face
-                                                   (if (listp face)
-                                                       face
-                                                     (list f face))
-                                                 f)))
+                           (propertize s 'font-lock-face (if face
+                                                             (if (listp face)
+                                                                 face
+                                                               (list f face))
+                                                           f)))
                        (p1 (k f)
                            (p0 (cdr (assoc k revinfo)) f))
                        (p2 (k1 k2 f)
@@ -670,15 +670,16 @@ modes is toggled, then this mode also gets toggled automatically.
                          (magit-blame--style-get 'margin-width))))
         (concat str
                 (propertize (make-string (max 0 (- width (length str))) ?\s)
-                            'face face))
+                            'font-lock-face face))
       str)))
 
 (defun magit-blame--format-separator ()
   (propertize
    (concat (propertize "\s" 'display '(space :height (2)))
            (propertize "\n" 'line-height t))
-   'face (list :background
-               (face-attribute 'magit-blame-heading :background nil t))))
+   'font-lock-face (list :background
+                         (face-attribute 'magit-blame-heading :background
+                                         nil t))))
 
 (defun magit-blame--format-time-string (time tz)
   (let* ((time-format (or (magit-blame--style-get 'time-format)

--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -759,8 +759,9 @@ and also rename the respective reflog file."
   [:description
    (lambda ()
      (concat
-      (propertize "Configure " 'face 'transient-heading)
-      (propertize (oref transient--prefix scope) 'face 'magit-branch-local)))
+      (propertize "Configure " 'font-lock-face 'transient-heading)
+      (propertize (oref transient--prefix scope)
+                  'font-lock-face 'magit-branch-local)))
    ("d"   magit-branch.<branch>.description)
    ("u"   magit-branch.<branch>.merge/remote)
    ("r"   magit-branch.<branch>.rebase)
@@ -838,8 +839,8 @@ and also rename the respective reflog file."
 
 (cl-defmethod transient-format-value ((obj magit--git-branch:upstream) key)
   (if-let ((value (funcall key (oref obj value))))
-      (propertize value 'face 'transient-argument)
-    (propertize "unset" 'face 'transient-inactive-argument)))
+      (propertize value 'font-lock-face 'transient-argument)
+    (propertize "unset" 'font-lock-face 'transient-inactive-argument)))
 
 (define-infix-command magit-branch.<branch>.rebase ()
   :class 'magit--git-variable:choices

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1920,7 +1920,7 @@ section or a child thereof."
       (magit-delete-match)
       (goto-char beg)
       (magit-insert-section (diffstat)
-        (insert (propertize heading 'face 'magit-diff-file-heading))
+        (insert (propertize heading 'font-lock-face 'magit-diff-file-heading))
         (magit-insert-heading)
         (let (files)
           (while (looking-at "^[-0-9]+\t[-0-9]+\t\\(.+\\)$")
@@ -1944,11 +1944,14 @@ section or a child thereof."
                 (when (> le ld)
                   (setq sep (concat (make-string (- le ld) ?\s) sep))))
               (magit-insert-section (file (pop files))
-                (insert (propertize file 'face 'magit-filename) sep cnt " ")
+                (insert (propertize file 'font-lock-face 'magit-filename)
+                        sep cnt " ")
                 (when add
-                  (insert (propertize add 'face 'magit-diffstat-added)))
+                  (insert (propertize add 'font-lock-face
+                                      'magit-diffstat-added)))
                 (when del
-                  (insert (propertize del 'face 'magit-diffstat-removed)))
+                  (insert (propertize del 'font-lock-face
+                                      'magit-diffstat-removed)))
                 (insert "\n")))))
         (if (looking-at "^$") (forward-line) (insert "\n"))))))
 
@@ -1975,7 +1978,7 @@ section or a child thereof."
                              (`(?A ?U) " (added by us)")
                              (`(?U ?A) " (added by them)")
                              (`(?U ?U) "")))
-                   'face 'magit-diff-file-heading))
+                   'font-lock-face 'magit-diff-file-heading))
           (insert ?\n))))
     t)
    ((looking-at (concat "^\\(merged\\|changed in both\\|"
@@ -2050,7 +2053,7 @@ section or a child thereof."
                                 (if (or (not orig) (equal orig file))
                                     file
                                   (format "%s -> %s" orig file)))
-                        'face 'magit-diff-file-heading))
+                        'font-lock-face 'magit-diff-file-heading))
     (magit-insert-heading)
     (unless (equal orig file)
       (oset section source orig))
@@ -2085,7 +2088,7 @@ section or a child thereof."
           (magit-insert-section (magit-module-section module t)
             (magit-insert-heading
               (propertize (concat "modified   " module)
-                          'face 'magit-diff-file-heading)
+                          'font-lock-face 'magit-diff-file-heading)
               " ("
               (cond (rewind "rewind")
                     ((string-match-p "\\.\\.\\." range) "non-ff")
@@ -2110,13 +2113,13 @@ section or a child thereof."
           (magit-insert-section (magit-module-section module)
             (magit-insert-heading
               (propertize (concat "submodule  " module)
-                          'face 'magit-diff-file-heading)
+                          'font-lock-face 'magit-diff-file-heading)
               " (" msg ")"))))
        (t
         (magit-insert-section (magit-module-section module)
           (magit-insert-heading
             (propertize (concat "modified   " module)
-                        'face 'magit-diff-file-heading)
+                        'font-lock-face 'magit-diff-file-heading)
             " ("
             (and modified "modified")
             (and modified untracked " and ")
@@ -2135,7 +2138,8 @@ section or a child thereof."
            (value    (cons about ranges)))
       (magit-delete-line)
       (magit-insert-section section (hunk value)
-        (insert (propertize (concat heading "\n") 'face 'magit-diff-hunk-heading))
+        (insert (propertize (concat heading "\n")
+                            'font-lock-face 'magit-diff-hunk-heading))
         (magit-insert-heading)
         (while (not (or (eobp) (looking-at "^[^-+\s\\]")))
           (forward-line))
@@ -2241,7 +2245,8 @@ or a ref which is not a branch, then it inserts nothing."
                              (match-string 1)
                              (match-string 2))))
         (magit-delete-line)
-        (insert (propertize heading 'face 'magit-section-secondary-heading)))
+        (insert (propertize heading 'font-lock-face
+                            'magit-section-secondary-heading)))
       (magit-insert-heading)
       (if (re-search-forward "-----BEGIN PGP SIGNATURE-----" nil t)
           (progn
@@ -2302,7 +2307,8 @@ or a ref which is not a branch, then it inserts nothing."
                                   (magit-commit-p text)))
                             (`slow
                              (magit-commit-p text)))
-                      (put-text-property beg (point) 'face 'magit-hash)
+                      (put-text-property beg (point)
+                                         'font-lock-face 'magit-hash)
                       (let ((end (point)))
                         (goto-char beg)
                         (magit-insert-section (commit text)
@@ -2317,8 +2323,8 @@ or a ref which is not a branch, then it inserts nothing."
               (let ((beg (match-beginning 0))
                     (end (match-end 0)))
                 (put-text-property
-                 beg end 'face
-                 (if-let ((face (get-text-property beg 'face)))
+                 beg end 'font-lock-face
+                 (if-let ((face (get-text-property beg 'font-lock-face)))
                      (list face 'magit-keyword)
                    'magit-keyword))))))
         (goto-char (point-max))))))
@@ -2344,7 +2350,7 @@ or a ref which is not a branch, then it inserts nothing."
                             (propertize (if (string-prefix-p "refs/notes/" ref)
                                             (substring ref 11)
                                           ref)
-                                        'face 'magit-refname)))
+                                        'font-lock-face 'magit-refname)))
             (forward-char)
             (add-face-text-property beg (point) 'magit-diff-hunk-heading)
             (magit-insert-heading)
@@ -2367,7 +2373,7 @@ or a ref which is not a branch, then it inserts nothing."
       (insert (magit-format-ref-labels it) ?\s))
     (insert (propertize
              (magit-rev-parse (concat magit-buffer-revision "^{commit}"))
-             'face 'magit-hash))
+             'font-lock-face 'magit-hash))
     (magit-insert-heading)
     (let ((beg (point)))
       (magit-rev-insert-format magit-revision-headers-format
@@ -2380,7 +2386,7 @@ or a ref which is not a branch, then it inserts nothing."
             (string-match "^\\([^ ]+\\) \\(.*\\)" line)
             (magit-bind-match-strings (hash msg) line
               (insert "Parent:     ")
-              (insert (propertize hash 'face 'magit-hash))
+              (insert (propertize hash 'font-lock-face 'magit-hash))
               (insert " " msg "\n")))))
       (magit--insert-related-refs
        magit-buffer-revision "--merged" "Merged"
@@ -2392,18 +2398,19 @@ or a ref which is not a branch, then it inserts nothing."
         (let ((tag (car  follows))
               (cnt (cadr follows)))
           (magit-insert-section (tag tag)
-            (insert (format "Follows:    %s (%s)\n"
-                            (propertize tag 'face 'magit-tag)
-                            (propertize (number-to-string cnt)
-                                        'face 'magit-branch-local))))))
+            (insert
+             (format "Follows:    %s (%s)\n"
+                     (propertize tag 'font-lock-face 'magit-tag)
+                     (propertize (number-to-string cnt)
+                                 'font-lock-face 'magit-branch-local))))))
       (when-let ((precedes (magit-get-next-tag magit-buffer-revision t)))
         (let ((tag (car  precedes))
               (cnt (cadr precedes)))
           (magit-insert-section (tag tag)
             (insert (format "Precedes:   %s (%s)\n"
-                            (propertize tag 'face 'magit-tag)
+                            (propertize tag 'font-lock-face 'magit-tag)
                             (propertize (number-to-string cnt)
-                                        'face 'magit-tag))))))
+                                        'font-lock-face 'magit-tag))))))
       (insert ?\n))))
 
 (defun magit--insert-related-refs (rev arg title remote)
@@ -2415,7 +2422,7 @@ or a ref which is not a branch, then it inserts nothing."
           (insert ?\s)
         (insert ?\n (make-string 12 ?\s)))
       (magit-insert-section (branch branch)
-        (insert (propertize branch 'face
+        (insert (propertize branch 'font-lock-face
                             (if (string-prefix-p "remotes/" branch)
                                 'magit-branch-remote
                               'magit-branch-local)))))
@@ -2795,7 +2802,7 @@ are highlighted."
               (put-text-property (1- (line-end-position)) (line-end-position)
                                  'invisible t))
             (put-text-property
-             (point) (1+ (line-end-position)) 'face
+             (point) (1+ (line-end-position)) 'font-lock-face
              (cond
               ((looking-at "^\\+\\+?\\([<=|>]\\)\\{7\\}")
                (setq stage (pcase (list (match-string 1) highlight)
@@ -2881,7 +2888,7 @@ are highlighted."
       (when (and magit-diff-highlight-trailing
                  (looking-at (concat prefix ".*?\\([ \t]+\\)$")))
         (let ((ov (make-overlay (match-beginning 1) (match-end 1) nil t)))
-          (overlay-put ov 'face 'magit-diff-whitespace-warning)
+          (overlay-put ov 'font-lock-face 'magit-diff-whitespace-warning)
           (overlay-put ov 'priority 2)
           (overlay-put ov 'evaporate t)))
       (when (or (and (eq indent 'tabs)
@@ -2890,7 +2897,7 @@ are highlighted."
                      (looking-at (format "%s\\([ \t]* \\{%s,\\}[ \t]*\\)"
                                          prefix indent))))
         (let ((ov (make-overlay (match-beginning 1) (match-end 1) nil t)))
-          (overlay-put ov 'face 'magit-diff-whitespace-warning)
+          (overlay-put ov 'font-lock-face 'magit-diff-whitespace-warning)
           (overlay-put ov 'priority 2)
           (overlay-put ov 'evaporate t))))))
 
@@ -2940,7 +2947,7 @@ are highlighted."
     (magit-diff--make-hunk-overlay
      (oref section start)
      (1- (oref section content))
-     'face 'magit-diff-lines-heading
+     'font-lock-face 'magit-diff-lines-heading
      'display (magit-diff-hunk-region-header section)
      'after-string (magit-diff--hunk-after-string 'magit-diff-lines-heading))
     (run-hook-with-args 'magit-diff-highlight-hunk-region-functions section)
@@ -2957,11 +2964,11 @@ for added and removed lines as for context lines."
       (setq face (list :background (face-attribute face :background))))
     (magit-diff--make-hunk-overlay (oref section content)
                                    (magit-diff-hunk-region-beginning)
-                                   'face face
+                                   'font-lock-face face
                                    'priority 2)
     (magit-diff--make-hunk-overlay (1+ (magit-diff-hunk-region-end))
                                    (oref section end)
-                                   'face face
+                                   'font-lock-face face
                                    'priority 2)))
 
 (defun magit-diff-highlight-hunk-region-using-face (_section)
@@ -2971,7 +2978,7 @@ changing only the `:weight' and/or `:slant' is recommended for that
 face."
   (magit-diff--make-hunk-overlay (magit-diff-hunk-region-beginning)
                                  (1+ (magit-diff-hunk-region-end))
-                                 'face 'magit-diff-hunk-region))
+                                 'font-lock-face 'magit-diff-hunk-region))
 
 (defun magit-diff-highlight-hunk-region-using-overlays (section)
   "Emphasize the hunk-internal region using delimiting horizontal lines.
@@ -2982,7 +2989,7 @@ This is implemented as single-pixel newlines places inside overlays."
             (str (propertize
                   (concat (propertize "\s" 'display '(space :height (1)))
                           (propertize "\n" 'line-height t))
-                  'face 'magit-diff-lines-boundary)))
+                  'font-lock-face 'magit-diff-lines-boundary)))
         (magit-diff--make-hunk-overlay beg (1+ beg) 'before-string str)
         (magit-diff--make-hunk-overlay end (1+ end) 'after-string  str))
     (magit-diff-highlight-hunk-region-using-face section)))
@@ -3003,7 +3010,7 @@ last (visual) lines of the region."
              (color (face-background 'magit-diff-lines-boundary nil t)))
         (cl-flet ((ln (b e &rest face)
                       (magit-diff--make-hunk-overlay
-                       b e 'face face 'after-string
+                       b e 'font-lock-face face 'after-string
                        (magit-diff--hunk-after-string face))))
           (if (= beg end-bol)
               (ln beg beg-eol :overline color :underline color)
@@ -3020,7 +3027,7 @@ last (visual) lines of the region."
 
 (defun magit-diff--hunk-after-string (face)
   (propertize "\s"
-              'face face
+              'font-lock-face face
               'display (list 'space :align-to
                              `(+ (0 . right)
                                  ,(min (window-hscroll)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1231,13 +1231,13 @@ to, or to some other symbolic-ref that points to the same ref."
 
 (defun magit--painted-branch-at-point (&optional type)
   (or (and (not (eq type 'remote))
-           (memq (get-text-property (point) 'face)
+           (memq (get-text-property (point) 'font-lock-face)
                  (list 'magit-branch-local
                        'magit-branch-current))
            (when-let ((branch (thing-at-point 'git-revision t)))
              (cdr (magit-split-branch-name branch))))
       (and (not (eq type 'local))
-           (memq (get-text-property (point) 'face)
+           (memq (get-text-property (point) 'font-lock-face)
                  (list 'magit-branch-remote
                        'magit-branch-remote-head))
            (thing-at-point 'git-revision t))))
@@ -1354,7 +1354,7 @@ remote-tracking branch.  The returned string is colorized
 according to the branch type."
   (when-let ((branch (or branch (magit-get-current-branch)))
              (upstream (magit-ref-abbrev (concat branch "@{upstream}"))))
-    (propertize upstream 'face
+    (propertize upstream 'font-lock-face
                 (if (equal (magit-get "branch" branch "remote") ".")
                     'magit-branch-local
                   'magit-branch-remote))))
@@ -1383,18 +1383,18 @@ according to the branch type."
              (remote (magit-get "branch" branch "remote")))
     (and (not (equal remote "."))
          (cond ((member remote (magit-list-remotes))
-                (propertize remote 'face 'magit-branch-remote))
+                (propertize remote 'font-lock-face 'magit-branch-remote))
                ((and allow-unnamed
                      (string-match-p "\\(\\`.\\{0,2\\}/\\|[:@]\\)" remote))
-                (propertize remote 'face 'bold))))))
+                (propertize remote 'font-lock-face 'bold))))))
 
 (defun magit-get-unnamed-upstream (&optional branch)
   (when-let ((branch (or branch (magit-get-current-branch)))
              (remote (magit-get "branch" branch "remote"))
              (merge  (magit-get "branch" branch "merge")))
     (and (magit--unnamed-upstream-p remote merge)
-         (list (propertize remote 'face 'bold)
-               (propertize merge  'face 'magit-branch-remote)))))
+         (list (propertize remote 'font-lock-face 'bold)
+               (propertize merge  'font-lock-face 'magit-branch-remote)))))
 
 (defun magit--unnamed-upstream-p (remote merge)
   (and remote (string-match-p "\\(\\`\\.\\{0,2\\}/\\|[:@]\\)" remote)
@@ -1411,14 +1411,14 @@ according to the branch type."
                  (remote (if (= (length remotes) 1)
                              (car remotes)
                            (car (member "origin" remotes)))))
-        (propertize remote 'face 'magit-branch-remote))))
+        (propertize remote 'font-lock-face 'magit-branch-remote))))
 
 (defun magit-get-push-remote (&optional branch)
   (when-let ((remote
               (or (and (or branch (setq branch (magit-get-current-branch)))
                        (magit-get "branch" branch "pushRemote"))
                   (magit-get "remote.pushDefault"))))
-    (propertize remote 'face 'magit-branch-remote)))
+    (propertize remote 'font-lock-face 'magit-branch-remote)))
 
 (defun magit-get-push-branch (&optional branch verify)
   (when-let ((branch (or branch (setq branch (magit-get-current-branch))))
@@ -1426,7 +1426,7 @@ according to the branch type."
              (target (concat remote "/" branch)))
     (and (or (not verify)
              (magit-rev-verify target))
-         (propertize target 'face 'magit-branch-remote))))
+         (propertize target 'font-lock-face 'magit-branch-remote))))
 
 (defun magit-get-@{push}-branch (&optional branch)
   (let ((ref (magit-rev-parse "--symbolic-full-name"
@@ -1738,7 +1738,7 @@ PATH has to be relative to the super-repository."
       (car (member rev (magit-list-remote-branch-names)))))
 
 (defun magit-branch-set-face (branch)
-  (propertize branch 'face (if (magit-local-branch-p branch)
+  (propertize branch 'font-lock-face (if (magit-local-branch-p branch)
                                'magit-branch-local
                              'magit-branch-remote)))
 
@@ -1810,7 +1810,7 @@ Return a list of two integers: (A>B B>A)."
 (defun magit-format-rev-summary (rev)
   (--when-let (magit-rev-format "%h %s" rev)
     (string-match " " it)
-    (put-text-property 0 (match-beginning 0) 'face 'magit-hash it)
+    (put-text-property 0 (match-beginning 0) 'font-lock-face 'magit-hash it)
     it))
 
 (defvar magit-ref-namespaces
@@ -1862,12 +1862,12 @@ and this option only controls what face is used.")
         (dolist (ref names)
           (let* ((face (cdr (--first (string-match (car it) ref)
                                      magit-ref-namespaces)))
-                 (name (propertize (or (match-string 1 ref) ref) 'face face)))
+                 (name (propertize (or (match-string 1 ref) ref) 'font-lock-face face)))
             (cl-case face
               ((magit-bisect-bad magit-bisect-skip magit-bisect-good)
                (setq state name))
               (magit-head
-               (setq head (propertize "@" 'face 'magit-head)))
+               (setq head (propertize "@" 'font-lock-face 'magit-head)))
               (magit-tag            (push name tags))
               (magit-branch-local   (push name branches))
               (magit-branch-remote  (push name remotes))
@@ -1883,8 +1883,8 @@ and this option only controls what face is used.")
                                        (magit-git-string
                                         "symbolic-ref"
                                         (format "refs/remotes/%s/HEAD" r)))
-                                (propertize name
-                                            'face 'magit-branch-remote-head)
+                                (propertize name 'font-lock-face
+                                            'magit-branch-remote-head)
                               name)))
                    name))
                remotes))
@@ -1900,12 +1900,14 @@ and this option only controls what face is used.")
                ((equal name current)
                 (setq head
                       (concat push
-                              (propertize name 'face 'magit-branch-current))))
+                              (propertize name 'font-lock-face
+                                          'magit-branch-current))))
                ((equal name target)
                 (setq upstream
                       (concat push
-                              (propertize name 'face '(magit-branch-upstream
-                                                       magit-branch-local)))))
+                              (propertize name 'font-lock-face
+                                          '(magit-branch-upstream
+                                            magit-branch-local)))))
                (t
                 (push (concat push name) combined)))))
           (when (and target (not upstream))
@@ -2208,7 +2210,7 @@ out.  Only existing branches can be selected."
                         ;; Ivy-mode strips faces from prompt.
                         (format  " `%s'" branch)
                       (concat " "
-                              (propertize branch 'face 'magit-branch-local))))
+                              (propertize branch 'font-lock-face 'magit-branch-local))))
                " starting at")
        (nconc (list "HEAD")
               (magit-list-refnames)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1098,21 +1098,23 @@ Do not add this to a hook variable."
           (when (and (derived-mode-p 'magit-refs-mode)
                      magit-refs-show-commit-count)
             (insert (make-string (1- magit-refs-focus-column-width) ?\s)))
-          (insert (propertize cherry 'face (if (string= cherry "-")
-                                               'magit-cherry-equivalent
-                                             'magit-cherry-unmatched)))
+          (insert (propertize cherry 'font-lock-face
+                              (if (string= cherry "-")
+                                  'magit-cherry-equivalent
+                                'magit-cherry-unmatched)))
           (insert ?\s))
         (when side
-          (insert (propertize side 'face (if (string= side "<")
-                                             'magit-cherry-equivalent
-                                           'magit-cherry-unmatched)))
+          (insert (propertize side 'font-lock-face
+                              (if (string= side "<")
+                                  'magit-cherry-equivalent
+                                'magit-cherry-unmatched)))
           (insert ?\s))
         (when align
-          (insert (propertize hash 'face 'magit-hash) ?\s))
+          (insert (propertize hash 'font-lock-face 'magit-hash) ?\s))
         (when graph
           (insert graph))
         (unless align
-          (insert (propertize hash 'face 'magit-hash) ?\s))
+          (insert (propertize hash 'font-lock-face 'magit-hash) ?\s))
         (when (and refs (not magit-log-show-refname-after-summary))
           (insert (magit-format-ref-labels refs) ?\s))
         (when (eq style 'reflog)
@@ -1122,7 +1124,7 @@ Do not add this to a hook variable."
                      (substring refsub 0 (if (string-match-p ":" refsub) -2 -1))))))
         (when msg
           (when gpg
-            (setq msg (propertize msg 'face
+            (setq msg (propertize msg 'font-lock-face
                                   (pcase (aref gpg 0)
                                     (?G 'magit-signature-good)
                                     (?B 'magit-signature-bad)
@@ -1201,13 +1203,13 @@ Do not add this to a hook variable."
       (setq start (match-end 0))
       (put-text-property (match-beginning 0)
                          (match-end 0)
-                         'face 'magit-keyword-squash msg))
+                         'font-lock-face 'magit-keyword-squash msg))
     (while (string-match "\\[[^[]*\\]" msg start)
       (setq start (match-end 0))
       (when magit-log-highlight-keywords
         (put-text-property (match-beginning 0)
                            (match-end 0)
-                           'face 'magit-keyword msg))))
+                           'font-lock-face 'magit-keyword msg))))
   msg)
 
 (defun magit-log-maybe-show-more-commits (section)
@@ -1319,7 +1321,7 @@ The shortstat style is experimental and rather slow."
                                            (or author "")
                                            details-width
                                            nil ?\s (make-string 1 magit-ellipsis))
-                                          'face 'magit-log-author)
+                                          'font-lock-face 'magit-log-author)
                               " "))
                  (propertize
                   (if (stringp style)
@@ -1331,7 +1333,7 @@ The shortstat style is experimental and rather slow."
                       (format (format (if abbr "%%2i%%-%ic" "%%2i %%-%is")
                                       (- width (if details (1+ details-width) 0)))
                               cnt unit)))
-                  'face 'magit-log-date)))))))
+                  'font-lock-face 'magit-log-date)))))))
 
 (defun magit-log-format-shortstat-margin (rev)
   (magit-make-margin-overlay
@@ -1345,10 +1347,12 @@ The shortstat style is experimental and rather slow."
              (format
               "%5s %5s%4s"
               (if add
-                  (propertize (format "%s+" add) 'face 'magit-diffstat-added)
+                  (propertize (format "%s+" add)
+                              'font-lock-face 'magit-diffstat-added)
                 "")
               (if del
-                  (propertize (format "%s-" del) 'face 'magit-diffstat-removed)
+                  (propertize (format "%s-" del)
+                              'font-lock-face 'magit-diffstat-removed)
                 "")
               files))
          "")
@@ -1438,11 +1442,11 @@ Type \\[magit-log-select-quit] to abort without selecting a commit."
   (when magit-log-select-show-usage
     (let ((pick (propertize (substitute-command-keys
                              "\\[magit-log-select-pick]")
-                            'face
+                            'font-lock-face
                             'magit-header-line-key))
           (quit (propertize (substitute-command-keys
                              "\\[magit-log-select-quit]")
-                            'face
+                            'font-lock-face
                             'magit-header-line-key)))
       (setq msg (format-spec
                  (if msg
@@ -1526,8 +1530,9 @@ Type \\[magit-cherry-pick] to apply the commit at point.
 
 (defun magit-insert-cherry-headers ()
   "Insert headers appropriate for `magit-cherry-mode' buffers."
-  (let ((branch (propertize magit-buffer-refname 'face 'magit-branch-local))
-        (upstream (propertize magit-buffer-upstream 'face
+  (let ((branch (propertize magit-buffer-refname
+                            'font-lock-face 'magit-branch-local))
+        (upstream (propertize magit-buffer-upstream 'font-lock-face
                               (if (magit-local-branch-p magit-buffer-upstream)
                                   'magit-branch-local
                                 'magit-branch-remote))))
@@ -1561,7 +1566,8 @@ Type \\[magit-cherry-pick] to apply the commit at point.
   (when-let ((upstream (magit-get-upstream-branch)))
     (magit-insert-section (unpulled "..@{upstream}" t)
       (magit-insert-heading
-        (format (propertize "Unpulled from %s:" 'face 'magit-section-heading)
+        (format (propertize "Unpulled from %s:"
+                            'font-lock-face 'magit-section-heading)
                 upstream))
       (magit-insert-log "..@{upstream}" magit-buffer-log-args))))
 
@@ -1580,8 +1586,9 @@ Type \\[magit-cherry-pick] to apply the commit at point.
                            magit-status-sections-hook)))
       (magit-insert-section (unpulled (concat ".." it) t)
         (magit-insert-heading
-          (format (propertize "Unpulled from %s:" 'face 'magit-section-heading)
-                  (propertize it 'face 'magit-branch-remote)))
+          (format (propertize "Unpulled from %s:"
+                              'font-lock-face 'magit-section-heading)
+                  (propertize it 'font-lock-face 'magit-branch-remote)))
         (magit-insert-log (concat ".." it) magit-buffer-log-args)))))
 
 (defvar magit-unpushed-section-map
@@ -1611,7 +1618,8 @@ then show the last `magit-log-section-commit-count' commits."
   (when (magit-git-success "rev-parse" "@{upstream}")
     (magit-insert-section (unpushed "@{upstream}..")
       (magit-insert-heading
-        (format (propertize "Unmerged into %s:" 'face 'magit-section-heading)
+        (format (propertize "Unmerged into %s:"
+                            'font-lock-face 'magit-section-heading)
                 (magit-get-upstream-branch)))
       (magit-insert-log "@{upstream}.." magit-buffer-log-args))))
 
@@ -1645,8 +1653,9 @@ Show the last `magit-log-section-commit-count' commits."
                            magit-status-sections-hook)))
       (magit-insert-section (unpushed (concat it "..") t)
         (magit-insert-heading
-          (format (propertize "Unpushed to %s:" 'face 'magit-section-heading)
-                  (propertize it 'face 'magit-branch-remote)))
+          (format (propertize "Unpushed to %s:"
+                              'font-lock-face 'magit-section-heading)
+                  (propertize it 'font-lock-face 'magit-branch-remote)))
         (magit-insert-log (concat it "..") magit-buffer-log-args)))))
 
 ;;;; Auxiliary Log Sections

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -617,7 +617,7 @@ Magit status buffer."
     (magit-insert-section (process)
       (insert (if errcode
                   (format "%3s " (propertize (number-to-string errcode)
-                                             'face 'magit-process-ng))
+                                             'font-lock-face 'magit-process-ng))
                 "run "))
       (unless (equal (expand-file-name pwd)
                      (expand-file-name default-directory))
@@ -626,20 +626,21 @@ Magit status buffer."
        ((and args (equal program magit-git-executable))
         (setq args (-split-at (length magit-git-global-arguments) args))
         (insert (propertize (file-name-nondirectory program)
-                            'face 'magit-section-heading) " ")
+                            'font-lock-face 'magit-section-heading) " ")
         (insert (propertize (char-to-string magit-ellipsis)
-                            'face 'magit-section-heading
+                            'font-lock-face 'magit-section-heading
                             'help-echo (mapconcat #'identity (car args) " ")))
         (insert " ")
         (insert (propertize (mapconcat #'shell-quote-argument (cadr args) " ")
-                            'face 'magit-section-heading)))
+                            'font-lock-face 'magit-section-heading)))
        ((and args (equal program shell-file-name))
-        (insert (propertize (cadr args) 'face 'magit-section-heading)))
+        (insert (propertize (cadr args)
+                            'font-lock-face 'magit-section-heading)))
        (t
         (insert (propertize (file-name-nondirectory program)
-                            'face 'magit-section-heading) " ")
+                            'font-lock-face 'magit-section-heading) " ")
         (insert (propertize (mapconcat #'shell-quote-argument args " ")
-                            'face 'magit-section-heading))))
+                            'font-lock-face 'magit-section-heading))))
       (magit-insert-heading)
       (when errlog
         (if (bufferp errlog)
@@ -906,7 +907,7 @@ as argument."
                           'mouse-face 'highlight
                           'keymap magit-mode-line-process-map
                           'help-echo "mouse-1: Show process buffer"
-                          'face 'magit-mode-line-process))))
+                          'font-lock-face 'magit-mode-line-process))))
     (magit-repository-local-set 'mode-line-process str)
     (dolist (buf (magit-mode-get-buffers))
       (with-current-buffer buf
@@ -930,7 +931,7 @@ If STR is supplied, it replaces the `mode-line-process' text."
                            'mouse-face 'highlight
                            'keymap magit-mode-line-process-map
                            'help-echo error
-                           'face 'magit-mode-line-process-error)))
+                           'font-lock-face 'magit-mode-line-process-error)))
     (magit-repository-local-set 'mode-line-process str)
     (dolist (buf (magit-mode-get-buffers))
       (with-current-buffer buf
@@ -966,7 +967,7 @@ If STR is supplied, it replaces the `mode-line-process' text."
   (let ((status (or mode-line-process
                     (magit-repository-local-get 'mode-line-process))))
     (when (and status
-               (eq (get-text-property 1 'face status)
+               (eq (get-text-property 1 'font-lock-face status)
                    'magit-mode-line-process-error))
       (magit-process-unset-mode-line))))
 
@@ -1053,9 +1054,9 @@ Limited by `magit-process-error-tooltip-max-lines'."
           (set-marker-insertion-type marker nil)
           (insert (propertize (format "%3s" arg)
                               'magit-section section
-                              'face (if (= arg 0)
-                                        'magit-process-ok
-                                      'magit-process-ng)))
+                              'font-lock-face (if (= arg 0)
+                                                  'magit-process-ok
+                                                'magit-process-ng)))
           (set-marker-insertion-type marker t))
         (when magit-process-finish-apply-ansi-colors
           (ansi-color-apply-on-region (oref section content)

--- a/lisp/magit-pull.el
+++ b/lisp/magit-pull.el
@@ -50,10 +50,10 @@
    (lambda ()
      (if-let ((branch (magit-get-current-branch)))
          (concat
-          (propertize "Pull into " 'face 'transient-heading)
-          (propertize branch       'face 'magit-branch-local)
-          (propertize " from"      'face 'transient-heading))
-       (propertize "Pull from" 'face 'transient-heading)))
+          (propertize "Pull into " 'font-lock-face 'transient-heading)
+          (propertize branch       'font-lock-face 'magit-branch-local)
+          (propertize " from"      'font-lock-face 'transient-heading))
+       (propertize "Pull from" 'font-lock-face 'transient-heading)))
    ("p" magit-pull-from-pushremote)
    ("u" magit-pull-from-upstream)
    ("e" "elsewhere"         magit-pull-branch)]
@@ -135,12 +135,12 @@ the upstream."
     (or (magit-get-upstream-branch branch)
         (let ((remote (magit-get "branch" branch "remote"))
               (merge  (magit-get "branch" branch "merge"))
-              (u (propertize "@{upstream}" 'face 'bold)))
+              (u (propertize "@{upstream}" 'font-lock-face 'bold)))
           (cond
            ((magit--unnamed-upstream-p remote merge)
             (format "%s of %s"
-                    (propertize merge  'face 'magit-branch-remote)
-                    (propertize remote 'face 'bold)))
+                    (propertize merge  'font-lock-face 'magit-branch-remote)
+                    (propertize remote 'font-lock-face 'bold)))
            ((magit--valid-upstream-p remote merge)
             (concat u ", replacing non-existent"))
            ((or remote merge)

--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -47,9 +47,10 @@
    (7 "-t" "Follow tags"    "--follow-tags")]
   [:if magit-get-current-branch
    :description (lambda ()
-                  (format (propertize "Push %s to" 'face 'transient-heading)
+                  (format (propertize "Push %s to"
+                                      'font-lock-face 'transient-heading)
                           (propertize (magit-get-current-branch)
-                                      'face 'magit-branch-local)))
+                                      'font-lock-face 'magit-branch-local)))
    ("p" magit-push-current-to-pushremote)
    ("u" magit-push-current-to-upstream)
    ("e" "elsewhere" magit-push-current)]
@@ -103,7 +104,7 @@ argument the push-remote can be changed before pushed to it."
      ((member remote (magit-list-remotes))
       (format "%s, creating it"
               (propertize (concat remote "/" branch)
-                          'face 'magit-branch-remote)))
+                          'font-lock-face 'magit-branch-remote)))
      (remote
       (format "%s, replacing invalid" v))
      (t
@@ -154,16 +155,16 @@ the upstream."
     (or (magit-get-upstream-branch branch)
         (let ((remote (magit-get "branch" branch "remote"))
               (merge  (magit-get "branch" branch "merge"))
-              (u (propertize "@{upstream}" 'face 'bold)))
+              (u (propertize "@{upstream}" 'font-lock-face 'bold)))
           (cond
            ((magit--unnamed-upstream-p remote merge)
             (format "%s as %s"
-                    (propertize remote 'face 'bold)
-                    (propertize merge  'face 'magit-branch-remote)))
+                    (propertize remote 'font-lock-face 'bold)
+                    (propertize merge  'font-lock-face 'magit-branch-remote)))
            ((magit--valid-upstream-p remote merge)
             (format "%s creating %s"
-                    (propertize remote 'face 'magit-branch-remote)
-                    (propertize merge  'face 'magit-branch-remote)))
+                    (propertize remote 'font-lock-face 'magit-branch-remote)
+                    (propertize merge  'font-lock-face 'magit-branch-remote)))
            ((or remote merge)
             (concat u ", creating it and replacing invalid"))
            (t
@@ -275,25 +276,25 @@ the popup buffer."
                                  (magit-remote-p "origin")))
                      (refspec (magit-get "remote" remote "push")))
             (format "%s using %s"
-                    (propertize remote  'face 'magit-branch-remote)
-                    (propertize refspec 'face 'bold)))
+                    (propertize remote  'font-lock-face 'magit-branch-remote)
+                    (propertize refspec 'font-lock-face 'bold)))
           (--when-let (and (not (magit-get-push-branch))
                            (magit-get-upstream-branch))
             (format "%s aka %s\n"
                     (magit-branch-set-face it)
-                    (propertize "@{upstream}" 'face 'bold)))
+                    (propertize "@{upstream}" 'font-lock-face 'bold)))
           (--when-let (magit-get-push-branch)
             (format "%s aka %s\n"
                     (magit-branch-set-face it)
-                    (propertize "pushRemote" 'face 'bold)))
+                    (propertize "pushRemote" 'font-lock-face 'bold)))
           (--when-let (magit-get-@{push}-branch)
             (format "%s aka %s\n"
                     (magit-branch-set-face it)
-                    (propertize "@{push}" 'face 'bold)))
+                    (propertize "@{push}" 'font-lock-face 'bold)))
           (format "using %s (%s is %s)\n"
-                  (propertize "git push"     'face 'bold)
-                  (propertize "push.default" 'face 'bold)
-                  (propertize default        'face 'bold))))))
+                  (propertize "git push"     'font-lock-face 'bold)
+                  (propertize "push.default" 'font-lock-face 'bold)
+                  (propertize default        'font-lock-face 'bold))))))
 
 ;;;###autoload
 (defun magit-push-to-remote (remote args)
@@ -312,7 +313,7 @@ these Git variables: `push.default', `remote.pushDefault',
   (magit-run-git-async "push" "-v" args remote))
 
 (defun magit-push-to-remote--desc ()
-  (format "using %s\n" (propertize "git push <remote>" 'face 'bold)))
+  (format "using %s\n" (propertize "git push <remote>" 'font-lock-face 'bold)))
 
 ;;; _
 (provide 'magit-push)

--- a/lisp/magit-reflog.el
+++ b/lisp/magit-reflog.el
@@ -202,7 +202,7 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
                             (delq nil (list command option type))
                             " "))))
     (format "%-16s "
-            (propertize text 'face
+            (propertize text 'font-lock-face
                         (or (cdr (assoc label magit-reflog-labels))
                             'magit-reflog-other)))))
 

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -441,13 +441,15 @@ different, but only if you have customized the option
                  (if (magit-branch-p branch)
                      (if (magit-rev-eq branch ref)
                          (magit-call-git "checkout" branch)
-                       (setq branch (propertize branch 'face 'magit-branch-local))
-                       (setq ref (propertize ref 'face 'magit-branch-remote))
+                       (setq branch (propertize branch 'font-lock-face
+                                                'magit-branch-local))
+                       (setq ref (propertize ref 'font-lock-face
+                                             'magit-branch-remote))
                        (pcase (prog1 (read-char-choice (format (propertize "\
 Branch %s already exists.
   [c]heckout %s as-is
   [r]reset %s to %s and checkout %s
-  [a]bort " 'face 'minibuffer-prompt) branch branch branch ref branch)
+  [a]bort " 'font-lock-face 'minibuffer-prompt) branch branch branch ref branch)
                                                        '(?c ?r ?a))
                                 (message "")) ; otherwise prompt sticks
                          (?c (magit-call-git "checkout" branch))
@@ -521,7 +523,7 @@ line is inserted at all."
               (magit-insert-section (tag tag t)
                 (magit-insert-heading
                   (magit-refs--format-focus-column tag 'tag)
-                  (propertize tag 'face 'magit-tag)
+                  (propertize tag 'font-lock-face 'magit-tag)
                   (make-string (max 1 (- magit-refs-primary-column-width
                                          (length tag)))
                                ?\s)
@@ -539,8 +541,9 @@ line is inserted at all."
       (magit-insert-heading
         (let ((pull (magit-get "remote" remote "url"))
               (push (magit-get "remote" remote "pushurl")))
-          (format (propertize "Remote %s (%s):" 'face 'magit-section-heading)
-                  (propertize remote 'face 'magit-branch-remote)
+          (format (propertize "Remote %s (%s):"
+                              'font-lock-face 'magit-section-heading)
+                  (propertize remote 'font-lock-face 'magit-branch-remote)
                   (concat pull (and pull push ", ") push))))
       (let (head)
         (dolist (line (magit-git-lines "for-each-ref" "--format=\
@@ -639,47 +642,49 @@ line is inserted at all."
               (if branch
                   (magit-refs--propertize-branch
                    branch ref (and headp 'magit-branch-current))
-                (propertize "(detached)" 'face 'font-lock-warning-face)))
+                (propertize "(detached)" 'font-lock-face
+                            'font-lock-warning-face)))
              (u:ahead  (and u:track
                             (string-match "ahead \\([0-9]+\\)" u:track)
                             (propertize
                              (concat (and magit-refs-pad-commit-counts " ")
                                      (match-string 1 u:track)
                                      ">")
-                             'face 'magit-dimmed)))
+                             'font-lock-face 'magit-dimmed)))
              (u:behind (and u:track
                             (string-match "behind \\([0-9]+\\)" u:track)
                             (propertize
                              (concat "<"
                                      (match-string 1 u:track)
                                      (and magit-refs-pad-commit-counts " "))
-                             'face 'magit-dimmed)))
+                             'font-lock-face 'magit-dimmed)))
              (p:ahead  (and pushp p:track
                             (string-match "ahead \\([0-9]+\\)" p:track)
                             (propertize
                              (concat (match-string 1 p:track)
                                      ">"
                                      (and magit-refs-pad-commit-counts " "))
-                             'face 'magit-branch-remote)))
+                             'font-lock-face 'magit-branch-remote)))
              (p:behind (and pushp p:track
                             (string-match "behind \\([0-9]+\\)" p:track)
                             (propertize
                              (concat "<"
                                      (match-string 1 p:track)
                                      (and magit-refs-pad-commit-counts " "))
-                             'face 'magit-dimmed))))
+                             'font-lock-face 'magit-dimmed))))
         (list (1+ (length (concat branch-desc u:ahead p:ahead u:behind)))
               branch
               (magit-refs--format-focus-column branch headp)
               branch-desc u:ahead p:ahead u:behind
               (and upstream
                    (concat (if (equal u:track "[gone]")
-                               (propertize upstream 'face 'error)
+                               (propertize upstream 'font-lock-face 'error)
                              (magit-refs--propertize-branch upstream u:ref))
                            " "))
               (and pushp
                    (concat p:behind
-                           (propertize push 'face 'magit-branch-remote)
+                           (propertize push 'font-lock-face
+                                       'magit-branch-remote)
                            " "))
               (and msg (magit-log-propertize-keywords nil msg)))))))
 
@@ -695,7 +700,7 @@ line is inserted at all."
                      (equal focus "HEAD")))
             (propertize (concat (if (equal focus "HEAD") "@" "*")
                                 (make-string (1- width) ?\s))
-                        'face 'magit-section-heading))
+                        'font-lock-face 'magit-section-heading))
            ((if (eq type 'tag)
                 (eq magit-refs-show-commit-count 'all)
               magit-refs-show-commit-count)
@@ -705,14 +710,15 @@ line is inserted at all."
                (cond ((> ahead  0) (concat "<" (number-to-string ahead)))
                      ((> behind 0) (concat (number-to-string behind) ">"))
                      (t "="))
-               'face 'magit-dimmed)))
+               'font-lock-face 'magit-dimmed)))
            (t "")))))
 
 (defun magit-refs--propertize-branch (branch ref &optional head-face)
   (let ((face (cdr (cl-find-if (pcase-lambda (`(,re . ,_))
                                  (string-match-p re ref))
                                magit-ref-namespaces))))
-    (propertize branch 'face (if head-face (list face head-face) face))))
+    (propertize branch 'font-lock-face
+                (if head-face (list face head-face) face))))
 
 (defun magit-refs--insert-refname-p (refname)
   (--if-let (-first (pcase-lambda (`(,key . ,_))

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -257,8 +257,9 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
   [:description
    (lambda ()
      (concat
-      (propertize "Configure " 'face 'transient-heading)
-      (propertize (oref transient--prefix scope) 'face 'magit-branch-remote)))
+      (propertize "Configure " 'font-lock-face 'transient-heading)
+      (propertize (oref transient--prefix scope)
+                  'font-lock-face 'magit-branch-remote)))
    ("u" magit-remote.<remote>.url)
    ("U" magit-remote.<remote>.fetch)
    ("s" magit-remote.<remote>.pushurl)
@@ -319,7 +320,7 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
   (propertize (if (or (not branch) magit-prefer-push-default)
                   (if short "pushDefault" "remote.pushDefault")
                 (if short "pushRemote" (format "branch.%s.pushRemote" branch)))
-              'face 'bold))
+              'font-lock-face 'bold))
 
 (defun magit--select-push-remote (prompt-suffix)
   (let* ((branch (or (magit-get-current-branch)

--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -187,7 +187,8 @@ Usually this is just its basename."
                                       "--date=format:%Y%m%d.%H%M"))))
     (save-match-data
       (when (string-match "-dirty\\'" v)
-        (put-text-property (1+ (match-beginning 0)) (length v) 'face 'error v))
+        (put-text-property (1+ (match-beginning 0)) (length v)
+                           'font-lock-face 'error v))
       (if (and v (string-match "\\`[0-9]" v))
           (concat " " v)
         v))))
@@ -215,35 +216,41 @@ Only one letter is shown, the first that applies."
   "Insert number of upstream commits not in the current branch."
   (--when-let (magit-get-upstream-branch)
     (let ((n (cadr (magit-rev-diff-count "HEAD" it))))
-      (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
+      (propertize (number-to-string n)
+                  'font-lock-face (if (> n 0) 'bold 'shadow)))))
 
 (defun magit-repolist-column-unpulled-from-pushremote (_id)
   "Insert number of commits in the push branch but not the current branch."
   (--when-let (magit-get-push-branch nil t)
     (let ((n (cadr (magit-rev-diff-count "HEAD" it))))
-      (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
+      (propertize (number-to-string n)
+                  'font-lock-face (if (> n 0) 'bold 'shadow)))))
 
 (defun magit-repolist-column-unpushed-to-upstream (_id)
   "Insert number of commits in the current branch but not its upstream."
   (--when-let (magit-get-upstream-branch)
     (let ((n (car (magit-rev-diff-count "HEAD" it))))
-      (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
+      (propertize (number-to-string n)
+                  'font-lock-face (if (> n 0) 'bold 'shadow)))))
 
 (defun magit-repolist-column-unpushed-to-pushremote (_id)
   "Insert number of commits in the current branch but not its push branch."
   (--when-let (magit-get-push-branch nil t)
     (let ((n (car (magit-rev-diff-count "HEAD" it))))
-      (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
+      (propertize (number-to-string n)
+                  'font-lock-face (if (> n 0) 'bold 'shadow)))))
 
 (defun magit-repolist-column-branches (_id)
   "Insert number of branches."
   (let ((n (length (magit-list-local-branches))))
-    (propertize (number-to-string n) 'face (if (> n 1) 'bold 'shadow))))
+    (propertize (number-to-string n)
+                'font-lock-face (if (> n 1) 'bold 'shadow))))
 
 (defun magit-repolist-column-stashes (_id)
   "Insert number of stashes."
   (let ((n (length (magit-list-stashes))))
-    (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow))))
+    (propertize (number-to-string n)
+                'font-lock-face (if (> n 0) 'bold 'shadow))))
 
 ;;; Read Repository
 

--- a/lisp/magit-reset.el
+++ b/lisp/magit-reset.el
@@ -61,7 +61,7 @@
   "Reset the `HEAD', index, and working tree to COMMIT.
 \n(git reset --hard REVISION)"
   (interactive (list (magit-reset-read-branch-or-commit
-                      (concat (propertize "Hard" 'face 'bold)
+                      (concat (propertize "Hard" 'font-lock-face 'bold)
                               " reset %s to"))))
   (magit-reset-internal "--hard" commit))
 
@@ -92,7 +92,7 @@ With a prefix argument reset the working tree otherwise don't.
 \n(git reset --mixed|--hard COMMIT)"
   (interactive (list (magit-reset-read-branch-or-commit
                       (if current-prefix-arg
-                          (concat (propertize "Hard" 'face 'bold)
+                          (concat (propertize "Hard" 'font-lock-face 'bold)
                                   " reset %s to")
                         "Reset %s to"))
                      current-prefix-arg))

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -1076,9 +1076,10 @@ insert a newline character if necessary."
   (declare (indent defun))
   (when args
     (let ((heading (apply #'concat args)))
-      (insert (if (text-property-not-all 0 (length heading) 'face nil heading)
+      (insert (if (text-property-not-all 0 (length heading)
+                                         'font-lock-face nil heading)
                   heading
-                (propertize heading 'face 'magit-section-heading)))))
+                (propertize heading 'font-lock-face 'magit-section-heading)))))
   (unless (bolp)
     (insert ?\n))
   (magit-maybe-make-margin-overlay)
@@ -1241,7 +1242,7 @@ invisible."
                           magit-diff-hunk-heading-selection)))
     (setq face (list :foreground (face-foreground face))))
   (let ((ov (make-overlay start end nil t)))
-    (overlay-put ov 'face face)
+    (overlay-put ov 'font-lock-face face)
     (overlay-put ov 'evaporate t)
     (push ov magit-section-highlight-overlays)
     ov))
@@ -1406,11 +1407,12 @@ invisible."
           (overlay-put
            ov 'after-string
            (propertize
-            (car magit-section-visibility-indicator) 'face
+            (car magit-section-visibility-indicator) 'font-lock-face
             (let ((pos (overlay-start ov)))
-              (delq nil (nconc (--map (overlay-get it 'face)
+              (delq nil (nconc (--map (overlay-get it 'font-lock-face)
                                       (overlays-at pos))
-                               (list (get-char-property pos 'face))))))))))))
+                               (list (get-char-property
+                                      pos 'font-lock-face))))))))))))
 
 (defun magit-section-maybe-remove-visibility-indicator (section)
   (when (and magit-section-visibility-indicator

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -511,9 +511,10 @@ This discards all changes made since the sequence started."
    (5 "-r" "Rebase merges" "--rebase-merges=" magit-rebase-merges-select-mode)]
   [:if-not magit-rebase-in-progress-p
    :description (lambda ()
-                  (format (propertize "Rebase %s onto" 'face 'transient-heading)
+                  (format (propertize "Rebase %s onto"
+                                      'font-lock-face 'transient-heading)
                           (propertize (or (magit-get-current-branch) "HEAD")
-                                      'face 'magit-branch-local)))
+                                      'font-lock-face 'magit-branch-local)))
    ("p" magit-rebase-onto-pushremote)
    ("u" magit-rebase-onto-upstream)
    ("e" "elsewhere" magit-rebase-branch)]
@@ -584,7 +585,7 @@ the upstream."
     (or (magit-get-upstream-branch branch)
         (let ((remote (magit-get "branch" branch "remote"))
               (merge  (magit-get "branch" branch "merge"))
-              (u (propertize "@{upstream}" 'face 'bold)))
+              (u (propertize "@{upstream}" 'font-lock-face 'bold)))
           (cond
            ((magit--unnamed-upstream-p remote merge)
             (concat u ", replacing unnamed"))
@@ -831,8 +832,8 @@ If no such sequence is in progress, do nothing."
                    "^\\(pick\\|revert\\) \\([^ ]+\\) \\(.*\\)$" line)
               (magit-bind-match-strings (cmd hash msg) line
                 (magit-insert-section (commit hash)
-                  (insert (propertize cmd 'face 'magit-sequence-pick)
-                          " " (propertize hash 'face 'magit-hash)
+                  (insert (propertize cmd 'font-lock-face 'magit-sequence-pick)
+                          " " (propertize hash 'font-lock-face 'magit-hash)
                           " " msg "\n"))))))
         (magit-sequence-insert-sequence
          (magit-file-line (magit-git-dir (if picking
@@ -875,8 +876,9 @@ If no such sequence is in progress, do nothing."
              (unless (re-search-forward "^Subject: " nil t)
                (goto-char (point-min)))
              (buffer-substring (point) (line-end-position)))))
-      (insert (propertize type 'face face)
-              ?\s (propertize (file-name-nondirectory patch) 'face 'magit-hash)
+      (insert (propertize type 'font-lock-face face)
+              ?\s (propertize (file-name-nondirectory patch)
+                              'font-lock-face 'magit-hash)
               ?\s title
               ?\n))))
 
@@ -921,14 +923,14 @@ status buffer (i.e. the reverse of how they will be applied)."
          (magit-sequence-insert-commit action target 'magit-sequence-pick))
         ((or (or `exec `label)
              (and `merge (guard (not action-options))))
-         (insert (propertize action 'face 'magit-sequence-onto) "\s"
-                 (propertize target 'face 'git-rebase-label) "\n"))
+         (insert (propertize action 'font-lock-face 'magit-sequence-onto) "\s"
+                 (propertize target 'font-lock-face 'git-rebase-label) "\n"))
         (`merge
          (if-let ((hash (and (string-match "-[cC] \\([^ ]+\\)" action-options)
                              (match-string 1 action-options))))
              (magit-insert-section (commit hash)
                (magit-insert-heading
-                 (propertize "merge" 'face 'magit-sequence-pick)
+                 (propertize "merge" 'font-lock-face 'magit-sequence-pick)
                  "\s"
                  (magit-format-rev-summary hash) "\n"))
            (error "failed to parse merge message hash"))))))
@@ -1020,7 +1022,7 @@ status buffer (i.e. the reverse of how they will be applied)."
 (defun magit-sequence-insert-commit (type hash face)
  (magit-insert-section (commit hash)
     (magit-insert-heading
-      (propertize type 'face face)    "\s"
+      (propertize type 'font-lock-face face)    "\s"
       (magit-format-rev-summary hash) "\n")))
 
 ;;; _

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -388,7 +388,7 @@ instead of \"Stashes:\"."
                               autostash))
                         "\0")))
             (magit-insert-section (stash autostash)
-              (insert (propertize "AUTOSTASH" 'face 'magit-hash))
+              (insert (propertize "AUTOSTASH" 'font-lock-face 'magit-hash))
               (insert " " msg "\n")
               (save-excursion
                 (backward-char)
@@ -458,8 +458,9 @@ instead of \"Stashes:\"."
   (magit-set-header-line-format
    (concat (capitalize magit-buffer-revision) " "
            (propertize (magit-rev-format "%s" magit-buffer-revision)
-                       'face (list :weight 'normal :foreground
-                                   (face-attribute 'default :foreground)))))
+                       'font-lock-face
+                       (list :weight 'normal :foreground
+                             (face-attribute 'default :foreground)))))
   (setq magit-buffer-revision-hash (magit-rev-parse magit-buffer-revision))
   (magit-insert-section (stash)
     (magit-run-section-hook 'magit-stash-sections-hook)))

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -428,8 +428,9 @@ the status buffer causes this section to disappear again."
   (when magit-this-error
     (magit-insert-section (error 'git)
       (insert (propertize (format "%-10s" "GitError! ")
-                          'face 'magit-section-heading))
-      (insert (propertize magit-this-error 'face 'font-lock-warning-face))
+                          'font-lock-face 'magit-section-heading))
+      (insert (propertize magit-this-error
+                          'font-lock-face 'font-lock-warning-face))
       (when-let ((key (car (where-is-internal 'magit-process-buffer))))
         (insert (format "  [Type `%s' for details]" (key-description key))))
       (insert ?\n))
@@ -441,7 +442,7 @@ the status buffer causes this section to disappear again."
     (when (or ignore-modules
               magit-buffer-diff-files)
       (insert (propertize (format "%-10s" "Filter! ")
-                          'face 'magit-section-heading))
+                          'font-lock-face 'magit-section-heading))
       (when ignore-modules
         (insert ignore-modules)
         (when magit-buffer-diff-files
@@ -466,14 +467,14 @@ instead.  The optional BRANCH argument is for internal use only."
           (magit-insert-section (branch branch)
             (insert (format "%-10s" "Head: "))
             (when magit-status-show-hashes-in-headers
-              (insert (propertize commit 'face 'magit-hash) ?\s))
-            (insert (propertize branch 'face 'magit-branch-local))
+              (insert (propertize commit 'font-lock-face 'magit-hash) ?\s))
+            (insert (propertize branch 'font-lock-face 'magit-branch-local))
             (insert ?\s)
             (insert (funcall magit-log-format-message-function branch summary))
             (insert ?\n))
         (magit-insert-section (commit commit)
           (insert (format "%-10s" "Head: "))
-          (insert (propertize commit 'face 'magit-hash))
+          (insert (propertize commit 'font-lock-face 'magit-hash))
           (insert ?\s)
           (insert (funcall magit-log-format-message-function nil summary))
           (insert ?\n))))))
@@ -499,7 +500,7 @@ arguments are for internal use only."
            (if upstream
                (concat (and magit-status-show-hashes-in-headers
                             (concat (propertize (magit-rev-format "%h" upstream)
-                                                'face 'magit-hash)
+                                                'font-lock-face 'magit-hash)
                                     " "))
                        upstream " "
                        (funcall magit-log-format-message-function upstream
@@ -508,22 +509,23 @@ arguments are for internal use only."
                                              "(no commit message)"))))
              (cond
               ((magit--unnamed-upstream-p remote merge)
-               (concat (propertize merge  'face 'magit-branch-remote) " from "
-                       (propertize remote 'face 'bold)))
+               (concat (propertize merge  'font-lock-face 'magit-branch-remote)
+                       " from "
+                       (propertize remote 'font-lock-face 'bold)))
               ((magit--valid-upstream-p remote merge)
                (if (equal remote ".")
                    (concat
-                    (propertize merge 'face 'magit-branch-local)
+                    (propertize merge 'font-lock-face 'magit-branch-local)
                     (propertize " does not exist"
-                                'face 'font-lock-warning-face))
+                                'font-lock-face 'font-lock-warning-face))
                  (concat
-                  (propertize merge 'face 'magit-branch-remote)
+                  (propertize merge 'font-lock-face 'magit-branch-remote)
                   (propertize " does not exist on "
-                              'face 'font-lock-warning-face)
-                  (propertize remote 'face 'magit-branch-remote))))
+                              'font-lock-face 'font-lock-warning-face)
+                  (propertize remote 'font-lock-face 'magit-branch-remote))))
               (t
                (propertize "invalid upstream configuration"
-                           'face 'font-lock-warning-face)))))
+                           'font-lock-face 'font-lock-warning-face)))))
           (insert ?\n))))))
 
 (defun magit-insert-push-branch-header ()
@@ -537,7 +539,7 @@ arguments are for internal use only."
            (concat target " "
                    (and magit-status-show-hashes-in-headers
                         (concat (propertize (magit-rev-format "%h" target)
-                                            'face 'magit-hash)
+                                            'font-lock-face 'magit-hash)
                                 " "))
                    (funcall magit-log-format-message-function target
                             (funcall magit-log-format-message-function nil
@@ -547,10 +549,10 @@ arguments are for internal use only."
            (if (magit-remote-p remote)
                (concat target
                        (propertize " does not exist"
-                                   'face 'font-lock-warning-face))
+                                   'font-lock-face 'font-lock-warning-face))
              (concat remote
                      (propertize " remote does not exist"
-                                 'face 'font-lock-warning-face))))))
+                                 'font-lock-face 'font-lock-warning-face))))))
       (insert ?\n))))
 
 (defun magit-insert-tags-header ()
@@ -567,11 +569,12 @@ arguments are for internal use only."
         (insert (format "%-10s" (if both-tags "Tags: " "Tag: ")))
         (cl-flet ((insert-count
                    (tag count face)
-                   (insert (concat (propertize tag 'face 'magit-tag)
+                   (insert (concat (propertize tag 'font-lock-face 'magit-tag)
                                    (and (> count 0)
                                         (format " (%s)"
-                                                (propertize (format "%s" count)
-                                                            'face face)))))))
+                                                (propertize
+                                                 (format "%s" count)
+                                                 'font-lock-face face)))))))
           (when this-tag  (insert-count this-tag this-cnt 'magit-branch-local))
           (when both-tags (insert ", "))
           (when next-tag  (insert-count next-tag next-cnt 'magit-tag)))
@@ -586,7 +589,7 @@ arguments are for internal use only."
     (when (and name email)
       (magit-insert-section (user name)
         (insert (format "%-10s" "User: "))
-        (insert (propertize name 'face 'magit-log-author))
+        (insert (propertize name 'font-lock-face 'magit-log-author))
         (insert " <" email ">\n")))))
 
 (defun magit-insert-repo-header ()
@@ -607,7 +610,7 @@ remote in alphabetic order."
              (url (magit-get "remote" name "url")))
     (magit-insert-section (remote name)
       (insert (format "%-10s" "Remote: "))
-      (insert (propertize name 'face 'magit-branch-remote) ?\s)
+      (insert (propertize name 'font-lock-face 'magit-branch-remote) ?\s)
       (insert url ?\n))))
 
 ;;;; File Sections
@@ -652,7 +655,7 @@ value of that variable can be set using \"D -- DIRECTORY RET g\"."
             (magit-insert-heading "Untracked files:")
             (dolist (file files)
               (magit-insert-section (file file)
-                (insert (propertize file 'face 'magit-filename) ?\n)))
+                (insert (propertize file 'font-lock-face 'magit-filename) ?\n)))
             (insert ?\n)))))))
 
 (magit-define-section-jumper magit-jump-to-tracked "Tracked files" tracked)
@@ -705,7 +708,7 @@ of that variable can be set using \"D -- DIRECTORY RET g\"."
       (if (equal dir directory)
           (let ((file (pop files)))
             (magit-insert-section (file file)
-              (insert (propertize file 'face 'magit-filename) ?\n)))
+              (insert (propertize file 'font-lock-face 'magit-filename) ?\n)))
         (magit-insert-section (file dir t)
           (insert (propertize dir 'file 'magit-filename) ?\n)
           (magit-insert-heading)

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -149,15 +149,16 @@ and also setting this variable to t will lead to tears."
     (replace-regexp-in-string
      "\\[--[^]]+\\]"
      (lambda (match)
-       (format (propertize "[%s]" 'face 'transient-inactive-argument)
+       (format (propertize "[%s]" 'font-lock-face 'transient-inactive-argument)
                (mapconcat (lambda (arg)
-                            (propertize arg 'face
+                            (propertize arg 'font-lock-face
                                         (if (member arg value)
                                             'transient-argument
                                           'transient-inactive-argument)))
                           (save-match-data
                             (split-string (substring match 1 -1) "|"))
-                          (propertize "|" 'face 'transient-inactive-argument))))
+                          (propertize "|" 'font-lock-face
+                                      'transient-inactive-argument))))
      (cl-call-next-method obj))))
 
 ;;;###autoload (autoload 'magit-submodule-add "magit-submodule" nil t)
@@ -411,7 +412,8 @@ whether they are wrapped in an additional section."
         (magit-insert-section (modules nil t)
           (magit-insert-heading
             (format "%s (%s)"
-                    (propertize "Modules" 'face 'magit-section-heading)
+                    (propertize "Modules"
+                                'font-lock-face 'magit-section-heading)
                     (length modules)))
           (magit-insert-section-body
             (magit--insert-modules)))
@@ -429,7 +431,8 @@ or, failing that, the abbreviated HEAD commit hash."
     (magit-insert-section (modules nil t)
       (magit-insert-heading
         (format "%s (%s)"
-                (propertize "Modules overview" 'face 'magit-section-heading)
+                (propertize "Modules overview"
+                            'font-lock-face 'magit-section-heading)
                 (length modules)))
       (magit-insert-section-body
         (magit--insert-modules-overview)))))
@@ -448,20 +451,21 @@ or, failing that, the abbreviated HEAD commit hash."
                 (expand-file-name (file-name-as-directory module))))
           (magit-insert-section (magit-module-section module t)
             (insert (propertize (format path-format module)
-                                'face 'magit-diff-file-heading))
+                                'font-lock-face 'magit-diff-file-heading))
             (if (not (file-exists-p ".git"))
                 (insert "(unpopulated)")
-              (insert (format branch-format
-                              (--if-let (magit-get-current-branch)
-                                  (propertize it 'face 'magit-branch-local)
-                                (propertize "(detached)" 'face 'warning))))
+              (insert (format
+                       branch-format
+                       (--if-let (magit-get-current-branch)
+                           (propertize it 'font-lock-face 'magit-branch-local)
+                         (propertize "(detached)" 'font-lock-face 'warning))))
               (--if-let (magit-git-string "describe" "--tags")
                   (progn (when (and magit-modules-overview-align-numbers
                                     (string-match-p "\\`[0-9]" it))
                            (insert ?\s))
-                         (insert (propertize it 'face 'magit-tag)))
+                         (insert (propertize it 'font-lock-face 'magit-tag)))
                 (--when-let (magit-rev-format "%h")
-                  (insert (propertize it 'face 'magit-hash)))))
+                  (insert (propertize it 'font-lock-face 'magit-hash)))))
             (insert ?\n))))))
   (insert ?\n))
 
@@ -548,8 +552,12 @@ These sections can be expanded to show the respective commits."
       (magit-insert-section section ((eval type) nil t)
         (string-match "\\`\\(.+\\) \\([^ ]+\\)\\'" heading)
         (magit-insert-heading
-          (propertize (match-string 1 heading) 'face 'magit-section-heading) " "
-          (propertize (match-string 2 heading) 'face 'magit-branch-remote) ":")
+          (propertize (match-string 1 heading)
+                      'font-lock-face 'magit-section-heading)
+          " "
+          (propertize (match-string 2 heading)
+                      'font-lock-face 'magit-branch-remote)
+          ":")
         (magit-with-toplevel
           (dolist (module modules)
             (when (magit-module-worktree-p module)
@@ -558,7 +566,9 @@ These sections can be expanded to show the respective commits."
                 (when (magit-file-accessible-directory-p default-directory)
                   (magit-insert-section sec (magit-module-section module t)
                     (magit-insert-heading
-                      (propertize module 'face 'magit-diff-file-heading) ":")
+                      (propertize module
+                                  'font-lock-face 'magit-diff-file-heading)
+                      ":")
                     (magit-git-wash
                         (apply-partially 'magit-log-wash-log 'module)
                       "-c" "push.default=current" "log" "--oneline" range)

--- a/lisp/magit-transient.el
+++ b/lisp/magit-transient.el
@@ -142,12 +142,13 @@
           (if (cdr value)
               (mapconcat (lambda (v)
                            (concat "\n     "
-                                   (propertize v 'face 'transient-value)))
+                                   (propertize
+                                    v 'font-lock-face 'transient-value)))
                          value "")
-            (propertize (car value) 'face 'transient-value))
+            (propertize (car value) 'font-lock-face 'transient-value))
         (propertize (car (split-string value "\n"))
-                    'face 'transient-value))
-    (propertize "unset" 'face 'transient-inactive-value)))
+                    'font-lock-face 'transient-value))
+    (propertize "unset" 'font-lock-face 'transient-inactive-value)))
 
 (cl-defmethod transient-format-value ((obj magit--git-variable:choices))
   (let* ((variable (oref obj variable))
@@ -162,35 +163,36 @@
     (when (functionp choices)
       (setq choices (funcall choices)))
     (concat
-     (propertize "[" 'face 'transient-inactive-value)
+     (propertize "[" 'font-lock-face 'transient-inactive-value)
      (mapconcat (lambda (choice)
-                  (propertize choice 'face (if (equal choice local)
-                                               'transient-value
-                                             'transient-inactive-value)))
+                  (propertize choice 'font-lock-face
+                              (if (equal choice local)
+                                  'transient-value
+                                'transient-inactive-value)))
                 choices
-                (propertize "|" 'face 'transient-inactive-value))
+                (propertize "|" 'font-lock-face 'transient-inactive-value))
      (and (or global fallback default)
           (concat
-           (propertize "|" 'face 'transient-inactive-value)
+           (propertize "|" 'font-lock-face 'transient-inactive-value)
            (cond (global
                   (propertize (concat "global:" global)
-                              'face (cond (local
-                                           'transient-inactive-value)
-                                          ((member global choices)
-                                           'transient-value)
-                                          (t
-                                           'font-lock-warning-face))))
+                              'font-lock-face (cond (local
+                                                     'transient-inactive-value)
+                                                    ((member global choices)
+                                                     'transient-value)
+                                                    (t
+                                                     'font-lock-warning-face))))
                  (fallback
                   (propertize fallback
-                              'face (if local
-                                        'transient-inactive-value
-                                      'transient-value)))
+                              'font-lock-face (if local
+                                                  'transient-inactive-value
+                                                'transient-value)))
                  (default
                    (propertize (concat "default:" default)
-                               'face (if local
-                                         'transient-inactive-value
-                                       'transient-value))))))
-     (propertize "]" 'face 'transient-inactive-value))))
+                               'font-lock-face (if local
+                                                   'transient-inactive-value
+                                                 'transient-value))))))
+     (propertize "]" 'font-lock-face 'transient-inactive-value))))
 
 ;;; _
 (provide 'magit-transient)

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -828,10 +828,11 @@ it aligns with the text area."
 
 (defun magit-face-property-all (face string)
   "Return non-nil if FACE is present in all of STRING."
-  (cl-loop for pos = 0 then (next-single-property-change pos 'face string)
+  (cl-loop for pos = 0 then (next-single-property-change
+                             pos 'font-lock-face string)
            unless pos
              return t
-           for current = (get-text-property pos 'face string)
+           for current = (get-text-property pos 'font-lock-face string)
            unless (if (consp current)
                       (memq face current)
                     (eq face current))
@@ -995,33 +996,6 @@ Imenu's potentially outdated and therefore unreliable cache by
 setting `imenu--index-alist' to nil before calling that function."
   (setq imenu--index-alist nil)
   (which-function))
-
-;;; Kludges for Incompatible Modes
-
-(defvar whitespace-mode)
-
-(defun whitespace-dont-turn-on-in-magit-mode (fn)
-  "Prevent `whitespace-mode' from being turned on in Magit buffers.
-
-Because `whitespace-mode' uses font-lock and Magit does not, they
-are not compatible.  Therefore you cannot turn on that minor-mode
-in Magit buffers.  If you try to enable it anyway, then this
-advice prevents that.
-
-If the reason the attempt is made is that `global-whitespace-mode'
-is enabled, then that is done silently.  However if you call the local
-minor-mode interactively, then that results in an error.
-
-See `magit-diff-paint-whitespace' for an alternative."
-  (if (not (derived-mode-p 'magit-mode))
-      (funcall fn)
-    (setq whitespace-mode nil)
-    (when (eq this-command 'whitespace-mode)
-      (user-error
-       "Whitespace mode NOT enabled because it is not compatible with Magit"))))
-
-(advice-add 'whitespace-turn-on :around
-            'whitespace-dont-turn-on-in-magit-mode)
 
 ;;; Kludges for Custom
 

--- a/lisp/magit-worktree.el
+++ b/lisp/magit-worktree.el
@@ -132,15 +132,16 @@ If there is only one worktree, then insert nothing."
       (magit-insert-section (worktrees)
         (magit-insert-heading "Worktrees:")
         (let* ((cols
-                (mapcar (pcase-lambda (`(,path ,barep ,commit ,branch))
-                          (cons (cond
-                                 (branch (propertize branch
-                                                     'face 'magit-branch-local))
-                                 (commit (propertize (magit-rev-abbrev commit)
-                                                     'face 'magit-hash))
-                                 (barep  "(bare)"))
-                                path))
-                        worktrees))
+                (mapcar
+                 (pcase-lambda (`(,path ,barep ,commit ,branch))
+                   (cons (cond
+                          (branch (propertize
+                                   branch 'font-lock-face 'magit-branch-local))
+                          (commit (propertize (magit-rev-abbrev commit)
+                                              'font-lock-face 'magit-hash))
+                          (barep  "(bare)"))
+                         path))
+                 worktrees))
                (align (1+ (-max (--map (string-width (car it)) cols)))))
           (pcase-dolist (`(,head . ,path) cols)
             (magit-insert-section (worktree path)


### PR DESCRIPTION
https://github.com/magit/magit/issues/2821#issuecomment-253082085 says

> `whitespace-mode` uses font-lock to do its thing. Magit does not use font-lock to to add faces/colors to its buffers. That makes them incompatible because turning on font-lock removes all faces keeping only those that it adds itself.
> 
> The only thing we could do is to somehow prevent `whitespace-mode` from being turned on in magit buffers.

But it looks like all that's needed to make magit compatible with `whitespace-mode` is `s/'face/'font-lock-face/` (I've only done a quick search&replace without reformatting, if this approach is okay I can go back and reformat lines which got longer as needed). The Elisp manual sort of mentions this in [(elisp) Precalculated Fontification](https://www.gnu.org/software/emacs/manual/html_node/elisp/Precalculated-Fontification.html); I'm think about adding some more explicit text about this there:

```diff
modified   doc/lispref/modes.texi
@@ -3201,7 +3201,12 @@ is disabled, @code{font-lock-face} has no effect on the display.
   It is ok for a mode to use @code{font-lock-face} for some text and
 also use the normal Font Lock machinery.  But if the mode does not use
 the normal Font Lock machinery, it should not set the variable
-@code{font-lock-defaults}.
+@code{font-lock-defaults}.  In this case the @code{face} property will
+not be overriden, so using the @code{face} property could work too.
+However, using @code{font-lock-face} is generally preferable as it
+allows the user to control the fontification by toggling
+@code{font-lock-mode}, and lets the code work regardless of whether
+the mode uses Font Lock machinery or not.
```

Also fixes #3885.