### PR TITLE
magit-process-filter: Strip \r *before* checking prompts

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -220,3 +220,6 @@ c47913461 * Rename magit-{push-current-set-remote => remote-set}-if-missing
 - When deleting a remote branch failed, the logic for deciding whether
   to prune the local remote-tracking ref was too loose, leading to
   false positives.  #3650
+
+- Fix handling of passphrase prompts which are output with leading
+  carriage return, such as those produced by Openssh 8.0.  #3843


### PR DESCRIPTION
As I said in https://github.com/magit/magit/issues/3843#issuecomment-485944696

> We already strip `\r` in `magit-process-filter`; the correct fix would
> be to shuffle the code around so that it happens before password
> prompt checking instead of after.

Fixes #3843.