### PR TITLE
Fix small typo in magit.org

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-810-g8c4e8ed74+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-844-g954b0745+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-810-g8c4e8ed74+1).
+This manual is for Magit version 2.90.1 (v2.90.1-844-g954b0745+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@bernoul.li>
@@ -7351,7 +7351,7 @@ add ~safe-with-wip~ to this list.
 
 Similarly it isn't necessary to require confirmation before moving a
 file to the system trash - if you trashed a file by mistake then you
-can recover it from the there.  Option ~magit-delete-by-moving-to-trash~
+can recover it from there.  Option ~magit-delete-by-moving-to-trash~
 controls whether the system trash is used, which is the case by default.
 Nevertheless, ~trash~ isn't a member of ~magit-no-confirm~ - you
 might want to change that.

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-810-g8c4e8ed74+1)
+@subtitle for version 2.90.1 (v2.90.1-844-g954b0745+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-810-g8c4e8ed74+1).
+This manual is for Magit version 2.90.1 (v2.90.1-844-g954b0745+1).
 
 @quotation
 Copyright (C) 2015-2019 Jonas Bernoulli <jonas@@bernoul.li>
@@ -9988,7 +9988,7 @@ add @code{safe-with-wip} to this list.
 
 Similarly it isn't necessary to require confirmation before moving a
 file to the system trash - if you trashed a file by mistake then you
-can recover it from the there.  Option @code{magit-delete-by-moving-to-trash}
+can recover it from there.  Option @code{magit-delete-by-moving-to-trash}
 controls whether the system trash is used, which is the case by default.
 Nevertheless, @code{trash} isn't a member of @code{magit-no-confirm} - you
 might want to change that.


### PR DESCRIPTION
Fixed a small typo in magit documentation.

#4015


