### PR TITLE
make magit-mode compatible with whitespace-mode and other font lock using modes (v2)

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -267,6 +267,9 @@
   ~magit-jump-to-skip-worktree~ and ~magit-jump-to-assume-unchanged~, and
   section inserter ~magit-insert-assume-unchanged-files~.  2d0de8614 ff
 
+- Magit buffers are now compatible with ~whitespace-mode~ (and other
+  modes which use font-lock).  #3840
+
 ** Fixes since v2.90.0
 
 - Bumped the minimal required version of ~git-commit~ to the correct

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -187,7 +187,7 @@ bisect run'."
                              (and bad-line (match-string 1 bad-line)))
         (magit-insert-heading
           (propertize (or bad-line (pop lines))
-                      'face 'magit-section-heading))
+                      'font-lock-face 'magit-section-heading))
         (dolist (line lines)
           (insert line "\n"))))
     (insert "\n")))
@@ -220,7 +220,8 @@ bisect run'."
           (narrow-to-region beg (point))
           (goto-char (point-min))
           (magit-insert-section (bisect-item heading t)
-            (insert (propertize heading 'face 'magit-section-secondary-heading))
+            (insert (propertize heading 'font-lock-face
+                                'magit-section-secondary-heading))
             (magit-insert-heading)
             (magit-wash-sequence
              (apply-partially 'magit-log-wash-rev 'bisect-log

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -622,7 +622,7 @@ modes is toggled, then this mode also gets toggled automatically.
           magit-blame-separator))))
 
 (defun magit-blame--update-highlight-overlay (ov)
-  (overlay-put ov 'face (magit-blame--style-get 'highlight-face)))
+  (overlay-put ov 'font-lock-face (magit-blame--style-get 'highlight-face)))
 
 (defun magit-blame--format-string (ov format face)
   (let* ((chunk   (overlay-get ov 'magit-blame-chunk))
@@ -643,15 +643,16 @@ modes is toggled, then this mode also gets toggled automatically.
              (propertize (concat (if (string-prefix-p "\s" format) "\s" "")
                                  "Not Yet Committed"
                                  (if (string-suffix-p "\n" format) "\n" ""))
-                         'face face)
+                         'font-lock-face face)
            (magit--format-spec
-            (propertize format 'face face)
+            (propertize format 'font-lock-face face)
             (cl-flet* ((p0 (s f)
-                           (propertize s 'face (if face
-                                                   (if (listp face)
-                                                       face
-                                                     (list f face))
-                                                 f)))
+                           (propertize s 'font-lock-face
+                                       (if face
+                                           (if (listp face)
+                                               face
+                                             (list f face))
+                                         f)))
                        (p1 (k f)
                            (p0 (cdr (assoc k revinfo)) f))
                        (p2 (k1 k2 f)
@@ -670,15 +671,16 @@ modes is toggled, then this mode also gets toggled automatically.
                          (magit-blame--style-get 'margin-width))))
         (concat str
                 (propertize (make-string (max 0 (- width (length str))) ?\s)
-                            'face face))
+                            'font-lock-face face))
       str)))
 
 (defun magit-blame--format-separator ()
   (propertize
    (concat (propertize "\s" 'display '(space :height (2)))
            (propertize "\n" 'line-height t))
-   'face (list :background
-               (face-attribute 'magit-blame-heading :background nil t))))
+   'font-lock-face (list :background
+                         (face-attribute 'magit-blame-heading
+                                         :background nil t))))
 
 (defun magit-blame--format-time-string (time tz)
   (let* ((time-format (or (magit-blame--style-get 'time-format)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1917,7 +1917,7 @@ section or a child thereof."
       (magit-delete-match)
       (goto-char beg)
       (magit-insert-section (diffstat)
-        (insert (propertize heading 'face 'magit-diff-file-heading))
+        (insert (propertize heading 'font-lock-face 'magit-diff-file-heading))
         (magit-insert-heading)
         (let (files)
           (while (looking-at "^[-0-9]+\t[-0-9]+\t\\(.+\\)$")
@@ -1945,11 +1945,14 @@ section or a child thereof."
                 (when (> le ld)
                   (setq sep (concat (make-string (- le ld) ?\s) sep))))
               (magit-insert-section (file (pop files))
-                (insert (propertize file 'face 'magit-filename) sep cnt " ")
+                (insert (propertize file 'font-lock-face 'magit-filename)
+                        sep cnt " ")
                 (when add
-                  (insert (propertize add 'face 'magit-diffstat-added)))
+                  (insert (propertize add 'font-lock-face
+                                      'magit-diffstat-added)))
                 (when del
-                  (insert (propertize del 'face 'magit-diffstat-removed)))
+                  (insert (propertize del 'font-lock-face
+                                      'magit-diffstat-removed)))
                 (insert "\n")))))
         (if (looking-at "^$") (forward-line) (insert "\n"))))))
 
@@ -1976,7 +1979,7 @@ section or a child thereof."
                              (`(?A ?U) " (added by us)")
                              (`(?U ?A) " (added by them)")
                              (`(?U ?U) "")))
-                   'face 'magit-diff-file-heading))
+                   'font-lock-face 'magit-diff-file-heading))
           (insert ?\n))))
     t)
    ((looking-at (concat "^\\(merged\\|changed in both\\|"
@@ -2051,7 +2054,7 @@ section or a child thereof."
                                 (if (or (not orig) (equal orig file))
                                     file
                                   (format "%s -> %s" orig file)))
-                        'face 'magit-diff-file-heading))
+                        'font-lock-face 'magit-diff-file-heading))
     (magit-insert-heading)
     (unless (equal orig file)
       (oset section source orig))
@@ -2086,7 +2089,7 @@ section or a child thereof."
           (magit-insert-section (magit-module-section module t)
             (magit-insert-heading
               (propertize (concat "modified   " module)
-                          'face 'magit-diff-file-heading)
+                          'font-lock-face 'magit-diff-file-heading)
               " ("
               (cond (rewind "rewind")
                     ((string-match-p "\\.\\.\\." range) "non-ff")
@@ -2111,13 +2114,13 @@ section or a child thereof."
           (magit-insert-section (magit-module-section module)
             (magit-insert-heading
               (propertize (concat "submodule  " module)
-                          'face 'magit-diff-file-heading)
+                          'font-lock-face 'magit-diff-file-heading)
               " (" msg ")"))))
        (t
         (magit-insert-section (magit-module-section module)
           (magit-insert-heading
             (propertize (concat "modified   " module)
-                        'face 'magit-diff-file-heading)
+                        'font-lock-face 'magit-diff-file-heading)
             " ("
             (and modified "modified")
             (and modified untracked " and ")
@@ -2136,7 +2139,8 @@ section or a child thereof."
            (value    (cons about ranges)))
       (magit-delete-line)
       (magit-insert-section section (hunk value)
-        (insert (propertize (concat heading "\n") 'face 'magit-diff-hunk-heading))
+        (insert (propertize (concat heading "\n")
+                            'font-lock-face 'magit-diff-hunk-heading))
         (magit-insert-heading)
         (while (not (or (eobp) (looking-at "^[^-+\s\\]")))
           (forward-line))
@@ -2242,7 +2246,8 @@ or a ref which is not a branch, then it inserts nothing."
                              (match-string 1)
                              (match-string 2))))
         (magit-delete-line)
-        (insert (propertize heading 'face 'magit-section-secondary-heading)))
+        (insert (propertize heading 'font-lock-face
+                            'magit-section-secondary-heading)))
       (magit-insert-heading)
       (if (re-search-forward "-----BEGIN PGP SIGNATURE-----" nil t)
           (progn
@@ -2303,7 +2308,8 @@ or a ref which is not a branch, then it inserts nothing."
                                   (magit-commit-p text)))
                             (`slow
                              (magit-commit-p text)))
-                      (put-text-property beg (point) 'face 'magit-hash)
+                      (put-text-property beg (point)
+                                         'font-lock-face 'magit-hash)
                       (let ((end (point)))
                         (goto-char beg)
                         (magit-insert-section (commit text)
@@ -2318,8 +2324,8 @@ or a ref which is not a branch, then it inserts nothing."
               (let ((beg (match-beginning 0))
                     (end (match-end 0)))
                 (put-text-property
-                 beg end 'face
-                 (if-let ((face (get-text-property beg 'face)))
+                 beg end 'font-lock-face
+                 (if-let ((face (get-text-property beg 'font-lock-face)))
                      (list face 'magit-keyword)
                    'magit-keyword))))))
         (goto-char (point-max))))))
@@ -2345,7 +2351,7 @@ or a ref which is not a branch, then it inserts nothing."
                             (propertize (if (string-prefix-p "refs/notes/" ref)
                                             (substring ref 11)
                                           ref)
-                                        'face 'magit-refname)))
+                                        'font-lock-face 'magit-refname)))
             (forward-char)
             (add-face-text-property beg (point) 'magit-diff-hunk-heading)
             (magit-insert-heading)
@@ -2368,7 +2374,7 @@ or a ref which is not a branch, then it inserts nothing."
       (insert (magit-format-ref-labels it) ?\s))
     (insert (propertize
              (magit-rev-parse (concat magit-buffer-revision "^{commit}"))
-             'face 'magit-hash))
+             'font-lock-face 'magit-hash))
     (magit-insert-heading)
     (let ((beg (point)))
       (magit-rev-insert-format magit-revision-headers-format
@@ -2381,7 +2387,7 @@ or a ref which is not a branch, then it inserts nothing."
             (string-match "^\\([^ ]+\\) \\(.*\\)" line)
             (magit-bind-match-strings (hash msg) line
               (insert "Parent:     ")
-              (insert (propertize hash 'face 'magit-hash))
+              (insert (propertize hash 'font-lock-face 'magit-hash))
               (insert " " msg "\n")))))
       (magit--insert-related-refs
        magit-buffer-revision "--merged" "Merged"
@@ -2393,18 +2399,19 @@ or a ref which is not a branch, then it inserts nothing."
         (let ((tag (car  follows))
               (cnt (cadr follows)))
           (magit-insert-section (tag tag)
-            (insert (format "Follows:    %s (%s)\n"
-                            (propertize tag 'face 'magit-tag)
-                            (propertize (number-to-string cnt)
-                                        'face 'magit-branch-local))))))
+            (insert
+             (format "Follows:    %s (%s)\n"
+                     (propertize tag 'font-lock-face 'magit-tag)
+                     (propertize (number-to-string cnt)
+                                 'font-lock-face 'magit-branch-local))))))
       (when-let ((precedes (magit-get-next-tag magit-buffer-revision t)))
         (let ((tag (car  precedes))
               (cnt (cadr precedes)))
           (magit-insert-section (tag tag)
             (insert (format "Precedes:   %s (%s)\n"
-                            (propertize tag 'face 'magit-tag)
+                            (propertize tag 'font-lock-face 'magit-tag)
                             (propertize (number-to-string cnt)
-                                        'face 'magit-tag))))))
+                                        'font-lock-face 'magit-tag))))))
       (insert ?\n))))
 
 (defun magit--insert-related-refs (rev arg title remote)
@@ -2416,7 +2423,7 @@ or a ref which is not a branch, then it inserts nothing."
           (insert ?\s)
         (insert ?\n (make-string 12 ?\s)))
       (magit-insert-section (branch branch)
-        (insert (propertize branch 'face
+        (insert (propertize branch 'font-lock-face
                             (if (string-prefix-p "remotes/" branch)
                                 'magit-branch-remote
                               'magit-branch-local)))))
@@ -2794,7 +2801,7 @@ are highlighted."
               (put-text-property (1- (line-end-position)) (line-end-position)
                                  'invisible t))
             (put-text-property
-             (point) (1+ (line-end-position)) 'face
+             (point) (1+ (line-end-position)) 'font-lock-face
              (cond
               ((looking-at "^\\+\\+?\\([<=|>]\\)\\{7\\}")
                (setq stage (pcase (list (match-string 1) highlight)
@@ -2880,7 +2887,7 @@ are highlighted."
       (when (and magit-diff-highlight-trailing
                  (looking-at (concat prefix ".*?\\([ \t]+\\)$")))
         (let ((ov (make-overlay (match-beginning 1) (match-end 1) nil t)))
-          (overlay-put ov 'face 'magit-diff-whitespace-warning)
+          (overlay-put ov 'font-lock-face 'magit-diff-whitespace-warning)
           (overlay-put ov 'priority 2)
           (overlay-put ov 'evaporate t)))
       (when (or (and (eq indent 'tabs)
@@ -2889,7 +2896,7 @@ are highlighted."
                      (looking-at (format "%s\\([ \t]* \\{%s,\\}[ \t]*\\)"
                                          prefix indent))))
         (let ((ov (make-overlay (match-beginning 1) (match-end 1) nil t)))
-          (overlay-put ov 'face 'magit-diff-whitespace-warning)
+          (overlay-put ov 'font-lock-face 'magit-diff-whitespace-warning)
           (overlay-put ov 'priority 2)
           (overlay-put ov 'evaporate t))))))
 
@@ -2939,7 +2946,7 @@ are highlighted."
     (magit-diff--make-hunk-overlay
      (oref section start)
      (1- (oref section content))
-     'face 'magit-diff-lines-heading
+     'font-lock-face 'magit-diff-lines-heading
      'display (magit-diff-hunk-region-header section)
      'after-string (magit-diff--hunk-after-string 'magit-diff-lines-heading))
     (run-hook-with-args 'magit-diff-highlight-hunk-region-functions section)
@@ -2956,11 +2963,11 @@ for added and removed lines as for context lines."
       (setq face (list :background (face-attribute face :background))))
     (magit-diff--make-hunk-overlay (oref section content)
                                    (magit-diff-hunk-region-beginning)
-                                   'face face
+                                   'font-lock-face face
                                    'priority 2)
     (magit-diff--make-hunk-overlay (1+ (magit-diff-hunk-region-end))
                                    (oref section end)
-                                   'face face
+                                   'font-lock-face face
                                    'priority 2)))
 
 (defun magit-diff-highlight-hunk-region-using-face (_section)
@@ -2970,7 +2977,7 @@ changing only the `:weight' and/or `:slant' is recommended for that
 face."
   (magit-diff--make-hunk-overlay (magit-diff-hunk-region-beginning)
                                  (1+ (magit-diff-hunk-region-end))
-                                 'face 'magit-diff-hunk-region))
+                                 'font-lock-face 'magit-diff-hunk-region))
 
 (defun magit-diff-highlight-hunk-region-using-overlays (section)
   "Emphasize the hunk-internal region using delimiting horizontal lines.
@@ -2981,7 +2988,7 @@ This is implemented as single-pixel newlines places inside overlays."
             (str (propertize
                   (concat (propertize "\s" 'display '(space :height (1)))
                           (propertize "\n" 'line-height t))
-                  'face 'magit-diff-lines-boundary)))
+                  'font-lock-face 'magit-diff-lines-boundary)))
         (magit-diff--make-hunk-overlay beg (1+ beg) 'before-string str)
         (magit-diff--make-hunk-overlay end (1+ end) 'after-string  str))
     (magit-diff-highlight-hunk-region-using-face section)))
@@ -3002,7 +3009,7 @@ last (visual) lines of the region."
              (color (face-background 'magit-diff-lines-boundary nil t)))
         (cl-flet ((ln (b e &rest face)
                       (magit-diff--make-hunk-overlay
-                       b e 'face face 'after-string
+                       b e 'font-lock-face face 'after-string
                        (magit-diff--hunk-after-string face))))
           (if (= beg end-bol)
               (ln beg beg-eol :overline color :underline color)
@@ -3019,7 +3026,7 @@ last (visual) lines of the region."
 
 (defun magit-diff--hunk-after-string (face)
   (propertize "\s"
-              'face face
+              'font-lock-face face
               'display (list 'space :align-to
                              `(+ (0 . right)
                                  ,(min (window-hscroll)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1120,21 +1120,23 @@ Do not add this to a hook variable."
           (when (and (derived-mode-p 'magit-refs-mode)
                      magit-refs-show-commit-count)
             (insert (make-string (1- magit-refs-focus-column-width) ?\s)))
-          (insert (propertize cherry 'face (if (string= cherry "-")
-                                               'magit-cherry-equivalent
-                                             'magit-cherry-unmatched)))
+          (insert (propertize cherry 'font-lock-face
+                              (if (string= cherry "-")
+                                  'magit-cherry-equivalent
+                                'magit-cherry-unmatched)))
           (insert ?\s))
         (when side
-          (insert (propertize side 'face (if (string= side "<")
-                                             'magit-cherry-equivalent
-                                           'magit-cherry-unmatched)))
+          (insert (propertize side 'font-lock-face
+                              (if (string= side "<")
+                                  'magit-cherry-equivalent
+                                'magit-cherry-unmatched)))
           (insert ?\s))
         (when align
-          (insert (propertize hash 'face 'magit-hash) ?\s))
+          (insert (propertize hash 'font-lock-face 'magit-hash) ?\s))
         (when graph
           (insert graph))
         (unless align
-          (insert (propertize hash 'face 'magit-hash) ?\s))
+          (insert (propertize hash 'font-lock-face 'magit-hash) ?\s))
         (when (and refs (not magit-log-show-refname-after-summary))
           (insert (magit-format-ref-labels refs) ?\s))
         (when (eq style 'reflog)
@@ -1144,7 +1146,7 @@ Do not add this to a hook variable."
                      (substring refsub 0 (if (string-match-p ":" refsub) -2 -1))))))
         (when msg
           (when gpg
-            (setq msg (propertize msg 'face
+            (setq msg (propertize msg 'font-lock-face
                                   (pcase (aref gpg 0)
                                     (?G 'magit-signature-good)
                                     (?B 'magit-signature-bad)
@@ -1221,15 +1223,13 @@ Do not add this to a hook variable."
   (let ((start 0))
     (when (string-match "^\\(squash\\|fixup\\)! " msg start)
       (setq start (match-end 0))
-      (put-text-property (match-beginning 0)
-                         (match-end 0)
-                         'face 'magit-keyword-squash msg))
+      (magit--put-face (match-beginning 0) (match-end 0)
+                       'magit-keyword-squash msg))
     (while (string-match "\\[[^[]*\\]" msg start)
       (setq start (match-end 0))
       (when magit-log-highlight-keywords
-        (put-text-property (match-beginning 0)
-                           (match-end 0)
-                           'face 'magit-keyword msg))))
+        (magit--put-face (match-beginning 0) (match-end 0)
+                         'magit-keyword msg))))
   msg)
 
 (defun magit-log-maybe-show-more-commits (section)
@@ -1340,13 +1340,14 @@ The shortstat style is experimental and rather slow."
                    (symbol-value (magit-margin-option)))))
     (magit-make-margin-overlay
      (concat (and details
-                  (concat (propertize (truncate-string-to-width
-                                       (or author "")
-                                       details-width
-                                       nil ?\s (make-string 1 magit-ellipsis))
-                                      'face 'magit-log-author)
+                  (concat (magit--propertize-face
+                           (truncate-string-to-width
+                            (or author "")
+                            details-width
+                            nil ?\s (make-string 1 magit-ellipsis))
+                           'face 'magit-log-author)
                           " "))
-             (propertize
+             (magit--propertize-face
               (if (stringp style)
                   (format-time-string
                    style
@@ -1371,10 +1372,12 @@ The shortstat style is experimental and rather slow."
              (format
               "%5s %5s%4s"
               (if add
-                  (propertize (format "%s+" add) 'face 'magit-diffstat-added)
+                  (magit--propertize-face (format "%s+" add)
+                                          'magit-diffstat-added)
                 "")
               (if del
-                  (propertize (format "%s-" del) 'face 'magit-diffstat-removed)
+                  (magit--propertize-face (format "%s-" del)
+                                          'magit-diffstat-removed)
                 "")
               files))
          "")
@@ -1464,11 +1467,11 @@ Type \\[magit-log-select-quit] to abort without selecting a commit."
   (when magit-log-select-show-usage
     (let ((pick (propertize (substitute-command-keys
                              "\\[magit-log-select-pick]")
-                            'face
+                            'font-lock-face
                             'magit-header-line-key))
           (quit (propertize (substitute-command-keys
                              "\\[magit-log-select-quit]")
-                            'face
+                            'font-lock-face
                             'magit-header-line-key)))
       (setq msg (format-spec
                  (if msg
@@ -1552,8 +1555,9 @@ Type \\[magit-cherry-pick] to apply the commit at point.
 
 (defun magit-insert-cherry-headers ()
   "Insert headers appropriate for `magit-cherry-mode' buffers."
-  (let ((branch (propertize magit-buffer-refname 'face 'magit-branch-local))
-        (upstream (propertize magit-buffer-upstream 'face
+  (let ((branch (propertize magit-buffer-refname
+                            'font-lock-face 'magit-branch-local))
+        (upstream (propertize magit-buffer-upstream 'font-lock-face
                               (if (magit-local-branch-p magit-buffer-upstream)
                                   'magit-branch-local
                                 'magit-branch-remote))))
@@ -1587,7 +1591,8 @@ Type \\[magit-cherry-pick] to apply the commit at point.
   (when-let ((upstream (magit-get-upstream-branch)))
     (magit-insert-section (unpulled "..@{upstream}" t)
       (magit-insert-heading
-        (format (propertize "Unpulled from %s:" 'face 'magit-section-heading)
+        (format (propertize "Unpulled from %s:"
+                            'font-lock-face 'magit-section-heading)
                 upstream))
       (magit-insert-log "..@{upstream}" magit-buffer-log-args))))
 
@@ -1606,8 +1611,9 @@ Type \\[magit-cherry-pick] to apply the commit at point.
                            magit-status-sections-hook)))
       (magit-insert-section (unpulled (concat ".." it) t)
         (magit-insert-heading
-          (format (propertize "Unpulled from %s:" 'face 'magit-section-heading)
-                  (propertize it 'face 'magit-branch-remote)))
+          (format (propertize "Unpulled from %s:"
+                              'font-lock-face 'magit-section-heading)
+                  (propertize it 'font-lock-face 'magit-branch-remote)))
         (magit-insert-log (concat ".." it) magit-buffer-log-args)))))
 
 (defvar magit-unpushed-section-map
@@ -1637,7 +1643,8 @@ then show the last `magit-log-section-commit-count' commits."
   (when (magit-git-success "rev-parse" "@{upstream}")
     (magit-insert-section (unpushed "@{upstream}..")
       (magit-insert-heading
-        (format (propertize "Unmerged into %s:" 'face 'magit-section-heading)
+        (format (propertize "Unmerged into %s:"
+                            'font-lock-face 'magit-section-heading)
                 (magit-get-upstream-branch)))
       (magit-insert-log "@{upstream}.." magit-buffer-log-args))))
 
@@ -1671,8 +1678,9 @@ Show the last `magit-log-section-commit-count' commits."
                            magit-status-sections-hook)))
       (magit-insert-section (unpushed (concat it "..") t)
         (magit-insert-heading
-          (format (propertize "Unpushed to %s:" 'face 'magit-section-heading)
-                  (propertize it 'face 'magit-branch-remote)))
+          (format (propertize "Unpushed to %s:"
+                              'font-lock-face 'magit-section-heading)
+                  (propertize it 'font-lock-face 'magit-branch-remote)))
         (magit-insert-log (concat it "..") magit-buffer-log-args)))))
 
 ;;;; Auxiliary Log Sections

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -617,7 +617,7 @@ Magit status buffer."
     (magit-insert-section (process)
       (insert (if errcode
                   (format "%3s " (propertize (number-to-string errcode)
-                                             'face 'magit-process-ng))
+                                             'font-lock-face 'magit-process-ng))
                 "run "))
       (unless (equal (expand-file-name pwd)
                      (expand-file-name default-directory))
@@ -626,20 +626,21 @@ Magit status buffer."
        ((and args (equal program magit-git-executable))
         (setq args (-split-at (length magit-git-global-arguments) args))
         (insert (propertize (file-name-nondirectory program)
-                            'face 'magit-section-heading) " ")
+                            'font-lock-face 'magit-section-heading) " ")
         (insert (propertize (char-to-string magit-ellipsis)
-                            'face 'magit-section-heading
+                            'font-lock-face 'magit-section-heading
                             'help-echo (mapconcat #'identity (car args) " ")))
         (insert " ")
         (insert (propertize (mapconcat #'shell-quote-argument (cadr args) " ")
-                            'face 'magit-section-heading)))
+                            'font-lock-face 'magit-section-heading)))
        ((and args (equal program shell-file-name))
-        (insert (propertize (cadr args) 'face 'magit-section-heading)))
+        (insert (propertize (cadr args)
+                            'font-lock-face 'magit-section-heading)))
        (t
         (insert (propertize (file-name-nondirectory program)
-                            'face 'magit-section-heading) " ")
+                            'font-lock-face 'magit-section-heading) " ")
         (insert (propertize (mapconcat #'shell-quote-argument args " ")
-                            'face 'magit-section-heading))))
+                            'font-lock-face 'magit-section-heading))))
       (magit-insert-heading)
       (when errlog
         (if (bufferp errlog)
@@ -906,7 +907,7 @@ as argument."
                           'mouse-face 'highlight
                           'keymap magit-mode-line-process-map
                           'help-echo "mouse-1: Show process buffer"
-                          'face 'magit-mode-line-process))))
+                          'font-lock-face 'magit-mode-line-process))))
     (magit-repository-local-set 'mode-line-process str)
     (dolist (buf (magit-mode-get-buffers))
       (with-current-buffer buf
@@ -930,7 +931,7 @@ If STR is supplied, it replaces the `mode-line-process' text."
                            'mouse-face 'highlight
                            'keymap magit-mode-line-process-map
                            'help-echo error
-                           'face 'magit-mode-line-process-error)))
+                           'font-lock-face 'magit-mode-line-process-error)))
     (magit-repository-local-set 'mode-line-process str)
     (dolist (buf (magit-mode-get-buffers))
       (with-current-buffer buf
@@ -966,7 +967,7 @@ If STR is supplied, it replaces the `mode-line-process' text."
   (let ((status (or mode-line-process
                     (magit-repository-local-get 'mode-line-process))))
     (when (and status
-               (eq (get-text-property 1 'face status)
+               (eq (get-text-property 1 'font-lock-face status)
                    'magit-mode-line-process-error))
       (magit-process-unset-mode-line))))
 
@@ -1053,9 +1054,9 @@ Limited by `magit-process-error-tooltip-max-lines'."
           (set-marker-insertion-type marker nil)
           (insert (propertize (format "%3s" arg)
                               'magit-section section
-                              'face (if (= arg 0)
-                                        'magit-process-ok
-                                      'magit-process-ng)))
+                              'font-lock-face (if (= arg 0)
+                                                  'magit-process-ok
+                                                'magit-process-ng)))
           (set-marker-insertion-type marker t))
         (when magit-process-finish-apply-ansi-colors
           (ansi-color-apply-on-region (oref section content)

--- a/lisp/magit-pull.el
+++ b/lisp/magit-pull.el
@@ -135,12 +135,12 @@ the upstream."
     (or (magit-get-upstream-branch branch)
         (let ((remote (magit-get "branch" branch "remote"))
               (merge  (magit-get "branch" branch "merge"))
-              (u (propertize "@{upstream}" 'face 'bold)))
+              (u (magit--propertize-face "@{upstream}" 'bold)))
           (cond
            ((magit--unnamed-upstream-p remote merge)
             (format "%s of %s"
-                    (propertize merge  'face 'magit-branch-remote)
-                    (propertize remote 'face 'bold)))
+                    (magit--propertize-face merge 'magit-branch-remote)
+                    (magit--propertize-face remote 'bold)))
            ((magit--valid-upstream-p remote merge)
             (concat u ", replacing non-existent"))
            ((or remote merge)

--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -102,8 +102,8 @@ argument the push-remote can be changed before pushed to it."
      (target)
      ((member remote (magit-list-remotes))
       (format "%s, creating it"
-              (propertize (concat remote "/" branch)
-                          'face 'magit-branch-remote)))
+              (magit--propertize-face (concat remote "/" branch)
+                                      'magit-branch-remote)))
      (remote
       (format "%s, replacing invalid" v))
      (t
@@ -154,16 +154,16 @@ the upstream."
     (or (magit-get-upstream-branch branch)
         (let ((remote (magit-get "branch" branch "remote"))
               (merge  (magit-get "branch" branch "merge"))
-              (u (propertize "@{upstream}" 'face 'bold)))
+              (u (magit--propertize-face "@{upstream}" 'bold)))
           (cond
            ((magit--unnamed-upstream-p remote merge)
             (format "%s as %s"
-                    (propertize remote 'face 'bold)
-                    (propertize merge  'face 'magit-branch-remote)))
+                    (magit--propertize-face remote 'bold)
+                    (magit--propertize-face merge 'magit-branch-remote)))
            ((magit--valid-upstream-p remote merge)
             (format "%s creating %s"
-                    (propertize remote 'face 'magit-branch-remote)
-                    (propertize merge  'face 'magit-branch-remote)))
+                    (magit--propertize-face remote 'magit-branch-remote)
+                    (magit--propertize-face merge 'magit-branch-remote)))
            ((or remote merge)
             (concat u ", creating it and replacing invalid"))
            (t
@@ -275,25 +275,25 @@ the popup buffer."
                                  (magit-remote-p "origin")))
                      (refspec (magit-get "remote" remote "push")))
             (format "%s using %s"
-                    (propertize remote  'face 'magit-branch-remote)
-                    (propertize refspec 'face 'bold)))
+                    (magit--propertize-face remote 'magit-branch-remote)
+                    (magit--propertize-face refspec 'bold)))
           (--when-let (and (not (magit-get-push-branch))
                            (magit-get-upstream-branch))
             (format "%s aka %s\n"
                     (magit-branch-set-face it)
-                    (propertize "@{upstream}" 'face 'bold)))
+                    (magit--propertize-face "@{upstream}" 'bold)))
           (--when-let (magit-get-push-branch)
             (format "%s aka %s\n"
                     (magit-branch-set-face it)
-                    (propertize "pushRemote" 'face 'bold)))
+                    (magit--propertize-face "pushRemote" 'bold)))
           (--when-let (magit-get-@{push}-branch)
             (format "%s aka %s\n"
                     (magit-branch-set-face it)
-                    (propertize "@{push}" 'face 'bold)))
+                    (magit--propertize-face "@{push}" 'bold)))
           (format "using %s (%s is %s)\n"
-                  (propertize "git push"     'face 'bold)
-                  (propertize "push.default" 'face 'bold)
-                  (propertize default        'face 'bold))))))
+                  (magit--propertize-face "git push"     'bold)
+                  (magit--propertize-face "push.default" 'bold)
+                  (magit--propertize-face default        'bold))))))
 
 ;;;###autoload
 (defun magit-push-to-remote (remote args)
@@ -312,7 +312,7 @@ these Git variables: `push.default', `remote.pushDefault',
   (magit-run-git-async "push" "-v" args remote))
 
 (defun magit-push-to-remote--desc ()
-  (format "using %s\n" (propertize "git push <remote>" 'face 'bold)))
+  (format "using %s\n" (magit--propertize-face "git push <remote>" 'bold)))
 
 ;;; _
 (provide 'magit-push)

--- a/lisp/magit-reflog.el
+++ b/lisp/magit-reflog.el
@@ -202,9 +202,9 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
                             (delq nil (list command option type))
                             " "))))
     (format "%-16s "
-            (propertize text 'face
-                        (or (cdr (assoc label magit-reflog-labels))
-                            'magit-reflog-other)))))
+            (magit--propertize-face
+             text (or (cdr (assoc label magit-reflog-labels))
+                      'magit-reflog-other)))))
 
 ;;; _
 (provide 'magit-reflog)

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -526,7 +526,7 @@ line is inserted at all."
               (magit-insert-section (tag tag t)
                 (magit-insert-heading
                   (magit-refs--format-focus-column tag 'tag)
-                  (propertize tag 'face 'magit-tag)
+                  (propertize tag 'font-lock-face 'magit-tag)
                   (make-string (max 1 (- magit-refs-primary-column-width
                                          (length tag)))
                                ?\s)
@@ -544,8 +544,9 @@ line is inserted at all."
       (magit-insert-heading
         (let ((pull (magit-get "remote" remote "url"))
               (push (magit-get "remote" remote "pushurl")))
-          (format (propertize "Remote %s (%s):" 'face 'magit-section-heading)
-                  (propertize remote 'face 'magit-branch-remote)
+          (format (propertize "Remote %s (%s):"
+                              'font-lock-face 'magit-section-heading)
+                  (propertize remote 'font-lock-face 'magit-branch-remote)
                   (concat pull (and pull push ", ") push))))
       (let (head)
         (dolist (line (magit-git-lines "for-each-ref" "--format=\
@@ -644,47 +645,49 @@ line is inserted at all."
               (if branch
                   (magit-refs--propertize-branch
                    branch ref (and headp 'magit-branch-current))
-                (propertize "(detached)" 'face 'font-lock-warning-face)))
+                (magit--propertize-face "(detached)"
+                                        'font-lock-warning-face)))
              (u:ahead  (and u:track
                             (string-match "ahead \\([0-9]+\\)" u:track)
-                            (propertize
+                            (magit--propertize-face
                              (concat (and magit-refs-pad-commit-counts " ")
                                      (match-string 1 u:track)
                                      ">")
-                             'face 'magit-dimmed)))
+                             'magit-dimmed)))
              (u:behind (and u:track
                             (string-match "behind \\([0-9]+\\)" u:track)
-                            (propertize
+                            (magit--propertize-face
                              (concat "<"
                                      (match-string 1 u:track)
                                      (and magit-refs-pad-commit-counts " "))
-                             'face 'magit-dimmed)))
+                             'magit-dimmed)))
              (p:ahead  (and pushp p:track
                             (string-match "ahead \\([0-9]+\\)" p:track)
-                            (propertize
+                            (magit--propertize-face
                              (concat (match-string 1 p:track)
                                      ">"
                                      (and magit-refs-pad-commit-counts " "))
-                             'face 'magit-branch-remote)))
+                             'magit-branch-remote)))
              (p:behind (and pushp p:track
                             (string-match "behind \\([0-9]+\\)" p:track)
-                            (propertize
+                            (magit--propertize-face
                              (concat "<"
                                      (match-string 1 p:track)
                                      (and magit-refs-pad-commit-counts " "))
-                             'face 'magit-dimmed))))
+                             'magit-dimmed))))
         (list (1+ (length (concat branch-desc u:ahead p:ahead u:behind)))
               branch
               (magit-refs--format-focus-column branch headp)
               branch-desc u:ahead p:ahead u:behind
               (and upstream
                    (concat (if (equal u:track "[gone]")
-                               (propertize upstream 'face 'error)
+                               (magit--propertize-face upstream 'error)
                              (magit-refs--propertize-branch upstream u:ref))
                            " "))
               (and pushp
                    (concat p:behind
-                           (propertize push 'face 'magit-branch-remote)
+                           (magit--propertize-face
+                            push 'magit-branch-remote)
                            " "))
               (and msg (magit-log-propertize-keywords nil msg)))))))
 
@@ -698,26 +701,27 @@ line is inserted at all."
      (cond ((or (equal ref focus)
                 (and (eq type t)
                      (equal focus "HEAD")))
-            (propertize (concat (if (equal focus "HEAD") "@" "*")
-                                (make-string (1- width) ?\s))
-                        'face 'magit-section-heading))
+            (magit--propertize-face (concat (if (equal focus "HEAD") "@" "*")
+                                            (make-string (1- width) ?\s))
+                                    'magit-section-heading))
            ((if (eq type 'tag)
                 (eq magit-refs-show-commit-count 'all)
               magit-refs-show-commit-count)
             (pcase-let ((`(,behind ,ahead)
                          (magit-rev-diff-count magit-buffer-upstream ref)))
-              (propertize
+              (magit--propertize-face
                (cond ((> ahead  0) (concat "<" (number-to-string ahead)))
                      ((> behind 0) (concat (number-to-string behind) ">"))
                      (t "="))
-               'face 'magit-dimmed)))
+               'magit-dimmed)))
            (t "")))))
 
 (defun magit-refs--propertize-branch (branch ref &optional head-face)
   (let ((face (cdr (cl-find-if (pcase-lambda (`(,re . ,_))
                                  (string-match-p re ref))
                                magit-ref-namespaces))))
-    (propertize branch 'face (if head-face (list face head-face) face))))
+    (magit--propertize-face
+     branch (if head-face (list face head-face) face))))
 
 (defun magit-refs--insert-refname-p (refname)
   (--if-let (-first (pcase-lambda (`(,key . ,_))

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -316,10 +316,11 @@ Delete the symbolic-ref \"refs/remotes/<remote>/HEAD\"."
 (defun magit--push-remote-variable (&optional branch short)
   (unless branch
     (setq branch (magit-get-current-branch)))
-  (propertize (if (or (not branch) magit-prefer-push-default)
-                  (if short "pushDefault" "remote.pushDefault")
-                (if short "pushRemote" (format "branch.%s.pushRemote" branch)))
-              'face 'bold))
+  (magit--propertize-face
+   (if (or (not branch) magit-prefer-push-default)
+       (if short "pushDefault" "remote.pushDefault")
+     (if short "pushRemote" (format "branch.%s.pushRemote" branch)))
+   'bold))
 
 (defun magit--select-push-remote (prompt-suffix)
   (let* ((branch (or (magit-get-current-branch)

--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -187,7 +187,7 @@ Usually this is just its basename."
                                       "--date=format:%Y%m%d.%H%M"))))
     (save-match-data
       (when (string-match "-dirty\\'" v)
-        (put-text-property (1+ (match-beginning 0)) (length v) 'face 'error v))
+        (magit--put-face (1+ (match-beginning 0)) (length v) 'error v))
       (if (and v (string-match "\\`[0-9]" v))
           (concat " " v)
         v))))
@@ -215,35 +215,39 @@ Only one letter is shown, the first that applies."
   "Insert number of upstream commits not in the current branch."
   (--when-let (magit-get-upstream-branch)
     (let ((n (cadr (magit-rev-diff-count "HEAD" it))))
-      (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
+      (magit--propertize-face
+       (number-to-string n) (if (> n 0) 'bold 'shadow)))))
 
 (defun magit-repolist-column-unpulled-from-pushremote (_id)
   "Insert number of commits in the push branch but not the current branch."
   (--when-let (magit-get-push-branch nil t)
     (let ((n (cadr (magit-rev-diff-count "HEAD" it))))
-      (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
+      (magit--propertize-face
+       (number-to-string n) (if (> n 0) 'bold 'shadow)))))
 
 (defun magit-repolist-column-unpushed-to-upstream (_id)
   "Insert number of commits in the current branch but not its upstream."
   (--when-let (magit-get-upstream-branch)
     (let ((n (car (magit-rev-diff-count "HEAD" it))))
-      (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
+      (magit--propertize-face
+       (number-to-string n) (if (> n 0) 'bold 'shadow)))))
 
 (defun magit-repolist-column-unpushed-to-pushremote (_id)
   "Insert number of commits in the current branch but not its push branch."
   (--when-let (magit-get-push-branch nil t)
     (let ((n (car (magit-rev-diff-count "HEAD" it))))
-      (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow)))))
+      (magit--propertize-face
+       (number-to-string n) (if (> n 0) 'bold 'shadow)))))
 
 (defun magit-repolist-column-branches (_id)
   "Insert number of branches."
   (let ((n (length (magit-list-local-branches))))
-    (propertize (number-to-string n) 'face (if (> n 1) 'bold 'shadow))))
+    (magit--propertize-face (number-to-string n) (if (> n 1) 'bold 'shadow))))
 
 (defun magit-repolist-column-stashes (_id)
   "Insert number of stashes."
   (let ((n (length (magit-list-stashes))))
-    (propertize (number-to-string n) 'face (if (> n 0) 'bold 'shadow))))
+    (magit--propertize-face (number-to-string n) (if (> n 0) 'bold 'shadow))))
 
 ;;; Read Repository
 

--- a/lisp/magit-reset.el
+++ b/lisp/magit-reset.el
@@ -61,7 +61,7 @@
   "Reset the `HEAD', index, and working tree to COMMIT.
 \n(git reset --hard REVISION)"
   (interactive (list (magit-reset-read-branch-or-commit
-                      (concat (propertize "Hard" 'face 'bold)
+                      (concat (magit--propertize-face "Hard" 'bold)
                               " reset %s to"))))
   (magit-reset-internal "--hard" commit))
 
@@ -92,7 +92,7 @@ With a prefix argument reset the working tree otherwise don't.
 \n(git reset --mixed|--hard COMMIT)"
   (interactive (list (magit-reset-read-branch-or-commit
                       (if current-prefix-arg
-                          (concat (propertize "Hard" 'face 'bold)
+                          (concat (magit--propertize-face "Hard" 'bold)
                                   " reset %s to")
                         "Reset %s to"))
                      current-prefix-arg))

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -1076,9 +1076,10 @@ insert a newline character if necessary."
   (declare (indent defun))
   (when args
     (let ((heading (apply #'concat args)))
-      (insert (if (text-property-not-all 0 (length heading) 'face nil heading)
+      (insert (if (text-property-not-all 0 (length heading)
+                                         'font-lock-face nil heading)
                   heading
-                (propertize heading 'face 'magit-section-heading)))))
+                (propertize heading 'font-lock-face 'magit-section-heading)))))
   (unless (bolp)
     (insert ?\n))
   (magit-maybe-make-margin-overlay)
@@ -1239,7 +1240,7 @@ invisible."
                           magit-diff-hunk-heading-selection)))
     (setq face (list :foreground (face-foreground face))))
   (let ((ov (make-overlay start end nil t)))
-    (overlay-put ov 'face face)
+    (overlay-put ov 'font-lock-face face)
     (overlay-put ov 'evaporate t)
     (push ov magit-section-highlight-overlays)
     ov))
@@ -1404,11 +1405,12 @@ invisible."
           (overlay-put
            ov 'after-string
            (propertize
-            (car magit-section-visibility-indicator) 'face
+            (car magit-section-visibility-indicator) 'font-lock-face
             (let ((pos (overlay-start ov)))
-              (delq nil (nconc (--map (overlay-get it 'face)
+              (delq nil (nconc (--map (overlay-get it 'font-lock-face)
                                       (overlays-at pos))
-                               (list (get-char-property pos 'face))))))))))))
+                               (list (get-char-property
+                                      pos 'font-lock-face))))))))))))
 
 (defun magit-section-maybe-remove-visibility-indicator (section)
   (when (and magit-section-visibility-indicator

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -584,7 +584,7 @@ the upstream."
     (or (magit-get-upstream-branch branch)
         (let ((remote (magit-get "branch" branch "remote"))
               (merge  (magit-get "branch" branch "merge"))
-              (u (propertize "@{upstream}" 'face 'bold)))
+              (u (magit--propertize-face "@{upstream}" 'bold)))
           (cond
            ((magit--unnamed-upstream-p remote merge)
             (concat u ", replacing unnamed"))
@@ -831,8 +831,8 @@ If no such sequence is in progress, do nothing."
                    "^\\(pick\\|revert\\) \\([^ ]+\\) \\(.*\\)$" line)
               (magit-bind-match-strings (cmd hash msg) line
                 (magit-insert-section (commit hash)
-                  (insert (propertize cmd 'face 'magit-sequence-pick)
-                          " " (propertize hash 'face 'magit-hash)
+                  (insert (propertize cmd 'font-lock-face 'magit-sequence-pick)
+                          " " (propertize hash 'font-lock-face 'magit-hash)
                           " " msg "\n"))))))
         (magit-sequence-insert-sequence
          (magit-file-line (magit-git-dir (if picking
@@ -875,8 +875,9 @@ If no such sequence is in progress, do nothing."
              (unless (re-search-forward "^Subject: " nil t)
                (goto-char (point-min)))
              (buffer-substring (point) (line-end-position)))))
-      (insert (propertize type 'face face)
-              ?\s (propertize (file-name-nondirectory patch) 'face 'magit-hash)
+      (insert (propertize type 'font-lock-face face)
+              ?\s (propertize (file-name-nondirectory patch)
+                              'font-lock-face 'magit-hash)
               ?\s title
               ?\n))))
 
@@ -921,14 +922,14 @@ status buffer (i.e. the reverse of how they will be applied)."
          (magit-sequence-insert-commit action target 'magit-sequence-pick))
         ((or (or `exec `label)
              (and `merge (guard (not action-options))))
-         (insert (propertize action 'face 'magit-sequence-onto) "\s"
-                 (propertize target 'face 'git-rebase-label) "\n"))
+         (insert (propertize action 'font-lock-face 'magit-sequence-onto) "\s"
+                 (propertize target 'font-lock-face 'git-rebase-label) "\n"))
         (`merge
          (if-let ((hash (and (string-match "-[cC] \\([^ ]+\\)" action-options)
                              (match-string 1 action-options))))
              (magit-insert-section (commit hash)
                (magit-insert-heading
-                 (propertize "merge" 'face 'magit-sequence-pick)
+                 (propertize "merge" 'font-lock-face 'magit-sequence-pick)
                  "\s"
                  (magit-format-rev-summary hash) "\n"))
            (error "failed to parse merge message hash"))))))
@@ -1020,7 +1021,7 @@ status buffer (i.e. the reverse of how they will be applied)."
 (defun magit-sequence-insert-commit (type hash face)
  (magit-insert-section (commit hash)
     (magit-insert-heading
-      (propertize type 'face face)    "\s"
+      (propertize type 'font-lock-face face)    "\s"
       (magit-format-rev-summary hash) "\n")))
 
 ;;; _

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -388,7 +388,7 @@ instead of \"Stashes:\"."
                               autostash))
                         "\0")))
             (magit-insert-section (stash autostash)
-              (insert (propertize "AUTOSTASH" 'face 'magit-hash))
+              (insert (propertize "AUTOSTASH" 'font-lock-face 'magit-hash))
               (insert " " msg "\n")
               (save-excursion
                 (backward-char)
@@ -458,8 +458,9 @@ instead of \"Stashes:\"."
   (magit-set-header-line-format
    (concat (capitalize magit-buffer-revision) " "
            (propertize (magit-rev-format "%s" magit-buffer-revision)
-                       'face (list :weight 'normal :foreground
-                                   (face-attribute 'default :foreground)))))
+                       'font-lock-face
+                       (list :weight 'normal :foreground
+                             (face-attribute 'default :foreground)))))
   (setq magit-buffer-revision-hash (magit-rev-parse magit-buffer-revision))
   (magit-insert-section (stash)
     (magit-run-section-hook 'magit-stash-sections-hook)))

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -430,8 +430,9 @@ the status buffer causes this section to disappear again."
   (when magit-this-error
     (magit-insert-section (error 'git)
       (insert (propertize (format "%-10s" "GitError! ")
-                          'face 'magit-section-heading))
-      (insert (propertize magit-this-error 'face 'font-lock-warning-face))
+                          'font-lock-face 'magit-section-heading))
+      (insert (propertize magit-this-error
+                          'font-lock-face 'font-lock-warning-face))
       (when-let ((key (car (where-is-internal 'magit-process-buffer))))
         (insert (format "  [Type `%s' for details]" (key-description key))))
       (insert ?\n))
@@ -443,7 +444,7 @@ the status buffer causes this section to disappear again."
     (when (or ignore-modules
               magit-buffer-diff-files)
       (insert (propertize (format "%-10s" "Filter! ")
-                          'face 'magit-section-heading))
+                          'font-lock-face 'magit-section-heading))
       (when ignore-modules
         (insert ignore-modules)
         (when magit-buffer-diff-files
@@ -468,14 +469,14 @@ instead.  The optional BRANCH argument is for internal use only."
           (magit-insert-section (branch branch)
             (insert (format "%-10s" "Head: "))
             (when magit-status-show-hashes-in-headers
-              (insert (propertize commit 'face 'magit-hash) ?\s))
-            (insert (propertize branch 'face 'magit-branch-local))
+              (insert (propertize commit 'font-lock-face 'magit-hash) ?\s))
+            (insert (propertize branch 'font-lock-face 'magit-branch-local))
             (insert ?\s)
             (insert (funcall magit-log-format-message-function branch summary))
             (insert ?\n))
         (magit-insert-section (commit commit)
           (insert (format "%-10s" "Head: "))
-          (insert (propertize commit 'face 'magit-hash))
+          (insert (propertize commit 'font-lock-face 'magit-hash))
           (insert ?\s)
           (insert (funcall magit-log-format-message-function nil summary))
           (insert ?\n))))))
@@ -501,7 +502,7 @@ arguments are for internal use only."
            (if upstream
                (concat (and magit-status-show-hashes-in-headers
                             (concat (propertize (magit-rev-format "%h" upstream)
-                                                'face 'magit-hash)
+                                                'font-lock-face 'magit-hash)
                                     " "))
                        upstream " "
                        (funcall magit-log-format-message-function upstream
@@ -510,22 +511,23 @@ arguments are for internal use only."
                                              "(no commit message)"))))
              (cond
               ((magit--unnamed-upstream-p remote merge)
-               (concat (propertize merge  'face 'magit-branch-remote) " from "
-                       (propertize remote 'face 'bold)))
+               (concat (propertize merge  'font-lock-face 'magit-branch-remote)
+                       " from "
+                       (propertize remote 'font-lock-face 'bold)))
               ((magit--valid-upstream-p remote merge)
                (if (equal remote ".")
                    (concat
-                    (propertize merge 'face 'magit-branch-local)
+                    (propertize merge 'font-lock-face 'magit-branch-local)
                     (propertize " does not exist"
-                                'face 'font-lock-warning-face))
+                                'font-lock-face 'font-lock-warning-face))
                  (concat
-                  (propertize merge 'face 'magit-branch-remote)
+                  (propertize merge 'font-lock-face 'magit-branch-remote)
                   (propertize " does not exist on "
-                              'face 'font-lock-warning-face)
-                  (propertize remote 'face 'magit-branch-remote))))
+                              'font-lock-face 'font-lock-warning-face)
+                  (propertize remote 'font-lock-face 'magit-branch-remote))))
               (t
                (propertize "invalid upstream configuration"
-                           'face 'font-lock-warning-face)))))
+                           'font-lock-face 'font-lock-warning-face)))))
           (insert ?\n))))))
 
 (defun magit-insert-push-branch-header ()
@@ -539,7 +541,7 @@ arguments are for internal use only."
            (concat target " "
                    (and magit-status-show-hashes-in-headers
                         (concat (propertize (magit-rev-format "%h" target)
-                                            'face 'magit-hash)
+                                            'font-lock-face 'magit-hash)
                                 " "))
                    (funcall magit-log-format-message-function target
                             (funcall magit-log-format-message-function nil
@@ -549,10 +551,10 @@ arguments are for internal use only."
            (if (magit-remote-p remote)
                (concat target
                        (propertize " does not exist"
-                                   'face 'font-lock-warning-face))
+                                   'font-lock-face 'font-lock-warning-face))
              (concat remote
                      (propertize " remote does not exist"
-                                 'face 'font-lock-warning-face))))))
+                                 'font-lock-face 'font-lock-warning-face))))))
       (insert ?\n))))
 
 (defun magit-insert-tags-header ()
@@ -569,11 +571,12 @@ arguments are for internal use only."
         (insert (format "%-10s" (if both-tags "Tags: " "Tag: ")))
         (cl-flet ((insert-count
                    (tag count face)
-                   (insert (concat (propertize tag 'face 'magit-tag)
+                   (insert (concat (propertize tag 'font-lock-face 'magit-tag)
                                    (and (> count 0)
                                         (format " (%s)"
-                                                (propertize (format "%s" count)
-                                                            'face face)))))))
+                                                (propertize
+                                                 (format "%s" count)
+                                                 'font-lock-face face)))))))
           (when this-tag  (insert-count this-tag this-cnt 'magit-branch-local))
           (when both-tags (insert ", "))
           (when next-tag  (insert-count next-tag next-cnt 'magit-tag)))
@@ -588,7 +591,7 @@ arguments are for internal use only."
     (when (and name email)
       (magit-insert-section (user name)
         (insert (format "%-10s" "User: "))
-        (insert (propertize name 'face 'magit-log-author))
+        (insert (propertize name 'font-lock-face 'magit-log-author))
         (insert " <" email ">\n")))))
 
 (defun magit-insert-repo-header ()
@@ -609,7 +612,7 @@ remote in alphabetic order."
              (url (magit-get "remote" name "url")))
     (magit-insert-section (remote name)
       (insert (format "%-10s" "Remote: "))
-      (insert (propertize name 'face 'magit-branch-remote) ?\s)
+      (insert (propertize name 'font-lock-face 'magit-branch-remote) ?\s)
       (insert url ?\n))))
 
 ;;;; File Sections
@@ -654,7 +657,7 @@ value of that variable can be set using \"D -- DIRECTORY RET g\"."
             (magit-insert-heading "Untracked files:")
             (dolist (file files)
               (magit-insert-section (file file)
-                (insert (propertize file 'face 'magit-filename) ?\n)))
+                (insert (propertize file 'font-lock-face 'magit-filename) ?\n)))
             (insert ?\n)))))))
 
 (magit-define-section-jumper magit-jump-to-tracked "Tracked files" tracked)
@@ -725,7 +728,7 @@ of that variable can be set using \"D -- DIRECTORY RET g\"."
       (if (equal dir directory)
           (let ((file (pop files)))
             (magit-insert-section (file file)
-              (insert (propertize file 'face 'magit-filename) ?\n)))
+              (insert (propertize file 'font-lock-face 'magit-filename) ?\n)))
         (magit-insert-section (file dir t)
           (insert (propertize dir 'file 'magit-filename) ?\n)
           (magit-insert-heading)

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -411,7 +411,8 @@ whether they are wrapped in an additional section."
         (magit-insert-section (modules nil t)
           (magit-insert-heading
             (format "%s (%s)"
-                    (propertize "Modules" 'face 'magit-section-heading)
+                    (propertize "Modules"
+                                'font-lock-face 'magit-section-heading)
                     (length modules)))
           (magit-insert-section-body
             (magit--insert-modules)))
@@ -429,7 +430,8 @@ or, failing that, the abbreviated HEAD commit hash."
     (magit-insert-section (modules nil t)
       (magit-insert-heading
         (format "%s (%s)"
-                (propertize "Modules overview" 'face 'magit-section-heading)
+                (propertize "Modules overview"
+                            'font-lock-face 'magit-section-heading)
                 (length modules)))
       (magit-insert-section-body
         (magit--insert-modules-overview)))))
@@ -448,20 +450,21 @@ or, failing that, the abbreviated HEAD commit hash."
                 (expand-file-name (file-name-as-directory module))))
           (magit-insert-section (magit-module-section module t)
             (insert (propertize (format path-format module)
-                                'face 'magit-diff-file-heading))
+                                'font-lock-face 'magit-diff-file-heading))
             (if (not (file-exists-p ".git"))
                 (insert "(unpopulated)")
-              (insert (format branch-format
-                              (--if-let (magit-get-current-branch)
-                                  (propertize it 'face 'magit-branch-local)
-                                (propertize "(detached)" 'face 'warning))))
+              (insert (format
+                       branch-format
+                       (--if-let (magit-get-current-branch)
+                           (propertize it 'font-lock-face 'magit-branch-local)
+                         (propertize "(detached)" 'font-lock-face 'warning))))
               (--if-let (magit-git-string "describe" "--tags")
                   (progn (when (and magit-modules-overview-align-numbers
                                     (string-match-p "\\`[0-9]" it))
                            (insert ?\s))
-                         (insert (propertize it 'face 'magit-tag)))
+                         (insert (propertize it 'font-lock-face 'magit-tag)))
                 (--when-let (magit-rev-format "%h")
-                  (insert (propertize it 'face 'magit-hash)))))
+                  (insert (propertize it 'font-lock-face 'magit-hash)))))
             (insert ?\n))))))
   (insert ?\n))
 
@@ -548,8 +551,12 @@ These sections can be expanded to show the respective commits."
       (magit-insert-section section ((eval type) nil t)
         (string-match "\\`\\(.+\\) \\([^ ]+\\)\\'" heading)
         (magit-insert-heading
-          (propertize (match-string 1 heading) 'face 'magit-section-heading) " "
-          (propertize (match-string 2 heading) 'face 'magit-branch-remote) ":")
+          (propertize (match-string 1 heading)
+                      'font-lock-face 'magit-section-heading)
+          " "
+          (propertize (match-string 2 heading)
+                      'font-lock-face 'magit-branch-remote)
+          ":")
         (magit-with-toplevel
           (dolist (module modules)
             (when (magit-module-worktree-p module)
@@ -558,7 +565,9 @@ These sections can be expanded to show the respective commits."
                 (when (magit-file-accessible-directory-p default-directory)
                   (magit-insert-section sec (magit-module-section module t)
                     (magit-insert-heading
-                      (propertize module 'face 'magit-diff-file-heading) ":")
+                      (propertize module
+                                  'font-lock-face 'magit-diff-file-heading)
+                      ":")
                     (magit-git-wash
                         (apply-partially 'magit-log-wash-log 'module)
                       "-c" "push.default=current" "log" "--oneline" range)

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -831,14 +831,22 @@ it aligns with the text area."
 
 (defun magit-face-property-all (face string)
   "Return non-nil if FACE is present in all of STRING."
-  (cl-loop for pos = 0 then (next-single-property-change pos 'face string)
+  (cl-loop for pos = 0 then (next-single-property-change
+                             pos 'font-lock-face string)
            unless pos
              return t
-           for current = (get-text-property pos 'face string)
+           for current = (get-text-property pos 'font-lock-face string)
            unless (if (consp current)
                       (memq face current)
                     (eq face current))
              return nil))
+
+(defun magit--propertize-face (string face)
+  (propertize string 'face face 'font-lock-face face))
+
+(defun magit--put-face (beg end face string)
+  (put-text-property beg end 'face face string)
+  (put-text-property beg end 'font-lock-face face string))
 
 (defun magit--format-spec (format specification)
   "Like `format-spec' but preserve text properties in SPECIFICATION."
@@ -998,33 +1006,6 @@ Imenu's potentially outdated and therefore unreliable cache by
 setting `imenu--index-alist' to nil before calling that function."
   (setq imenu--index-alist nil)
   (which-function))
-
-;;; Kludges for Incompatible Modes
-
-(defvar whitespace-mode)
-
-(defun whitespace-dont-turn-on-in-magit-mode (fn)
-  "Prevent `whitespace-mode' from being turned on in Magit buffers.
-
-Because `whitespace-mode' uses font-lock and Magit does not, they
-are not compatible.  Therefore you cannot turn on that minor-mode
-in Magit buffers.  If you try to enable it anyway, then this
-advice prevents that.
-
-If the reason the attempt is made is that `global-whitespace-mode'
-is enabled, then that is done silently.  However if you call the local
-minor-mode interactively, then that results in an error.
-
-See `magit-diff-paint-whitespace' for an alternative."
-  (if (not (derived-mode-p 'magit-mode))
-      (funcall fn)
-    (setq whitespace-mode nil)
-    (when (eq this-command 'whitespace-mode)
-      (user-error
-       "Whitespace mode NOT enabled because it is not compatible with Magit"))))
-
-(advice-add 'whitespace-turn-on :around
-            'whitespace-dont-turn-on-in-magit-mode)
 
 ;;; Kludges for Custom
 

--- a/lisp/magit-worktree.el
+++ b/lisp/magit-worktree.el
@@ -132,15 +132,16 @@ If there is only one worktree, then insert nothing."
       (magit-insert-section (worktrees)
         (magit-insert-heading "Worktrees:")
         (let* ((cols
-                (mapcar (pcase-lambda (`(,path ,barep ,commit ,branch))
-                          (cons (cond
-                                 (branch (propertize branch
-                                                     'face 'magit-branch-local))
-                                 (commit (propertize (magit-rev-abbrev commit)
-                                                     'face 'magit-hash))
-                                 (barep  "(bare)"))
-                                path))
-                        worktrees))
+                (mapcar
+                 (pcase-lambda (`(,path ,barep ,commit ,branch))
+                   (cons (cond
+                          (branch (propertize
+                                   branch 'font-lock-face 'magit-branch-local))
+                          (commit (propertize (magit-rev-abbrev commit)
+                                              'font-lock-face 'magit-hash))
+                          (barep  "(bare)"))
+                         path))
+                 worktrees))
                (align (1+ (-max (--map (string-width (car it)) cols)))))
           (pcase-dolist (`(,head . ,path) cols)
             (magit-insert-section (worktree path)


### PR DESCRIPTION
This is a continuation of #3840 which was prematurely merged (and then unmerged, but github doesn't realize that part).

> So I think [all functions that return a propertized string] should use both `face` and `font-lock-face`, because a 3rd party package might insert the string into a buffer without font lock (like transient, where we want `face`), or a buffer with font lock searching enabled (where we would want `font-lock-face`).

I've added a `squash!` commit which does that. Though it occurs that it might be simpler for future maintenance to just always use both `face` and `font-lock-face` regardless of circumstances.