### PR TITLE
Remove conditions for Emacs version lower than 25

### DIFF
--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -683,8 +683,7 @@ modes is toggled, then this mode also gets toggled automatically.
 (defun magit-blame--format-time-string (time tz)
   (let* ((time-format (or (magit-blame--style-get 'time-format)
                           magit-blame-time-format))
-         (tz-in-second (and (not (version< emacs-version "25"))
-                            (string-match "%z" time-format)
+         (tz-in-second (and (string-match "%z" time-format)
                             (car (last (parse-time-string tz))))))
     (format-time-string time-format
                         (seconds-to-time (string-to-number time))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2664,16 +2664,14 @@ actually a `diff' but a `diffstat' section."
 
 (defun magit-diff-use-hunk-region-p ()
   (and (region-active-p)
-       (not (and (if (version< emacs-version "25.1")
-                     (eq this-command 'mouse-drag-region)
-                   ;; TODO implement this from first principals
-                   ;; currently it's trial-and-error
-                   (or (eq this-command 'mouse-drag-region)
-                       (eq last-command 'mouse-drag-region)
-                       ;; When another window was previously
-                       ;; selected then the last-command is
-                       ;; some byte-code function.
-                       (byte-code-function-p last-command)))
+       ;; TODO implement this from first principals
+       ;; currently it's trial-and-error
+       (not (and (or (eq this-command 'mouse-drag-region)
+                     (eq last-command 'mouse-drag-region)
+                     ;; When another window was previously
+                     ;; selected then the last-command is
+                     ;; some byte-code function.
+                     (byte-code-function-p last-command))
                  (eq (region-end) (region-beginning))))))
 
 ;;; Diff Highlight

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -1182,9 +1182,7 @@ evaluated its BODY.  Admittedly that's a bit of a hack."
         (unless (eq magit-section-highlighted-section section)
           (setq magit-section-highlighted-section
                 (and (not (oref section hidden))
-                     section))))
-      (when (version< emacs-version "25.1")
-        (setq deactivate-mark nil)))
+                     section)))))
     (magit-section-maybe-paint-visibility-ellipses)))
 
 (defun magit-section-highlight (section selection)


### PR DESCRIPTION
Since Magit no longer supports Emacs version lower than 25, these conditions should be removed.
