### PR TITLE
Fix `git-commit-co-authored' typo in git-commit-mode-menu

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -743,7 +743,7 @@ With a numeric prefix ARG, go forward ARG comments."
   (interactive (git-commit-read-ident))
   (git-commit-insert-header "Suggested-by" name mail))
 
-(defun git-commit-co-authored-by (name mail)
+(defun git-commit-co-authored (name mail)
   "Insert a header mentioning the person who co-authored the commit."
   (interactive (git-commit-read-ident))
   (git-commit-insert-header "Co-authored-by" name mail))


### PR DESCRIPTION
Clicking the Co-authored-by entry in the Commit menu currently produces an error: `apply: Wrong type argument: commandp, git-commit-co-authored`.

This commit fixes that error by referring to the right function name.

Renaming the function would have made its name more consistent with other like functions, but it might have caused breakage? I couldn't find any use of the function on GitHub.
