### PR TITLE
magit-repolist-column-flag: Replacement for magit-repolist-column-dirty

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -36,6 +36,10 @@
 
 ** Changes since v2.90.0
 
+- Replaced ~magit-repolist-column-dirty~ with ~magit-repolist-column-flag~
+  which allows specifying arbitrary flags and predicates in custom order
+  using ~magit-repolist-column-flag-alist~.  #3936 #3937
+
 - It isn't always obvious that a section can be expanded, especially
   to users who are just getting started with Magit.  Mainly to make
   it easier for those users, expandable and collapsable sections now

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-750-g7e6b544aa+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-752-gbea3eff81+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-750-g7e6b544aa+1).
+This manual is for Magit version 2.90.1 (v2.90.1-752-gbea3eff81+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -2427,13 +2427,16 @@ The following functions can be added to the above option:
 
   This function inserts the number of stashes.
 
-- Function: magit-repolist-column-dirty
+- Function: magit-repolist-column-flag
 
-  This function inserts a letter if there are uncommitted changes:
+  This function inserts a flag as specified by
+  ~magit-repolist-column-flag-alist~.
 
-  - N if there is at least one untracked file.
-  - U if there is at least one unstaged file.
-  - S if there is at least one staged file.
+  By default this indicates whether there are uncommitted changes.
+
+  - ~N~ if there is at least one untracked file.
+  - ~U~ if there is at least one unstaged file.
+  - ~S~ if there is at least one staged file.
 
   Only the first one of these that applies is shown.
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-750-g7e6b544aa+1)
+@subtitle for version 2.90.1 (v2.90.1-752-gbea3eff81+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-750-g7e6b544aa+1).
+This manual is for Magit version 2.90.1 (v2.90.1-752-gbea3eff81+1).
 
 @quotation
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -3243,19 +3243,22 @@ This function inserts the number of branches.
 This function inserts the number of stashes.
 @end defun
 
-@defun magit-repolist-column-dirty
+@defun magit-repolist-column-flag
 
-This function inserts a letter if there are uncommitted changes:
+This function inserts a flag as specified by
+@code{magit-repolist-column-flag-alist}.
+
+By default this indicates whether there are uncommitted changes.
 
 @itemize
 @item
-N if there is at least one untracked file.
+@code{N} if there is at least one untracked file.
 
 @item
-U if there is at least one unstaged file.
+@code{U} if there is at least one unstaged file.
 
 @item
-S if there is at least one staged file.
+@code{S} if there is at least one staged file.
 @end itemize
 
 Only the first one of these that applies is shown.

--- a/lisp/magit-obsolete.el
+++ b/lisp/magit-obsolete.el
@@ -46,6 +46,9 @@
 (define-obsolete-function-alias 'magit-dispatch-popup
   'magit-dispatch "Magit 2.91.0")
 
+(define-obsolete-function-alias 'magit-repolist-column-dirty
+  'magit-repolist-column-flag "Magit 2.91.0")
+
 (defun magit--magit-popup-warning ()
   (display-warning 'magit "\
 Magit no longer uses Magit-Popup.


### PR DESCRIPTION
Allow specifying arbitrary flags and predicates in custom order.

With the default value of magit-repolist-column-flag-alist, this is
fully backward compatible with the original magit-repolist-column-dirty,
which is also preserved as an obsolete function alias.

[This is a continuation of #3936]