### PR TITLE
apply: Adjust hunk line positions for partial application

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -371,6 +371,10 @@
   paths relative to the current directory instead of the top-level of
   the repository.  6d3f12d58
 
+- Staging a hunk applied the change to the wrong location in rare
+  cases where repetitive diff context prevented ~git apply~ from
+  finding the correct location.  #3924
+
 - Various bug fixes to
   ~magit-branch-delete~ (3e73ff19d),
   ~magit--{upstream,pushbranch}-suffix-predicate~ (0ce7fbbc2),


### PR DESCRIPTION
When applying a hunk or a region of a hunk that is not the first hunk
from the file, the line number in the header for the new start
position will often be incorrect because it accounts for content of
the ignored hunk(s) from above.  This usually isn't problematic
because there is enough context for 'git apply' to locate the
appropriate spot, but, in some cases where the context is too
repetitive to identify the location, it can lead to incorrect staging.

Note that the problem here is simpler than the one that 'git add -p' needs
to solve because, due to Magit's restrictions on what makes a valid
selection, we know that the hunks are contiguous and from the same
file.

Re: #3924