### PR TITLE
Kill associated Magit buffers with C-u C-u q

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-628-gabc75923d+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-652-gab4811f54+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-628-gabc75923d+1).
+This manual is for Magit version 2.90.1 (v2.90.1-652-gab4811f54+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -601,8 +601,11 @@ buffers whose major-modes derive from ~magit-mode~.
 
 - Key: q, magit-mode-bury-buffer
 
-  This command buries the current Magit buffer.  With a prefix
-  argument, it instead kills the buffer.
+  This command buries the current Magit buffer.
+
+  With a prefix argument, it instead kills the buffer.  With a double
+  prefix argument, also kills all other Magit buffers associated with
+  the current project.
 
 - User Option: magit-bury-buffer-function
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-628-gabc75923d+1)
+@subtitle for version 2.90.1 (v2.90.1-652-gab4811f54+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-628-gabc75923d+1).
+This manual is for Magit version 2.90.1 (v2.90.1-652-gab4811f54+1).
 
 @quotation
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -985,8 +985,11 @@ control how buffer names are uniquified.
 @cindex magit-mode-bury-buffer
 @item @kbd{q} @tie{}@tie{}@tie{}@tie{}(@code{magit-mode-bury-buffer})
 
-This command buries the current Magit buffer.  With a prefix
-argument, it instead kills the buffer.
+This command buries the current Magit buffer.
+
+With a prefix argument, it instead kills the buffer.  With a double
+prefix argument, also kills all other Magit buffers associated with
+the current project.
 
 @end table
 

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1071,8 +1071,16 @@ latter is displayed in its place."
 (defun magit-mode-bury-buffer (&optional kill-buffer)
   "Bury the current buffer.
 With a prefix argument, kill the buffer instead.
+With two prefix arguments, also kill all Magit buffers associated
+with this repository.
 This is done using `magit-bury-buffer-function'."
   (interactive "P")
+  ;; Kill all associated Magit buffers when a double prefix arg is given.
+  (when (>= (prefix-numeric-value kill-buffer) 16)
+    (let ((current (current-buffer)))
+      (dolist (buf (magit-mode-get-buffers))
+        (unless (eq buf current)
+          (kill-buffer buf)))))
   (funcall magit-bury-buffer-function kill-buffer))
 
 (defun magit-mode-quit-window (kill-buffer)


### PR DESCRIPTION
As discussed in #3862, with this pull request, a double prefix argument given
to `magit-mode-bury-buffer` will also kill all other Magit buffers associated
with the current project.

I've chosen not to add a new `magit-bury-buffer-function` implementation which
would have that feature (as you've suggested) but just do it directly in
`magit-mode-bury-buffer` so that it will work no matter which
`magit-bury-buffer-function` people are using.