### PR TITLE
git-commit-setup-changelog-support: Fix filling

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -574,7 +574,8 @@ Don't use it directly, instead enable `global-git-commit-mode'."
 (put 'git-commit-mode 'permanent-local t)
 
 (defun git-commit-setup-changelog-support ()
-  "Treat ChangeLog entries as paragraphs."
+  "Treat ChangeLog entries as unindented paragraphs."
+  (setq-local fill-indent-according-to-mode t)
   (setq-local paragraph-start (concat paragraph-start "\\|\\*\\|(")))
 
 (defun git-commit-turn-on-auto-fill ()


### PR DESCRIPTION
Change log entries are customarily unindented[1].  In `git-commit-mode`, however, `adaptive-fill-regexp` picks up leading asterisks `"* "` in change log entries, which are subsequently interpreted as a fill prefix of 2 spaces.  Thus, entries like the following:

```
* file: very long description...
```

are "indented" to column 2 when filled:

```
* file: very long
  description...
```

Instead of messing with `adaptive-fill-mode`, the simplest way to avoid this `fill-prefix` by default (but still allow users to enforce it by manually indenting the paragraph's 2nd line) is to enable `fill-indent-according-to-mode`, as was recently done in Emacs' `python-mode` for bug#36056[2].

[1]: `(info "(standards) Style of Change Logs")`
https://www.gnu.org/prep/standards/html_node/Style-of-Change-Logs.html
[2]: https://debbugs.gnu.org/36056