### PR TITLE
magit-merge: Add an argument to select diff algorithm

### DIFF
--- a/lisp/magit-merge.el
+++ b/lisp/magit-merge.el
@@ -46,6 +46,7 @@
    ("-f" "Fast-forward only" "--ff-only")
    ("-n" "No fast-forward"   "--no-ff")
    (magit-merge:--strategy)
+   (magit-merge:--diff-algorithm)
    (5 magit:--gpg-sign)]
   ["Actions"
    :if-not magit-merge-in-progress-p
@@ -75,6 +76,20 @@
   :key "-s"
   :argument "--strategy="
   :choices '("resolve" "recursive" "octopus" "ours" "subtree"))
+
+(define-infix-argument magit-merge:--diff-algorithm ()
+  :description "Diff algorithm"
+  :class 'transient-option
+  :key "-A"
+  :argument "-Xdiff-algorithm="
+  :reader 'magit-merge-select-algorithm)
+
+(defun magit-merge-select-algorithm (&rest _ignore)
+  (magit-read-char-case nil t
+    (?d "[d]efault"   "default")
+    (?m "[m]inimal"   "minimal")
+    (?p "[p]atience"  "patience")
+    (?h "[h]istogram" "histogram")))
 
 ;;;###autoload
 (defun magit-merge-plain (rev &optional args nocommit)


### PR DESCRIPTION
Selecting a different diff algorithm when merging can prevent merge conflicts. This adds an argument to the merge popup which lets the user select which algorithm to use. The same selector is used as for magit-diff for consistency. 

More context can be found in [this post](https://blog.jcoglan.com/2017/06/19/why-merges-fail-and-what-can-be-done-about-it/).