### PR TITLE
Support going from diff to a blob from HEAD

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-576-gabf03b54c+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-585-g157aaca67+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-576-gabf03b54c+1).
+This manual is for Magit version 2.90.1 (v2.90.1-585-g157aaca67+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -2967,14 +2967,15 @@ These commands are available in diff buffers.
 
   From a diff, visit the corresponding file at the appropriate position.
 
-  If the diff shows changes in the worktree, the index, or ~HEAD~, then
-  visit the actual file.  Otherwise, when the diff is about an older
-  commit or a range, then visit the appropriate blob.
-
   If point is on a removed line, then visit the blob for the first
   parent of the commit which removed that line, i.e. the last
   commit where that line still existed.  Otherwise visit the blob
   for the commit whose changes are being shown.
+
+  If point is on a added or context line, then visit the blob that
+  adds that line, or if the diff shows changes in multiple commits,
+  then the last of those commits.  If the diff shows unstaged or
+  staged changes, then visit the worktree file.
 
   Interactively, when the file or blob to be displayed is already
   being displayed in another window of the same frame, then just

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-576-gabf03b54c+1)
+@subtitle for version 2.90.1 (v2.90.1-585-g157aaca67+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-576-gabf03b54c+1).
+This manual is for Magit version 2.90.1 (v2.90.1-585-g157aaca67+1).
 
 @quotation
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -4033,14 +4033,15 @@ These commands are available in diff buffers.
 
 From a diff, visit the corresponding file at the appropriate position.
 
-If the diff shows changes in the worktree, the index, or @code{HEAD}, then
-visit the actual file.  Otherwise, when the diff is about an older
-commit or a range, then visit the appropriate blob.
-
 If point is on a removed line, then visit the blob for the first
 parent of the commit which removed that line, i.e. the last
 commit where that line still existed.  Otherwise visit the blob
 for the commit whose changes are being shown.
+
+If point is on a added or context line, then visit the blob that
+adds that line, or if the diff shows changes in multiple commits,
+then the last of those commits.  If the diff shows unstaged or
+staged changes, then visit the worktree file.
 
 Interactively, when the file or blob to be displayed is already
 being displayed in another window of the same frame, then just

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -510,13 +510,10 @@ If no commit is in progress, then initiate it.  Use the function
 specified by variable `magit-commit-add-log-insert-function' to
 actually insert the entry."
   (interactive)
-  (let ((hunk (and (magit-section-match 'hunk)
-                   (magit-current-section)))
-        (log  (magit-commit-message-buffer)) buf pos)
-    (save-window-excursion
-      (call-interactively #'magit-diff-visit-file)
-      (setq buf (current-buffer))
-      (setq pos (point)))
+  (pcase-let* ((hunk (and (magit-section-match 'hunk)
+                          (magit-current-section)))
+               (log  (magit-commit-message-buffer))
+               (`(,buf ,pos) (magit-diff-visit-file--noselect)))
     (unless log
       (unless (magit-commit-assert nil)
         (user-error "Abort"))

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -523,8 +523,8 @@ actually insert the entry."
       (magit-commit-create)
       (while (not (setq log (magit-commit-message-buffer)))
         (sit-for 0.01)))
-    (save-excursion
-      (with-current-buffer buf
+    (with-current-buffer buf
+      (save-excursion
         (goto-char pos)
         (funcall magit-commit-add-log-insert-function log
                  (magit-file-relative-name)

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -520,12 +520,10 @@ actually insert the entry."
       (magit-commit-create)
       (while (not (setq log (magit-commit-message-buffer)))
         (sit-for 0.01)))
-    (with-current-buffer buf
-      (save-excursion
-        (goto-char pos)
-        (funcall magit-commit-add-log-insert-function log
-                 (magit-file-relative-name)
-                 (and hunk (add-log-current-defun)))))))
+    (magit--with-temp-position buf pos
+      (funcall magit-commit-add-log-insert-function log
+               (magit-file-relative-name)
+               (and hunk (add-log-current-defun))))))
 
 (defun magit-commit-add-log-insert (buffer file defun)
   (with-current-buffer buffer

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1412,7 +1412,9 @@ or `HEAD'."
 
 ;;;;; Position
 
-(defun magit-diff-visit-file--noselect (file &optional in-worktree)
+(defun magit-diff-visit-file--noselect (&optional file in-worktree)
+  (unless file
+    (setq file (magit-file-at-point t t)))
   (let* ((hunk (magit-diff-visit--hunk))
          (last (and magit-diff-visit-previous-blob
                     (not in-worktree)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1419,9 +1419,7 @@ or `HEAD'."
          (last (and magit-diff-visit-previous-blob
                     (not in-worktree)
                     (magit-section-match 'hunk)
-                    (save-excursion
-                      (goto-char (line-beginning-position))
-                      (looking-at "-"))))
+                    (= (char-after (line-beginning-position)) ?-)))
          (line (and hunk (magit-diff-hunk-line   hunk)))
          (col  (and hunk (magit-diff-hunk-column hunk last)))
          (rev  (if last

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -276,20 +276,6 @@ many spaces.  Otherwise, highlight neither."
   :group 'magit-diff
   :type 'boolean)
 
-(defcustom magit-diff-visit-previous-blob t
-  "Whether `magit-diff-visit-file' may visit the previous blob.
-
-When this is t and point is on a removed line in a diff for a
-committed change, then `magit-diff-visit-file' visits the blob
-from the last revision which still had that line.
-
-Currently this is only supported for committed changes, for
-staged and unstaged changes `magit-diff-visit-file' always
-visits the file in the working tree."
-  :package-version '(magit . "2.9.0")
-  :group 'magit-diff
-  :type 'boolean)
-
 (defcustom magit-diff-highlight-keywords t
   "Whether to highlight bracketed keywords in commit messages."
   :package-version '(magit . "2.12.0")
@@ -463,6 +449,22 @@ filter if the log arguments include --follow.  If non-nil, the
 log's file filter is always honored."
   :package-version '(magit . "2.91.0")
   :group 'magit-revision
+  :type 'boolean)
+
+;;;; Visit Commands
+
+(defcustom magit-diff-visit-previous-blob t
+  "Whether `magit-diff-visit-file' may visit the previous blob.
+
+When this is t and point is on a removed line in a diff for a
+committed change, then `magit-diff-visit-file' visits the blob
+from the last revision which still had that line.
+
+Currently this is only supported for committed changes, for
+staged and unstaged changes `magit-diff-visit-file' always
+visits the file in the working tree."
+  :package-version '(magit . "2.9.0")
+  :group 'magit-diff
   :type 'boolean)
 
 ;;; Faces

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1387,7 +1387,11 @@ parent of the commit which removed that line, i.e. the last
 commit where that line still existed.  Otherwise visit the blob
 for the commit whose changes are being shown."
   (interactive (list (magit-file-at-point t t)))
-  (magit-diff-visit-file file t))
+  (if (magit-file-accessible-directory-p file)
+      (magit-diff-visit-directory file t)
+    (pcase-let ((`(,buf ,pos) (magit-diff-visit-file--noselect file)))
+      (switch-to-buffer-other-window buf)
+      (magit-diff-visit--setup buf pos))))
 
 (defun magit-diff-visit-file-worktree (file &optional other-window)
   "From a diff, visit the corresponding file at the appropriate position.
@@ -1405,7 +1409,11 @@ Also see `magit-diff-visit-file' which visits the respective
 blob, unless the diff shows changes in the worktree, the index,
 or `HEAD'."
   (interactive (list (magit-file-at-point t t) current-prefix-arg))
-  (magit-diff-visit-file file other-window t))
+  (if (magit-file-accessible-directory-p file)
+      (magit-diff-visit-directory file other-window)
+    (pcase-let ((`(,buf ,pos) (magit-diff-visit-file--noselect file t)))
+      (magit-display-file-buffer buf)
+      (magit-diff-visit--setup buf pos))))
 
 ;;;;; Internal
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1339,10 +1339,7 @@ function explicitly, in which case OTHER-WINDOW is ignored.
 The optional FORCE-WORKTREE means to force visiting the worktree
 version of the file.  To do this interactively use the command
 `magit-diff-visit-file-worktree' instead."
-  (interactive (list (--if-let (magit-file-at-point)
-                         (expand-file-name it)
-                       (user-error "No file at point"))
-                     current-prefix-arg))
+  (interactive (list (magit-file-at-point t t)))
   (if (magit-file-accessible-directory-p file)
       (magit-diff-visit-directory file other-window)
     (let* ((hunk (magit-diff-visit--hunk))
@@ -1407,9 +1404,7 @@ If point is on a removed line, then visit the blob for the first
 parent of the commit which removed that line, i.e. the last
 commit where that line still existed.  Otherwise visit the blob
 for the commit whose changes are being shown."
-  (interactive (list (--if-let (magit-file-at-point)
-                         (expand-file-name it)
-                       (user-error "No file at point"))))
+  (interactive (list (magit-file-at-point t t)))
   (magit-diff-visit-file file t))
 
 (defun magit-diff-visit-file-worktree (file &optional other-window)
@@ -1427,9 +1422,7 @@ reliable.
 Also see `magit-diff-visit-file' which visits the respective
 blob, unless the diff shows changes in the worktree, the index,
 or `HEAD'."
-  (interactive (list (or (magit-file-at-point)
-                         (user-error "No file at point"))
-                     current-prefix-arg))
+  (interactive (list (magit-file-at-point t t) current-prefix-arg))
   (magit-diff-visit-file file other-window t))
 
 ;;;;; Internal

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2225,10 +2225,9 @@ or a ref which is not a branch, then it inserts nothing."
     (oset section heading-highlight-face 'magit-diff-hunk-heading-highlight)
     (let ((beg (point))
           (rev magit-buffer-revision))
-      (insert (save-excursion ; The risky var query can move point.
-                (with-temp-buffer
-                  (magit-rev-insert-format "%B" rev)
-                  (magit-revision--wash-message))))
+      (insert (with-temp-buffer
+                (magit-rev-insert-format "%B" rev)
+                (magit-revision--wash-message)))
       (if (= (point) (+ beg 2))
           (progn (backward-delete-char 2)
                  (insert "(no message)\n"))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1354,16 +1354,7 @@ version of the file.  To do this interactively use the command
              (switch-to-buffer-other-window buf))
             (t
              (pop-to-buffer buf)))
-      (with-selected-window
-          (or (get-buffer-window buf 'visible)
-              (error "File buffer is not visible"))
-        (when pos
-          (unless (<= (point-min) pos (point-max))
-            (widen))
-          (goto-char pos))
-        (when (magit-anything-unmerged-p file)
-          (smerge-start-session))
-        (run-hooks 'magit-diff-visit-file-hook)))))
+      (magit-diff-visit--setup buf pos))))
 
 (defun magit-diff-visit-file-other-window (file)
   "From a diff, visit the corresponding file at the appropriate position.
@@ -1409,6 +1400,19 @@ or `HEAD'."
                '(nil (inhibit-same-window t))
              '(display-buffer-same-window))))
       (magit-status-setup-buffer directory))))
+
+(defun magit-diff-visit--setup (buf pos)
+  (if-let ((win (get-buffer-window buf 'visible)))
+      (with-selected-window win
+        (when pos
+          (unless (<= (point-min) pos (point-max))
+            (widen))
+          (goto-char pos))
+        (when (and buffer-file-name
+                   (magit-anything-unmerged-p buffer-file-name))
+          (smerge-start-session))
+        (run-hooks 'magit-diff-visit-file-hook))
+    (error "File buffer is not visible")))
 
 ;;;;; Position
 

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -257,10 +257,8 @@ a position in a file-visiting buffer."
   (interactive (list current-prefix-arg
                      (prompt-for-change-log-name)))
   (pcase-let ((`(,buf ,pos) (magit-diff-visit-file--noselect)))
-    (with-current-buffer buf
-      (save-excursion
-        (goto-char pos)
-        (add-change-log-entry whoami file-name other-window)))))
+    (magit--with-temp-position buf pos
+      (add-change-log-entry whoami file-name other-window))))
 
 ;;;###autoload
 (defun magit-add-change-log-entry-other-window (&optional whoami file-name)

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -261,8 +261,8 @@ a position in a file-visiting buffer."
       (call-interactively #'magit-diff-visit-file)
       (setq buf (current-buffer))
       (setq pos (point)))
-    (save-excursion
-      (with-current-buffer buf
+    (with-current-buffer buf
+      (save-excursion
         (goto-char pos)
         (add-change-log-entry whoami file-name other-window)))))
 

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -256,11 +256,7 @@ it acts on the current hunk in a Magit buffer instead of on
 a position in a file-visiting buffer."
   (interactive (list current-prefix-arg
                      (prompt-for-change-log-name)))
-  (let (buf pos)
-    (save-window-excursion
-      (call-interactively #'magit-diff-visit-file)
-      (setq buf (current-buffer))
-      (setq pos (point)))
+  (pcase-let ((`(,buf ,pos) (magit-diff-visit-file--noselect)))
     (with-current-buffer buf
       (save-excursion
         (goto-char pos)
@@ -339,12 +335,12 @@ Neither the blob nor the file buffer are killed when finishing
 the rebase.  If that is undesirable, then it might be better to
 use `magit-rebase-edit-command' instead of this command."
   (interactive)
-  (let ((magit-diff-visit-previous-blob nil))
-    (magit-diff-visit-file (--if-let (magit-file-at-point)
-                               (expand-file-name it)
-                             (user-error "No file at point"))
-                           nil 'switch-to-buffer))
-  (magit-edit-line-commit))
+  (pcase-let ((`(,buf ,pos)
+               (let ((magit-diff-visit-previous-blob nil))
+                 (magit-diff-visit-file--noselect))))
+    (switch-to-buffer buf)
+    (magit-diff-visit--setup buf pos)
+    (magit-edit-line-commit)))
 
 (put 'magit-diff-edit-hunk-commit 'disabled t)
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -953,10 +953,15 @@ Sorted from longest to shortest CYGWIN name."
                             t)
     path))
 
-(defun magit-file-at-point ()
-  (magit-section-case
-    (file (oref it value))
-    (hunk (magit-section-parent-value it))))
+(defun magit-file-at-point (&optional expand assert)
+  (if-let ((file (magit-section-case
+                   (file (oref it value))
+                   (hunk (magit-section-parent-value it)))))
+      (if expand
+          (expand-file-name file (magit-toplevel))
+        file)
+    (when assert
+      (user-error "No file at point"))))
 
 (defun magit-current-file ()
   (or (magit-file-relative-name)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -688,8 +688,8 @@ active, restrict the log to the lines that the region touches."
       (call-interactively #'magit-diff-visit-file)
       (setq buf (current-buffer))
       (setq pos (point)))
-    (save-excursion
-      (with-current-buffer buf
+    (with-current-buffer buf
+      (save-excursion
         (goto-char pos)
         (call-interactively #'magit-log-trace-definition)))))
 
@@ -1283,9 +1283,9 @@ If there is no blob buffer in the same frame, then do nothing."
            (pcase-let ((`(,rev ,buf) magit--update-blob-buffer))
              (setq magit--update-blob-buffer nil)
              (when (buffer-live-p buf)
-               (save-excursion
-                 (with-selected-window (get-buffer-window buf)
-                   (with-current-buffer buf
+               (with-selected-window (get-buffer-window buf)
+                 (with-current-buffer buf
+                   (save-excursion
                      (magit-blob-visit (list (magit-rev-parse rev)
                                              (magit-file-relative-name
                                               magit-buffer-file-name))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -683,11 +683,7 @@ active, restrict the log to the lines that the region touches."
 (defun magit-diff-trace-definition ()
   "Show log for the definition at point in a diff."
   (interactive)
-  (let (buf pos)
-    (save-window-excursion
-      (call-interactively #'magit-diff-visit-file)
-      (setq buf (current-buffer))
-      (setq pos (point)))
+  (pcase-let ((`(,buf ,pos) (magit-diff-visit-file--noselect)))
     (with-current-buffer buf
       (save-excursion
         (goto-char pos)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -684,10 +684,8 @@ active, restrict the log to the lines that the region touches."
   "Show log for the definition at point in a diff."
   (interactive)
   (pcase-let ((`(,buf ,pos) (magit-diff-visit-file--noselect)))
-    (with-current-buffer buf
-      (save-excursion
-        (goto-char pos)
-        (call-interactively #'magit-log-trace-definition)))))
+    (magit--with-temp-position buf pos
+      (call-interactively #'magit-log-trace-definition))))
 
 ;;;###autoload
 (defun magit-log-merged (commit branch &optional args files)

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -1188,6 +1188,15 @@ Like `message', except that `message-log-max' is bound to nil."
   (let ((message-log-max nil))
     (apply #'message format-string args)))
 
+(defmacro magit--with-temp-position (buf pos &rest body)
+  (declare (indent 2))
+  `(with-current-buffer ,buf
+     (save-excursion
+       (save-restriction
+         (widen)
+         (goto-char ,pos)
+         ,@body))))
+
 ;;; _
 (provide 'magit-utils)
 ;;; magit-utils.el ends here


### PR DESCRIPTION
I hope users will notice this change because the changed feature is a very useful, i.e. I hope people use this. I also expect that it will take some users by surprise. The change in behavior is this:

```diff
 * RET (magit-diff-visit-file) on uncommitted change:
   jump to position in file in worktree
 * RET on committed change:
   jump to position in blob from commit
-  * except RET on HEAD change:
-    jump to position in file in worktree
-    therefore it is impossible to jump to a HEAD blob

 * C-RET (magit-diff-visit-file-worktree) on any change:
   jump to position in file in worktree
```

It might take some time for muscle memory to adjust, but being able to jump to a blob from HEAD is a win.