### PR TITLE
Fix diff-switch-range-type.  replace-match requires match # to fix

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1265,7 +1265,7 @@ Change \"revA..revB\" to \"revA...revB\", or vice versa."
             (replace-match (if (string= (match-string 2 magit-buffer-range) "..")
                                "..."
                              "..")
-                           t t magit-buffer-range))
+                           t t magit-buffer-range 2))
     (user-error "No range to change"))
   (magit-refresh))
 


### PR DESCRIPTION
Fixing a simple bug with magit-diff-switch-range-type

Addresses Issue #3898 