### PR TITLE
Check if buffer's file is unrelated remote before checking it exists

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1337,10 +1337,13 @@ argument (the prefix) non-nil means save all with no questions."
        arg (lambda ()
              (and (not magit-inhibit-refresh-save)
                   buffer-file-name
-                  (file-exists-p (file-name-directory buffer-file-name))
                   ;; Avoid needlessly connecting to unrelated remotes.
                   (equal (file-remote-p buffer-file-name)
                          remote)
+                  ;; For remote files this makes network requests and
+                  ;; therefore has to come after the above to avoid
+                  ;; unnecessary waiting for unrelated hosts.
+                  (file-exists-p (file-name-directory buffer-file-name))
                   (string-prefix-p topdir (file-truename buffer-file-name))
                   (equal (magit-rev-parse-safe "--show-toplevel")
                          topdir)))))))


### PR DESCRIPTION
`file-exists-p' calls tramp functions for remote files which can cause
Emacs to hang if the remote host is no longer accessible.

### Testing
It looks like this bug has been addressed a few times before (#1472 #3087) but subsequent updates have reintroduced it.  It would be nice to add a test to prevent this but I'm not sure the best way to test this. 

I'm happy to try adding a test if there are any suggestions on a good approach.  I'll also put more thought into it later and try to come up with something for discussion.