### PR TITLE
[WIP] use remote name as default value for input remote URL

### DIFF
--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -98,9 +98,16 @@ has to be used to view and change remote related variables."
 ;;;###autoload
 (defun magit-remote-add (remote url &optional args)
   "Add a remote named REMOTE and fetch it."
-  (interactive (list (magit-read-string-ns "Remote name")
-                     (magit-read-url "Remote url")
-                     (transient-args 'magit-remote)))
+  (interactive (let* ((remote-name (magit-read-string-ns "Remote name"))
+                      (url (magit-get "remote.origin.url"))
+                      (repo-name (and (string-match "\\`git@github\\.com:\\([^/]+\\)/\\(.+\\)\\.git\\'" url)
+                                      (match-string 2 url))))
+                 (list remote-name
+                       (magit-read-url
+                        "Remote url"
+                        (and repo-name
+                             (format "git@github.com:%s/%s.git" remote-name repo-name)))
+                       (transient-args 'magit-remote))))
   (if (pcase (list magit-remote-add-set-remote.pushDefault
                    (magit-get "remote.pushDefault"))
         (`(,(pred stringp) ,_) t)

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -61,6 +61,12 @@ has to be used to view and change remote related variables."
   :group 'magit-commands
   :type 'boolean)
 
+(defcustom magit-remote-guess-url nil
+  "Whether to guess remote URL using remote name."
+  :package-version '(magit . "2.91.0")
+  :group 'magit-commands
+  :type 'boolean)
+
 ;;; Commands
 
 ;;;###autoload (autoload 'magit-remote "magit-remote" nil t)
@@ -105,7 +111,8 @@ has to be used to view and change remote related variables."
                  (list remote-name
                        (magit-read-url
                         "Remote url"
-                        (and repo-name
+                        (and magit-remote-guess-url
+                             repo-name
                              (format "git@github.com:%s/%s.git" remote-name repo-name)))
                        (transient-args 'magit-remote))))
   (if (pcase (list magit-remote-add-set-remote.pushDefault


### PR DESCRIPTION
Hi!
I want to create dwim interface for `magit-clone`.
My clone and pull-request flow is showed as below.
1. `M-x magit-clone`
2. Press `u` to select `Clone from URL`
3. Input `magit/magit` ; for example
4. Press `Enter`
  because I set `magit-clone-default-directory` to "~/dev/forks/"
  (Currently, remote is only `origin` to git@github.com:magit/magit.git)
5. Create branch and Commit something
6. Create fork via `M-x magit-status` and press `! !`, input `git fork`.
  (As my configure, `git` is alias to `hub`)
7. Add my fork url named `conao3` to remote
  via
  - `M a`
  - input `conao3`
  - browse my fork via browser
  - click `Clone or download`
  - click `Copy` button to copy `git@github.com:conao3/magit.git`
  - paste `git@github.com:conao3/magit.git` to mini-buffer
8. Push local branch to my fork
  via `P e` input `conao3/<feature>`
9. Fetch all things via `' f f` using `forge`
10. Create pull-request via `' c p`

Well, I want to fix input fork URL as remote named `conao3` step.
That work is almost done, but I couldn't find a way to get the SSH URL dynamically.
Is this interface good? And can you give me advice.

Also, since I first started using Magit in earnest, it has only been a week.
Please let me know if there is an efficient flow to create pull-request.