### PR TITLE
magit-repolist-column-dirty: Change order to staged, unstaged, untracked

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-750-g7e6b544aa+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-751-gc7077c593+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-750-g7e6b544aa+1).
+This manual is for Magit version 2.90.1 (v2.90.1-751-gc7077c593+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -2431,9 +2431,9 @@ The following functions can be added to the above option:
 
   This function inserts a letter if there are uncommitted changes:
 
-  - N if there is at least one untracked file.
-  - U if there is at least one unstaged file.
   - S if there is at least one staged file.
+  - U if there is at least one unstaged file.
+  - N if there is at least one untracked file.
 
   Only the first one of these that applies is shown.
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-750-g7e6b544aa+1)
+@subtitle for version 2.90.1 (v2.90.1-751-gc7077c593+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-750-g7e6b544aa+1).
+This manual is for Magit version 2.90.1 (v2.90.1-751-gc7077c593+1).
 
 @quotation
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -3249,13 +3249,13 @@ This function inserts a letter if there are uncommitted changes:
 
 @itemize
 @item
-N if there is at least one untracked file.
+S if there is at least one staged file.
 
 @item
 U if there is at least one unstaged file.
 
 @item
-S if there is at least one staged file.
+N if there is at least one untracked file.
 @end itemize
 
 Only the first one of these that applies is shown.

--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -207,9 +207,9 @@ Show N if there is at least one untracked file.
 Show U if there is at least one unstaged file.
 Show S if there is at least one staged file.
 Only one letter is shown, the first that applies."
-  (cond ((magit-untracked-files) "N")
+  (cond ((magit-staged-files)    "S")
         ((magit-unstaged-files)  "U")
-        ((magit-staged-files)    "S")))
+        ((magit-untracked-files) "N")))
 
 (defun magit-repolist-column-unpulled-from-upstream (_id)
   "Insert number of upstream commits not in the current branch."


### PR DESCRIPTION
Use the order of urgency ("WIPness"): uncommitted files are generally
much more interesting than untracked files.