### PR TITLE
Fix magit-read-file-trace argument error / undefined behaviour

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -557,6 +557,8 @@ the upstream isn't ahead of the current branch) show."
 (defun magit-read-file-trace (&rest _ignored)
   (let ((file  (magit-read-file-from-rev "HEAD" "File"))
         (trace (magit-read-string "Trace")))
+    (string-match "^\\(/.+/\\|:[^:]+\\|[0-9]+,[-+]?[0-9]+\\)\\(:\\)?$"
+                  trace)
     (concat trace (or (match-string 2 trace) ":") file)))
 
 ;;;; Setup Commands


### PR DESCRIPTION
In bcb501476, validation via `string-match` was removed, but `match-string` is still being called. This PR restores that call to `string-match` but doesn't do anything with the returned value.

* Error: "Wrong type argument: (or eieio-object class), nil, obj"

* Or sometimes no error, but the "-L" argument returned by this function would contain unrelated string-match data. Good ol' emacs global mutable state
