### PR TITLE
Add libgit2 implementation for magit-get-current-branch

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1313,7 +1313,7 @@ to, or to some other symbolic-ref that points to the same ref."
                (funcall predicate module))
            module))))
 
-(defun magit-get-current-branch ()
+(cl-defgeneric magit-get-current-branch ()
   "Return the refname of the currently checked out branch.
 Return nil if no branch is currently checked out."
   (magit-git-string "symbolic-ref" "--short" "HEAD"))

--- a/lisp/magit-libgit.el
+++ b/lisp/magit-libgit.el
@@ -69,6 +69,13 @@ If optional DIRECTORY is nil, then use `default-directory'."
          (unless noerror
            (signal 'magit-outside-git-repo default-directory)))))
 
+(cl-defmethod magit-get-current-branch
+  (&context ((magit-gitimpl) (eql libgit)))
+  (when-let ((repo (magit-libgit-repo))
+             (ref (libgit-reference-dwim repo "HEAD")))
+    (when (libgit-reference-branch-p ref)
+      (libgit-reference-shorthand ref))))
+
 ;;; _
 (provide 'magit-libgit)
 ;;; magit-libgit.el ends here


### PR DESCRIPTION
This change implements `magit-get-current-branch` using libgit2. This is to help make progress on #2959.