### PR TITLE
Fix keybinding typo in 2.91.0 release notes

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -281,7 +281,7 @@
   modes which use font-lock).  #3840
 
 - Added new command ~magit-status-here~ available from file-visiting
-  buffers at ~C-c M-g s~.  This command tries to go to the position in
+  buffers at ~C-c M-g g~.  This command tries to go to the position in
   the status buffer that corresponds to the position in the current
   file-visiting buffer.  Setting ~magit-status-goto-file-position~ to
   a non-nil value causes ~magit-status~ to behave the same way.  #3930


### PR DESCRIPTION
(magit-status-here) is in C-c M-g g; C-c M-g s is (magit-stage-file).
