### PR TITLE
magit-find-file-other-window: use correct switch-to-buffer fn

### DIFF
--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -58,7 +58,7 @@ already exists.  If prior to calling this command the current
 buffer and/or cursor position is about the same file, then go to
 the line and column corresponding to that location."
   (interactive (magit-find-file-read-args "Find file in other window"))
-  (magit-find-file--internal rev file #'switch-to-buffer-other-frame))
+  (magit-find-file--internal rev file #'switch-to-buffer-other-window))
 
 ;;;###autoload
 (defun magit-find-file-other-frame (rev file)


### PR DESCRIPTION
Noticed a regression on the MELPA magit when I updated today: `magit-find-file-other-window` would always open up a new frame. Fix was trivial.

Commit message:

> Commit 8e380e892086e9 ("magit-find-file--internal: New function") passes the wrong switch-to-buffer func through to magit-find-file--internal, which caused magit-find-file-other-window to act like its other-frame sibling.

(Don't know if it matters for magit, but my copyright assignment is on file with the GNU.)