### PR TITLE
Fix ...-maybe-update-... functions.

### DIFF
--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -927,11 +927,11 @@ instead of the hash, like `kill-ring-save' would."
 ;;; Utilities
 
 (defun magit-blame-maybe-update-revision-buffer ()
-  (unless magit--update-revision-buffer
-    (setq magit--update-revision-buffer nil)
-    (when-let ((chunk  (magit-current-blame-chunk))
-               (commit (oref chunk orig-rev))
-               (buffer (magit-get-mode-buffer 'magit-revision-mode nil t)))
+  (when-let ((chunk  (magit-current-blame-chunk))
+             (commit (oref chunk orig-rev))
+             (buffer (magit-get-mode-buffer 'magit-revision-mode nil t)))
+    (if magit--update-revision-buffer
+        (setq magit--update-revision-buffer (list commit buffer))
       (setq magit--update-revision-buffer (list commit buffer))
       (run-with-idle-timer
        magit-update-other-window-delay nil

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1283,7 +1283,7 @@ If there is no blob buffer in the same frame, then do nothing."
     (magit--maybe-update-blob-buffer)))
 
 (defun magit--maybe-update-blob-buffer ()
-  (unless magit--update-revision-buffer
+  (unless magit--update-blob-buffer
     (when-let ((commit (magit-section-value-if 'commit))
                (buffer (--first (with-current-buffer it
                                   (eq revert-buffer-function

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -438,9 +438,10 @@ If there is no stash buffer in the same frame, then do nothing."
     (magit--maybe-update-stash-buffer)))
 
 (defun magit--maybe-update-stash-buffer ()
-  (unless magit--update-stash-buffer
-    (when-let ((stash  (magit-section-value-if 'stash))
-               (buffer (magit-get-mode-buffer 'magit-stash-mode nil t)))
+  (when-let ((stash  (magit-section-value-if 'stash))
+             (buffer (magit-get-mode-buffer 'magit-stash-mode nil t)))
+    (if magit--update-stash-buffer
+        (setq magit--update-stash-buffer (list stash buffer))
       (setq magit--update-stash-buffer (list stash buffer))
       (run-with-idle-timer
        magit-update-other-window-delay nil


### PR DESCRIPTION
These functions did not show the correct objects when point was moving quickly
through the list. The object to show was stored when the command to go to the
next item was issued for the first time and then displayed later after a timer
elapsed.

This is inadequate when moving through the list quickly: By the time the objects
are shown point is actually further ahead so there is a discrepancy between the
shown object and the place where point is.

This commit also fixes a small bug in magit--maybe-update-blob-buffer which was
looking at the wrong variable.
