### PR TITLE
Add --invert-grep transient to log

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -391,6 +391,7 @@ the upstream isn't ahead of the current branch) show."
    (7 "=s" "Limit to commits since" "--since=" transient-read-date)
    (7 "=u" "Limit to commits until" "--until=" transient-read-date)
    (magit-log:--grep)
+   ("-I" "Invert search pattern" "--invert-grep")
    (magit-log:-G)     ;2
    (magit-log:-S)     ;2
    (magit-log:-L)     ;2
@@ -445,6 +446,7 @@ the upstream isn't ahead of the current branch) show."
     (magit-log:-n)
     (magit:--author)
     (magit-log:--grep)
+    ("-I" "Invert search pattern" "--invert-grep")
     (magit-log:-G)
     (magit-log:-S)
     (magit-log:-L)]


### PR DESCRIPTION
Sometimes it is useful to filter out commits that match a certain
pattern, which is tedious to do with just --grep and a breeze with
--invert-grep flag.