### PR TITLE
magit-log-propertize-keywords: Fix regexp search

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1261,15 +1261,15 @@ Do not add this to a hook variable."
   t)
 
 (defun magit-log-propertize-keywords (_rev msg)
-  (let ((start 0))
-    (when (string-match "^\\(?:squash\\|fixup\\)! " msg start)
-      (setq start (match-end 0))
-      (magit--put-face (match-beginning 0) (1- start)
+  (let ((boundary 0))
+    (when (string-match "^\\(?:squash\\|fixup\\)! " msg boundary)
+      (setq boundary (match-end 0))
+      (magit--put-face (match-beginning 0) (1- boundary)
                        'magit-keyword-squash msg))
     (when magit-log-highlight-keywords
-      (while (string-match "\\[[^[]*?]" msg start)
-        (setq start (match-end 0))
-        (magit--put-face (match-beginning 0) start
+      (while (string-match "\\[[^[]*?]" msg boundary)
+        (setq boundary (match-end 0))
+        (magit--put-face (match-beginning 0) boundary
                          'magit-keyword msg))))
   msg)
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1262,14 +1262,14 @@ Do not add this to a hook variable."
 
 (defun magit-log-propertize-keywords (_rev msg)
   (let ((start 0))
-    (when (string-match "^\\(squash\\|fixup\\)! " msg start)
+    (when (string-match "^\\(?:squash\\|fixup\\)! " msg start)
       (setq start (match-end 0))
-      (magit--put-face (match-beginning 0) (match-end 0)
+      (magit--put-face (match-beginning 0) (1- start)
                        'magit-keyword-squash msg))
-    (while (string-match "\\[[^[]*\\]" msg start)
-      (setq start (match-end 0))
-      (when magit-log-highlight-keywords
-        (magit--put-face (match-beginning 0) (match-end 0)
+    (when magit-log-highlight-keywords
+      (while (string-match "\\[[^[]*?]" msg start)
+        (setq start (match-end 0))
+        (magit--put-face (match-beginning 0) start
                          'magit-keyword msg))))
   msg)
 


### PR DESCRIPTION
#### TL;DR

The `magit-keyword` face is currently applied to keywords in log messages greedily, e.g. the entire message `"[EMACS] Rebind C-]"` receives the `magit-keyword` face due to the trailing `]`.

#### ChangeLog

- Make unused grouping construct shy.
- Avoid applying `magit-keyword-squash` face to whitespace.
- Hoist `magit-log-highlight-keywords` guard out of loop.
- Make keyword regexp non-greedy so as to handle cases like `"[EMACS] Rebind C-]"`.
- Avoid meaningless quoting of `?\]` inside regexp, as per advice in [`(elisp) Regexp Special`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Regexp-Special.html).  This is because backslash quoting does not remove special meaning of `?-` and `?\]` in regexps.