### PR TITLE
Goto to the same location within another version and/or view of this file/diff

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1155,11 +1155,15 @@ the file or blob."
                              (car (magit-show-commit--arguments))
                              (list file))
         (save-buffer)
-        (magit-diff-setup-buffer (or (magit-get-current-branch) "HEAD")
-                                 nil
-                                 (car (magit-diff-arguments))
-                                 (list file)
-                                 magit-diff-buffer-file-locked))
+        (let ((line (line-number-at-pos))
+              (col (current-column)))
+          (with-current-buffer
+              (magit-diff-setup-buffer (or (magit-get-current-branch) "HEAD")
+                                       nil
+                                       (car (magit-diff-arguments))
+                                       (list file)
+                                       magit-diff-buffer-file-locked)
+            (magit-diff--goto-position file line col))))
     (user-error "Buffer isn't visiting a file")))
 
 ;;;###autoload

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1154,6 +1154,7 @@ the file or blob."
           (magit-show-commit magit-buffer-refname
                              (car (magit-show-commit--arguments))
                              (list file))
+        (save-buffer)
         (magit-diff-setup-buffer (or (magit-get-current-branch) "HEAD")
                                  nil
                                  (car (magit-diff-arguments))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1141,17 +1141,24 @@ be committed."
 
 ;;;###autoload
 (defun magit-diff-buffer-file ()
-  "Show diff for the blob or file visited in the current buffer."
+  "Show diff for the blob or file visited in the current buffer.
+
+When the buffer visits a blob, then show the respective commit.
+When the buffer visits a file, then show the differenced between
+`HEAD' and the working tree.  In both cases limit the diff to
+the file or blob."
   (interactive)
   (require 'magit)
   (if-let ((file (magit-file-relative-name)))
-      (magit-diff-setup-buffer (or magit-buffer-refname
-                                   (magit-get-current-branch)
-                                   "HEAD")
-                               nil
-                               (car (magit-diff-arguments))
-                               (list file)
-                               magit-diff-buffer-file-locked)
+      (if magit-buffer-refname
+          (magit-show-commit magit-buffer-refname
+                             (car (magit-show-commit--arguments))
+                             (list file))
+        (magit-diff-setup-buffer (or (magit-get-current-branch) "HEAD")
+                                 nil
+                                 (car (magit-diff-arguments))
+                                 (list file)
+                                 magit-diff-buffer-file-locked))
     (user-error "Buffer isn't visiting a file")))
 
 ;;;###autoload

--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -166,7 +166,7 @@ FILE has to be relative to the top directory of the repository."
   (magit-with-toplevel
     (let* ((conf (current-window-configuration))
            (bufA (magit-get-revision-buffer "HEAD" file))
-           (bufB (get-buffer (concat file ".~{index}~")))
+           (bufB (magit-get-revision-buffer "{index}" file))
            (bufBrw (and bufB (with-current-buffer bufB (not buffer-read-only))))
            (bufC (get-file-buffer file))
            (fileBufC (or bufC (find-file-noselect file)))

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -46,7 +46,7 @@
 Switch to a buffer visiting blob REV:FILE,
 creating one if none already exists."
   (interactive (magit-find-file-read-args "Find file"))
-  (pop-to-buffer-same-window (magit-find-file-noselect rev file)))
+  (magit-find-file--internal rev file #'pop-to-buffer-same-window))
 
 ;;;###autoload
 (defun magit-find-file-other-window (rev file)
@@ -54,7 +54,7 @@ creating one if none already exists."
 Like `magit-find-file', but create a new window or reuse an
 existing one."
   (interactive (magit-find-file-read-args "Find file in other window"))
-  (switch-to-buffer-other-window (magit-find-file-noselect rev file)))
+  (magit-find-file--internal rev file #'switch-to-buffer-other-frame))
 
 ;;;###autoload
 (defun magit-find-file-other-frame (rev file)
@@ -62,11 +62,17 @@ existing one."
 Like `magit-find-file', but create a new frame or reuse an
 existing one."
   (interactive (magit-find-file-read-args "Find file in other frame"))
-  (switch-to-buffer-other-frame (magit-find-file-noselect rev file)))
+  (magit-find-file--internal rev file #'switch-to-buffer-other-frame))
 
 (defun magit-find-file-read-args (prompt)
   (let  ((rev (magit-read-branch-or-commit "Find file from revision")))
     (list rev (magit-read-file-from-rev rev prompt))))
+
+(defun magit-find-file--internal (rev file fn)
+  (let ((buf (magit-find-file-noselect rev file))
+        )
+    (funcall fn buf)
+    buf))
 
 (defun magit-find-file-noselect (rev file)
   "Read FILE from REV into a buffer and return the buffer.

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -255,7 +255,9 @@ directory, while reading the FILENAME."
     ("m" "Blame echo" magit-blame-echo)
     ("q" "Quit blame" magit-blame-quit)]
    [("p" "Prev blob"  magit-blob-previous)
-    ("n" "Next blob"  magit-blob-next)]
+    ("n" "Next blob"  magit-blob-next)
+    ("g" "Goto blob"  magit-find-file)
+    ]
    [(5 "C-c r" "Rename file"   magit-file-rename)
     (5 "C-c d" "Delete file"   magit-file-delete)
     (5 "C-c u" "Untrack file"  magit-file-untrack)

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -109,7 +109,8 @@ An empty REV stands for index."
 
 (defun magit-get-revision-buffer (rev file &optional create)
   (funcall (if create 'get-buffer-create 'get-buffer)
-           (format "%s.~%s~" file (if (equal rev "") "index"
+           (format "%s.~%s~" file (if (equal rev "")
+                                      "{index}"
                                     (subst-char-in-string ?/ ?_ rev)))))
 
 (defun magit-revert-rev-file-buffer (_ignore-auto noconfirm)

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -77,9 +77,9 @@ existing one."
 (defun magit-find-file-noselect (rev file)
   "Read FILE from REV into a buffer and return the buffer.
 FILE must be relative to the top directory of the repository."
-  (magit-find-file-noselect-1 rev file 'magit-find-file-hook))
+  (magit-find-file-noselect-1 rev file))
 
-(defun magit-find-file-noselect-1 (rev file hookvar &optional revert)
+(defun magit-find-file-noselect-1 (rev file &optional revert)
   "Read FILE from REV into a buffer and return the buffer.
 FILE must be relative to the top directory of the repository.
 An empty REV stands for index."
@@ -103,7 +103,9 @@ An empty REV stands for index."
                 (if (file-exists-p dir) dir topdir)))
         (setq-local revert-buffer-function #'magit-revert-rev-file-buffer)
         (revert-buffer t t)
-        (run-hooks hookvar))
+        (run-hooks (if (equal rev "{index}")
+                       'magit-find-index-hook
+                     'magit-find-file-hook)))
       (current-buffer))))
 
 (defun magit-get-revision-buffer-create (rev file)
@@ -148,8 +150,7 @@ An empty REV stands for index."
 (defun magit-find-file-index-noselect (file &optional revert)
   "Read FILE from the index into a buffer and return the buffer.
 FILE must to be relative to the top directory of the repository."
-  (magit-find-file-noselect-1 "{index}" file 'magit-find-index-hook
-                              (or revert 'ask-revert)))
+  (magit-find-file-noselect-1 "{index}" file (or revert 'ask-revert)))
 
 (defun magit-update-index ()
   "Update the index with the contents of the current buffer.

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -309,7 +309,7 @@ directory, while reading the FILENAME."
    [("p" "Prev blob"  magit-blob-previous)
     ("n" "Next blob"  magit-blob-next)
     ("g" "Goto blob"  magit-find-file)
-    ]
+    ("w" "Goto file"  magit-blob-visit-file)]
    [(5 "C-c r" "Rename file"   magit-file-rename)
     (5 "C-c d" "Delete file"   magit-file-delete)
     (5 "C-c u" "Untrack file"  magit-file-untrack)
@@ -394,6 +394,16 @@ Currently this only adds the following key bindings.
           (magit-blob-visit it)
         (user-error "You have reached the beginning of time"))
     (user-error "Buffer isn't visiting a file or blob")))
+
+;;;###autoload
+(defun magit-blob-visit-file ()
+  "View the file from the worktree corresponding to the current blob.
+When visiting a blob or the version from the index, then go to
+the same location in the respective file in the working tree."
+  (interactive)
+  (if-let ((file (magit-file-relative-name)))
+      (magit-find-file--internal "{worktree}" file #'pop-to-buffer-same-window)
+    (user-error "Not visiting a blob")))
 
 (defun magit-blob-visit (blob-or-file)
   (if (stringp blob-or-file)

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -93,7 +93,9 @@ An empty REV stands for index."
                                       (buffer-name))))
                 revert)
         (setq magit-buffer-revision
-              (if (string= rev "") "{index}" (magit-rev-format "%H" rev)))
+              (if (equal rev "{index}")
+                  "{index}"
+                (magit-rev-format "%H" rev)))
         (setq magit-buffer-refname rev)
         (setq magit-buffer-file-name (expand-file-name file topdir))
         (setq default-directory
@@ -146,7 +148,7 @@ An empty REV stands for index."
 (defun magit-find-file-index-noselect (file &optional revert)
   "Read FILE from the index into a buffer and return the buffer.
 FILE must to be relative to the top directory of the repository."
-  (magit-find-file-noselect-1 "" file 'magit-find-index-hook
+  (magit-find-file-noselect-1 "{index}" file 'magit-find-index-hook
                               (or revert 'ask-revert)))
 
 (defun magit-update-index ()

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -380,8 +380,7 @@ Currently this only adds the following key bindings.
   (if magit-buffer-file-name
       (magit-blob-visit (or (magit-blob-successor magit-buffer-revision
                                                   magit-buffer-file-name)
-                            magit-buffer-file-name)
-                        (line-number-at-pos))
+                            magit-buffer-file-name))
     (if (buffer-file-name (buffer-base-buffer))
         (user-error "You have reached the end of time")
       (user-error "Buffer isn't visiting a file or blob"))))
@@ -392,20 +391,18 @@ Currently this only adds the following key bindings.
   (if-let ((file (or magit-buffer-file-name
                      (buffer-file-name (buffer-base-buffer)))))
       (--if-let (magit-blob-ancestor magit-buffer-revision file)
-          (magit-blob-visit it (line-number-at-pos))
+          (magit-blob-visit it)
         (user-error "You have reached the beginning of time"))
     (user-error "Buffer isn't visiting a file or blob")))
 
-(defun magit-blob-visit (blob-or-file line)
+(defun magit-blob-visit (blob-or-file)
   (if (stringp blob-or-file)
       (find-file blob-or-file)
     (pcase-let ((`(,rev ,file) blob-or-file))
       (magit-find-file rev file)
       (apply #'message "%s (%s %s ago)"
              (magit-rev-format "%s" rev)
-             (magit--age (magit-rev-format "%ct" rev)))))
-  (goto-char (point-min))
-  (forward-line (1- line)))
+             (magit--age (magit-rev-format "%ct" rev))))))
 
 (defun magit-blob-ancestor (rev file)
   (let ((lines (magit-with-toplevel


### PR DESCRIPTION
This is a sequel to #3848, which cleaned up some of the code that is being reused here. This is all still a bit messy and I plan to clean it up once `git-handler.el` (#2958) is ready. The plan was to implement that library first, but I got stuck early on and concentrated on other things. If I had known that taking some big steps here would be a fairly small amount or work, even without implementation that library first, I probably would have done this much earlier.

I think it's quite a big deal to be able to move between different versions of some code (as a file or a diff) without losing the location. That being said, there probably still are bugs and places where we *could* preserve the location but don't do so yet. Even so this is a big step toward taking care of  #2995. Well at least the parts of that that have something to do with this. That issue lists quite a few unrelated things, but this is the one I really cared about when I wrote that summary. This also closes #3130.