### PR TITLE
Add autoload cookies for `magit--handle-bookmark`

### DIFF
--- a/lisp/magit-bookmark.el
+++ b/lisp/magit-bookmark.el
@@ -64,6 +64,7 @@ and the buffer-local values of the variables referenced in its
         bookmark)
     (user-error "Bookmarking is not implemented for %s buffers" major-mode)))
 
+;;;###autoload
 (defun magit--handle-bookmark (bookmark)
   "Open a bookmark created by `magit--make-bookmark'.
 Call the `magit-*-setup-buffer' function of the the major-mode


### PR DESCRIPTION
Make it possible to trigger loading of magit when visiting a magit-status bookmark