### PR TITLE
Fix pull/push push remote strings

### DIFF
--- a/lisp/magit-pull.el
+++ b/lisp/magit-pull.el
@@ -86,7 +86,7 @@ argument the push-remote can be changed before pulling from it."
   :description 'magit-pull--pushbranch-description
   (interactive (list (magit-pull-arguments)))
   (pcase-let ((`(,branch ,remote)
-               (magit--select-push-remote "push there")))
+               (magit--select-push-remote "pull from there")))
     (run-hooks 'magit-credential-hook)
     (magit-run-git-async "pull" args remote branch)))
 

--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -87,7 +87,7 @@ argument the push-remote can be changed before pushed to it."
   :description 'magit-push--pushbranch-description
   (interactive (list (magit-push-arguments)))
   (pcase-let ((`(,_ ,remote)
-               (magit--select-push-remote "pull from there")))
+               (magit--select-push-remote "push there")))
     (run-hooks 'magit-credential-hook)
     (magit-run-git-async "push" "-v" args remote "HEAD")))
 


### PR DESCRIPTION
The description strings of `magit-pull-from-pushremote` and `magit-push-current-to-pushremote` were mixed: `magit-pull-from-pushremote` ended the sentence with "push there", and `magit-push-current-to-pushremote` ended the sentence with "pull from there".