### PR TITLE
Give require-match the correct meaning in magit-ido-completing-read

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -69,7 +69,7 @@
 If you have enabled `ivy-mode' or `helm-mode', then you don't
 have to customize this option; `magit-builtin-completing-read'
 will work just fine.  However, if you use Ido completion, then
-you do have to use `magit-ido-completion-read', because Ido is
+you do have to use `magit-ido-completing-read', because Ido is
 less well behaved than the former, more modern alternatives.
 
 If you would like to use Ivy or Helm completion with Magit but

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -570,7 +570,8 @@ drop-in replacement for `completing-read', instead we use
 same name."
   (if (require 'ido-completing-read+ nil t)
       (ido-completing-read+ prompt choices predicate require-match
-                            initial-input hist def)
+                            initial-input hist
+                            (or def (and require-match (car choices))))
     (display-warning 'magit "ido-completing-read+ is not installed
 
 To use Ido completion with Magit you need to install the


### PR DESCRIPTION
Since the REQUIRE-MATCH argument to `magit-completing-read` means that an empty string is not a valid completion (unlike in `completing-read`), I've modified the call to `ido-completing-read+` to prevent it from accepting an empty string from the user when REQUIRE-MATCH is non-nil. This means that magit's ido completion will no longer offer the empty string as the first completion option, and pressing RET without typing anything will accept the first choice.

<strike>If there actually *is* a case where the empty string is desired as the default choice, then the only way to specify that now is to explicitly pass the empty string (not nil) as the default. This might be desired if the calling function *really* wants to make sure the user is intentionally selecting an option instead of just hitting RET to pick the first thing on the list.</strike> Edit: Actually this won't really work because it will kind of mess up the prompt. I think there might not be any good way to specify the empty string as the default when a match is required. This is probably fine.

This pull request also includes a 2nd commit that fixes a typo in the docstring relating to `magit-ido-completing-read`.