### PR TITLE
magit-mode: Disable syntactic font lock

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -592,6 +592,7 @@ Magit is documented in info node `(magit)'."
   (setq truncate-lines t)
   (setq buffer-read-only t)
   (setq-local line-move-visual t) ; see #1771
+  (setq font-lock-defaults '(nil t))
   (setq show-trailing-whitespace nil)
   (setq list-buffers-directory (abbreviate-file-name default-directory))
   (hack-dir-local-variables-non-file-buffer)


### PR DESCRIPTION
Syntactic font lock automatically fontifies syntactic elements such as strings in Magit diffs using the `face` property.  This clashes with Magit's manual application of the `font-lock-face` property.

Fixes #3950.