### PR TITLE
Add magit-worktree-move

### DIFF
--- a/Documentation/RelNotes/2.91.0.org
+++ b/Documentation/RelNotes/2.91.0.org
@@ -292,6 +292,9 @@
   ~magit-stashes-maybe-update-stash-buffer~ to
   ~magit-section-movement-hook~.  #3943
 
+- Added new command ~magit-move-worktree~ to allow you to move an
+  existing worktree to a new directory.
+
 ** Fixes since v2.90.0
 
 - Bumped the minimal required version of ~git-commit~ to the correct

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-789-g3add5310b+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-791-g62dad50a+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-789-g3add5310b+1).
+This manual is for Magit version 2.90.1 (v2.90.1-791-g62dad50a+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -6757,6 +6757,10 @@ Also see [[man:git-worktree]]
 - Key: % c, magit-worktree-branch
 
   Create a new BRANCH and check it out in a new worktree at PATH.
+
+- Key: % m, magit-worktree-move
+
+  Move an existing worktree to a new PATH.
 
 - Key: % k, magit-worktree-delete
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-789-g3add5310b+1)
+@subtitle for version 2.90.1 (v2.90.1-791-g62dad50a+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-789-g3add5310b+1).
+This manual is for Magit version 2.90.1 (v2.90.1-791-g62dad50a+1).
 
 @quotation
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -9256,6 +9256,12 @@ Checkout BRANCH in a new worktree at PATH@.
 @item @kbd{% c} @tie{}@tie{}@tie{}@tie{}(@code{magit-worktree-branch})
 
 Create a new BRANCH and check it out in a new worktree at PATH@.
+
+@kindex % m
+@cindex magit-worktree-move
+@item @kbd{% m} @tie{}@tie{}@tie{}@tie{}(@code{magit-worktree-move})
+
+Move an existing worktree to a new PATH@.
 
 @kindex % k
 @cindex magit-worktree-delete


### PR DESCRIPTION
I noticed that there exists a [`git worktree move` command](https://git-scm.com/docs/git-worktree#Documentation/git-worktree.txt-move) in the git worktree documentation, and figured it would make a good addition to the repertoire of existing magit worktree commands.

Since having implemented it, I've actually integrated it into my workflow—largely as a mechanism to move worktrees that I have accidentally created where they ought not to be.