### PR TITLE
async-bytecomp-allowed-packages value can now be

### DIFF
--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -81,7 +81,10 @@
 (require 'magit)
 
 (and (require 'async-bytecomp nil t)
-     (memq 'magit (bound-and-true-p async-bytecomp-allowed-packages))
+     (when-let ((pkgs (bound-and-true-p async-bytecomp-allowed-packages)))
+       (if (consp pkgs)
+           (cl-intersection '(all magit) pkgs)
+         (memq pkgs '(all t))))
      (fboundp 'async-bytecomp-package-mode)
      (async-bytecomp-package-mode 1))
 


### PR DESCRIPTION
the symbol 'all instead of '(all) previously
'(all) is still supported though, but if a user set it to 'all, magit
will fail to load.
