### PR TITLE
Fix face-attribute 'region :extend on Emacs 27

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -551,7 +551,7 @@ If you prefer the old behaviors, then set this to t."
 (defface magit-diff-hunk-region
   `((t :inherit bold
        ,@(and (>= emacs-major-version 27)
-              (list :extend (face-attribute 'region :extend)))))
+              (list :extend (ignore-errors (face-attribute 'region :extend))))))
   "Face used by `magit-diff-highlight-hunk-region-using-face'.
 
 This face is overlaid over text that uses other hunk faces,


### PR DESCRIPTION
Add ignore-errors around face-attribute 'region :extend as mentioned in my comment on https://github.com/magit/magit/issues/3986#issuecomment-555391760

It caused byte-compiling errors on latest Emacs 27. Just slapped ignore-errors there as advised
by Henrik of doom-emacs at https://github.com/hlissner/doom-emacs/issues/2070

_I'm sending this pull-request - more as a convenience - not really sure if you would like to fix the problem exactly this way. But it fixed the issue I was experiencing._