### PR TITLE
magit-emacs-Q-command: Save to system clipboard instead kill-ring.

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -763,9 +763,11 @@ See info node `(magit)Debugging Tools' for more information."
                 ;; Avoid Emacs bug#16406 by using full path.
                 "-l" ,(file-name-sans-extension (locate-library "magit")))
               " ")))
-    (message "Uncustomized Magit command saved to kill-ring, %s"
+    (message "Uncustomized Magit command saved to clipboard, %s"
              "please run it in a terminal.")
-    (kill-new cmd)))
+    (with-temp-buffer
+      (insert cmd)
+      (clipboard-kill-ring-save (point-min) (point-max)))))
 
 ;;; Text Utilities
 


### PR DESCRIPTION
Kill-ring is only accessible in Emacs, this allow user use generated command in terminal(or any other places)