### PR TITLE
magit-autorevert.el: Define own counter variable

### DIFF
--- a/lisp/magit-autorevert.el
+++ b/lisp/magit-autorevert.el
@@ -207,9 +207,8 @@ This function calls the hook `magit-auto-revert-mode-hook'.")
 
 (defvar magit-auto-revert-toplevel nil)
 
-(when (< emacs-major-version 25)
-  (defvar auto-revert-buffers-counter 1
-    "Incremented each time `auto-revert-buffers' is called"))
+(defvar magit-auto-revert-counter 1
+  "Incremented each time `auto-revert-buffers' is called.")
 
 (defun magit-auto-revert-buffer-p (buffer)
   "Return non-nil if BUFFER visits a file inside the current repository.
@@ -225,10 +224,10 @@ defaults to nil) for any BUFFER."
   ;; Call `magit-toplevel' just once per cycle.
   (unless (and magit-auto-revert-toplevel
                (= (cdr magit-auto-revert-toplevel)
-                  auto-revert-buffers-counter))
+                  magit-auto-revert-counter))
     (setq magit-auto-revert-toplevel
           (cons (or (magit-toplevel) 'no-repo)
-                auto-revert-buffers-counter)))
+                magit-auto-revert-counter)))
   (let ((top (car magit-auto-revert-toplevel)))
     (if (eq top 'no-repo)
         fallback
@@ -239,8 +238,7 @@ defaults to nil) for any BUFFER."
              (file-in-directory-p dir top))))))
 
 (defun auto-revert-buffers--buffer-list-filter ()
-  (when (< emacs-major-version 25)
-    (cl-incf auto-revert-buffers-counter))
+  (cl-incf magit-auto-revert-counter)
   (when auto-revert-buffer-list-filter
     (setq auto-revert-buffer-list
           (-filter auto-revert-buffer-list-filter


### PR DESCRIPTION
### Issue

As of the following Emacs version:

```
In GNU Emacs 27.0.50 (build 2, x86_64-pc-linux-gnu, X toolkit, Xaw3d scroll bars)
 of 2019-04-30 built on thunk
Repository revision: 826f1e260121edc5185e0ed3fa20a781fbddc9a2
Repository branch: master
Windowing system distributor 'The X.Org Foundation', version 11.0.12003000
System Description: Debian GNU/Linux buster/sid
```

the variable `auto-revert-buffers-counter` no longer exists. This gives rise to the following error:

1. `make emacs-Q`
2. <kbd>C-x</kbd><kbd>C-f</kbd>`Makefile`<kbd>RET</kbd>
3. <kbd>RET</kbd><kbd>C-x</kbd><kbd>C-s</kbd>
4. <kbd>C-x</kbd><kbd>g</kbd>
5. <kbd>k</kbd><kbd>y</kbd>

```
Debugger entered--Lisp error: (void-variable auto-revert-buffers-counter)
  (cons (or (magit-toplevel) 'no-repo) auto-revert-buffers-counter)
  (setq magit-auto-revert-toplevel (cons (or (magit-toplevel) 'no-repo) auto-revert-buffers-counter))
  (if (and magit-auto-revert-toplevel (= (cdr magit-auto-revert-toplevel) auto-revert-buffers-counter)) nil (setq magit-auto-revert-toplevel (cons (or (magit-toplevel) 'no-repo) auto-revert-buffers-counter)))
  magit-auto-revert-repository-buffer-p(#<buffer Makefile>)
  -filter(magit-auto-revert-repository-buffer-p (#<buffer Makefile>))
  (setq auto-revert-buffer-list (-filter auto-revert-buffer-list-filter auto-revert-buffer-list))
  (progn (setq auto-revert-buffer-list (-filter auto-revert-buffer-list-filter auto-revert-buffer-list)))
  (if auto-revert-buffer-list-filter (progn (setq auto-revert-buffer-list (-filter auto-revert-buffer-list-filter auto-revert-buffer-list))))
  auto-revert-buffers--buffer-list-filter()
  apply(auto-revert-buffers--buffer-list-filter nil)
  auto-revert-buffers()
  (let ((auto-revert-buffer-list-filter (or auto-revert-buffer-list-filter #'magit-auto-revert-repository-buffer-p))) (auto-revert-buffers))
  (progn (let ((auto-revert-buffer-list-filter (or auto-revert-buffer-list-filter #'magit-auto-revert-repository-buffer-p))) (auto-revert-buffers)))
  (if (and magit-auto-revert-immediately (or global-auto-revert-mode (and magit-auto-revert-mode auto-revert-buffer-list))) (progn (let ((auto-revert-buffer-list-filter (or auto-revert-buffer-list-filter #'magit-auto-revert-repository-buffer-p))) (auto-revert-buffers))))
  magit-auto-revert-buffers()
  (let ((start (current-time)) (magit--refresh-cache (or magit--refresh-cache (list (cons 0 0))))) (if magit-refresh-verbose (progn (message "Refreshing magit..."))) (magit-run-hook-with-benchmark 'magit-pre-refresh-hook) (if (derived-mode-p 'magit-mode) (progn (magit-refresh-buffer))) (let ((it (and magit-refresh-status-buffer (not (derived-mode-p 'magit-status-mode)) (magit-get-mode-buffer 'magit-status-mode)))) (if it (progn (save-current-buffer (set-buffer it) (magit-refresh-buffer))))) (magit-auto-revert-buffers) (cond ((and (not this-command) (memq last-command magit-post-commit-hook-commands)) (magit-run-hook-with-benchmark 'magit-post-commit-hook)) ((memq this-command magit-post-stage-hook-commands) (magit-run-hook-with-benchmark 'magit-post-stage-hook)) ((memq this-command magit-post-unstage-hook-commands) (magit-run-hook-with-benchmark 'magit-post-unstage-hook))) (magit-run-hook-with-benchmark 'magit-post-refresh-hook) (if magit-refresh-verbose (progn (message "Refreshing magit...done (%.3fs, cached %s/%s)" (float-time (time-subtract (current-time) start)) (car (car magit--refresh-cache)) (+ (car (car magit--refresh-cache)) (cdr (car magit--refresh-cache)))))))
  (unwind-protect (let ((start (current-time)) (magit--refresh-cache (or magit--refresh-cache (list (cons 0 0))))) (if magit-refresh-verbose (progn (message "Refreshing magit..."))) (magit-run-hook-with-benchmark 'magit-pre-refresh-hook) (if (derived-mode-p 'magit-mode) (progn (magit-refresh-buffer))) (let ((it (and magit-refresh-status-buffer (not (derived-mode-p ...)) (magit-get-mode-buffer 'magit-status-mode)))) (if it (progn (save-current-buffer (set-buffer it) (magit-refresh-buffer))))) (magit-auto-revert-buffers) (cond ((and (not this-command) (memq last-command magit-post-commit-hook-commands)) (magit-run-hook-with-benchmark 'magit-post-commit-hook)) ((memq this-command magit-post-stage-hook-commands) (magit-run-hook-with-benchmark 'magit-post-stage-hook)) ((memq this-command magit-post-unstage-hook-commands) (magit-run-hook-with-benchmark 'magit-post-unstage-hook))) (magit-run-hook-with-benchmark 'magit-post-refresh-hook) (if magit-refresh-verbose (progn (message "Refreshing magit...done (%.3fs, cached %s/%s)" (float-time (time-subtract (current-time) start)) (car (car magit--refresh-cache)) (+ (car (car magit--refresh-cache)) (cdr (car magit--refresh-cache))))))) (run-hooks 'magit-unwind-refresh-hook))
  (if inhibit-magit-refresh nil (unwind-protect (let ((start (current-time)) (magit--refresh-cache (or magit--refresh-cache (list (cons 0 0))))) (if magit-refresh-verbose (progn (message "Refreshing magit..."))) (magit-run-hook-with-benchmark 'magit-pre-refresh-hook) (if (derived-mode-p 'magit-mode) (progn (magit-refresh-buffer))) (let ((it (and magit-refresh-status-buffer (not ...) (magit-get-mode-buffer ...)))) (if it (progn (save-current-buffer (set-buffer it) (magit-refresh-buffer))))) (magit-auto-revert-buffers) (cond ((and (not this-command) (memq last-command magit-post-commit-hook-commands)) (magit-run-hook-with-benchmark 'magit-post-commit-hook)) ((memq this-command magit-post-stage-hook-commands) (magit-run-hook-with-benchmark 'magit-post-stage-hook)) ((memq this-command magit-post-unstage-hook-commands) (magit-run-hook-with-benchmark 'magit-post-unstage-hook))) (magit-run-hook-with-benchmark 'magit-post-refresh-hook) (if magit-refresh-verbose (progn (message "Refreshing magit...done (%.3fs, cached %s/%s)" (float-time (time-subtract ... start)) (car (car magit--refresh-cache)) (+ (car ...) (cdr ...)))))) (run-hooks 'magit-unwind-refresh-hook)))
  magit-refresh()
  (unwind-protect (let ((inhibit-magit-refresh t)) (magit-wip-commit-before-change files " before discard") (if resolve (progn (magit-discard-files--resolve (nreverse resolve)))) (if resurrect (progn (magit-discard-files--resurrect (nreverse resurrect)))) (if delete (progn (magit-discard-files--delete (nreverse delete) status))) (if rename (progn (magit-discard-files--rename (nreverse rename) status))) (if (or discard discard-new) (progn (magit-discard-files--discard (nreverse discard) (nreverse discard-new)))) (magit-wip-commit-after-apply files " after discard")) (magit-refresh))
  (let ((auto-revert-verbose nil) (type (magit-diff-type (car sections))) (status (magit-file-status)) files delete resurrect rename discard discard-new resolve) (let ((--dolist-tail-- sections)) (while --dolist-tail-- (let ((section (car --dolist-tail--))) (let ((file (eieio-oref section ...))) (setq files (cons file files)) (let* ((val ...)) (if (consp val) (let* ... ...) nil))) (setq --dolist-tail-- (cdr --dolist-tail--))))) (unwind-protect (let ((inhibit-magit-refresh t)) (magit-wip-commit-before-change files " before discard") (if resolve (progn (magit-discard-files--resolve (nreverse resolve)))) (if resurrect (progn (magit-discard-files--resurrect (nreverse resurrect)))) (if delete (progn (magit-discard-files--delete (nreverse delete) status))) (if rename (progn (magit-discard-files--rename (nreverse rename) status))) (if (or discard discard-new) (progn (magit-discard-files--discard (nreverse discard) (nreverse discard-new)))) (magit-wip-commit-after-apply files " after discard")) (magit-refresh)))
  magit-discard-files((#<magit-file-section "Makefile" [file unstaged status] 925-1>))
  (progn (magit-discard-files it))
  (if (null x400) (progn (magit-discard-files it)) nil)
  (let* ((x400 (cdr x393))) (if (null x400) (progn (magit-discard-files it)) nil))
  (cond ((eq x394 'region) (let* ((x395 (cdr x393))) (if (null x395) (progn (magit-discard-region it)) nil))) ((eq x394 'hunk) (let* ((x396 (cdr x393))) (if (null x396) (progn (magit-discard-hunk it)) nil))) ((eq x394 'hunks) (let* ((x397 (cdr x393))) (if (null x397) (progn (magit-discard-hunks it)) nil))) ((eq x394 'file) (let* ((x398 (cdr x393))) (if (null x398) (progn (magit-discard-file it)) nil))) ((eq x394 'files) (let* ((x399 (cdr x393))) (if (null x399) (progn (magit-discard-files it)) nil))) ((eq x394 'list) (let* ((x400 (cdr x393))) (if (null x400) (progn (magit-discard-files it)) nil))) (t nil))
  (let* ((x394 (car x393))) (cond ((eq x394 'region) (let* ((x395 (cdr x393))) (if (null x395) (progn (magit-discard-region it)) nil))) ((eq x394 'hunk) (let* ((x396 (cdr x393))) (if (null x396) (progn (magit-discard-hunk it)) nil))) ((eq x394 'hunks) (let* ((x397 (cdr x393))) (if (null x397) (progn (magit-discard-hunks it)) nil))) ((eq x394 'file) (let* ((x398 (cdr x393))) (if (null x398) (progn (magit-discard-file it)) nil))) ((eq x394 'files) (let* ((x399 (cdr x393))) (if (null x399) (progn (magit-discard-files it)) nil))) ((eq x394 'list) (let* ((x400 (cdr x393))) (if (null x400) (progn (magit-discard-files it)) nil))) (t nil)))
  (if (consp x393) (let* ((x394 (car x393))) (cond ((eq x394 'region) (let* ((x395 (cdr x393))) (if (null x395) (progn (magit-discard-region it)) nil))) ((eq x394 'hunk) (let* ((x396 (cdr x393))) (if (null x396) (progn (magit-discard-hunk it)) nil))) ((eq x394 'hunks) (let* ((x397 (cdr x393))) (if (null x397) (progn (magit-discard-hunks it)) nil))) ((eq x394 'file) (let* ((x398 (cdr x393))) (if (null x398) (progn (magit-discard-file it)) nil))) ((eq x394 'files) (let* ((x399 (cdr x393))) (if (null x399) (progn (magit-discard-files it)) nil))) ((eq x394 'list) (let* ((x400 (cdr x393))) (if (null x400) (progn (magit-discard-files it)) nil))) (t nil))) nil)
  (let* ((x393 (cdr val))) (if (consp x393) (let* ((x394 (car x393))) (cond ((eq x394 'region) (let* ((x395 ...)) (if (null x395) (progn ...) nil))) ((eq x394 'hunk) (let* ((x396 ...)) (if (null x396) (progn ...) nil))) ((eq x394 'hunks) (let* ((x397 ...)) (if (null x397) (progn ...) nil))) ((eq x394 'file) (let* ((x398 ...)) (if (null x398) (progn ...) nil))) ((eq x394 'files) (let* ((x399 ...)) (if (null x399) (progn ...) nil))) ((eq x394 'list) (let* ((x400 ...)) (if (null x400) (progn ...) nil))) (t nil))) nil))
  (cond ((eq x386 'committed) (let* ((x387 (cdr val))) (if (consp x387) (let* ((x389 (cdr x387))) (if (null x389) (progn (user-error "Cannot discard committed changes")) nil)) nil))) ((eq x386 'undefined) (let* ((x390 (cdr val))) (if (consp x390) (let* ((x392 (cdr x390))) (if (null x392) (progn (user-error "Cannot discard this change")) nil)) nil))) (t (let* ((x393 (cdr val))) (if (consp x393) (let* ((x394 (car x393))) (cond ((eq x394 ...) (let* ... ...)) ((eq x394 ...) (let* ... ...)) ((eq x394 ...) (let* ... ...)) ((eq x394 ...) (let* ... ...)) ((eq x394 ...) (let* ... ...)) ((eq x394 ...) (let* ... ...)) (t nil))) nil))))
  (let* ((x386 (car val))) (cond ((eq x386 'committed) (let* ((x387 (cdr val))) (if (consp x387) (let* ((x389 ...)) (if (null x389) (progn ...) nil)) nil))) ((eq x386 'undefined) (let* ((x390 (cdr val))) (if (consp x390) (let* ((x392 ...)) (if (null x392) (progn ...) nil)) nil))) (t (let* ((x393 (cdr val))) (if (consp x393) (let* ((x394 ...)) (cond (... ...) (... ...) (... ...) (... ...) (... ...) (... ...) (t nil))) nil)))))
  (if (consp val) (let* ((x386 (car val))) (cond ((eq x386 'committed) (let* ((x387 (cdr val))) (if (consp x387) (let* (...) (if ... ... nil)) nil))) ((eq x386 'undefined) (let* ((x390 (cdr val))) (if (consp x390) (let* (...) (if ... ... nil)) nil))) (t (let* ((x393 (cdr val))) (if (consp x393) (let* (...) (cond ... ... ... ... ... ... ...)) nil))))) nil)
  (let* ((val (list (magit-diff-type) (magit-diff-scope)))) (if (consp val) (let* ((x386 (car val))) (cond ((eq x386 'committed) (let* ((x387 ...)) (if (consp x387) (let* ... ...) nil))) ((eq x386 'undefined) (let* ((x390 ...)) (if (consp x390) (let* ... ...) nil))) (t (let* ((x393 ...)) (if (consp x393) (let* ... ...) nil))))) nil))
  (progn (let* ((val (list (magit-diff-type) (magit-diff-scope)))) (if (consp val) (let* ((x386 (car val))) (cond ((eq x386 'committed) (let* (...) (if ... ... nil))) ((eq x386 'undefined) (let* (...) (if ... ... nil))) (t (let* (...) (if ... ... nil))))) nil)))
  (if it (progn (let* ((val (list (magit-diff-type) (magit-diff-scope)))) (if (consp val) (let* ((x386 (car val))) (cond ((eq x386 ...) (let* ... ...)) ((eq x386 ...) (let* ... ...)) (t (let* ... ...)))) nil))))
  (let ((it (magit-apply--get-selection))) (if it (progn (let* ((val (list (magit-diff-type) (magit-diff-scope)))) (if (consp val) (let* ((x386 ...)) (cond (... ...) (... ...) (t ...))) nil)))))
  magit-discard()
  funcall-interactively(magit-discard)
  call-interactively(magit-discard nil nil)
  command-execute(magit-discard)
```

### Fix

This PR replaces `auto-revert-buffers-counter` with our own variable `magit-auto-revert-counter` (feel free to rename it as you prefer). It is possible to do this because we already advise `auto-revert-buffers`. In other words, reusing `auto-revert-buffers-counter` was unnecessary to begin with, AFAICS.

Thanks.

### Off-topic question

What's the current preference/policy regarding `subr-x`, `cl-lib`, and `dash` utilities? I noticed `magit-autorevert.el` loads `dash` only to use `--when-let` and `-filter`, both of which have built-in analogues in Emacs 25. The file also loads `cl-lib` just to use `cl-incf`.

Is there interest in replacing `--when-let` with `when-let`, and `-filter` with either `seq-filter` or `cl-delete-if-not`? Is there any preference between the libraries `seq` and `cl-lib`?