### PR TITLE
Add new option, `stage` for magit-commit-ask-to-stage

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -42,8 +42,8 @@
   "Whether to ask to stage all unstaged changes when committing and nothing is staged."
   :package-version '(magit . "2.3.0")
   :group 'magit-commands
-  :type '(choice (const :tag "Ask showing diff" verbose)
-                 (const :tag "Ask" t)
+  :type '(choice (const :tag "Ask" t)
+                 (const :tag "Ask showing diff" verbose)
                  (const :tag "Don't ask" nil)))
 
 (defcustom magit-commit-show-diff t

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -44,6 +44,7 @@
   :group 'magit-commands
   :type '(choice (const :tag "Ask" t)
                  (const :tag "Ask showing diff" verbose)
+                 (const :tag "Stage without confirmation" stage)
                  (const :tag "Don't ask" nil)))
 
 (defcustom magit-commit-show-diff t
@@ -372,7 +373,8 @@ depending on the value of option `magit-commit-squash-confirm'."
    (magit-commit-ask-to-stage
     (when (eq magit-commit-ask-to-stage 'verbose)
       (magit-diff-unstaged))
-    (prog1 (when (y-or-n-p "Nothing staged.  Stage and commit all unstaged changes? ")
+    (prog1 (when (or (eq magit-commit-ask-to-stage 'stage)
+                     (y-or-n-p "Nothing staged.  Stage and commit all unstaged changes? "))
              (magit-run-git "add" "-u" ".")
              (or args (list "--")))
       (when (and (eq magit-commit-ask-to-stage 'verbose)


### PR DESCRIPTION
Hi!

I usually commit with some changes.
Adding all changes without any confirming helps me to easy commit.
So I added 'stage new option to stage anything without confirm.