### PR TITLE
magit-pull.el: Add autostash option

### DIFF
--- a/lisp/magit-pull.el
+++ b/lisp/magit-pull.el
@@ -45,7 +45,8 @@
   :man-page "git-pull"
   [:description
    (lambda () (if magit-pull-or-fetch "Pull arguments" "Arguments"))
-   ("-r" "Rebase local commits" ("-r" "--rebase"))]
+   ("-r" "Rebase local commits" ("-r" "--rebase"))
+   ("-a" "Autostash local changes and pop after pull" ("-a" "--autostash"))]
   [:description
    (lambda ()
      (if-let ((branch (magit-get-current-branch)))


### PR DESCRIPTION
Hey,

Long-time user of Magit. It's one of the main reasons why I keep returning to Emacs after trying out other editors.

There are occasions in my workflow where I will have made a commit and need to pull changes from remote before pushing. But I will also have some local changes that need to be stashed. Git provides the great `--autostash` option for this, which to the best of my knowledge wasn't exposed when pulling through Magit.

This PR attempts to add `--autostash` during Magit pulls. I've tested this locally, and it works.

This is my first PR to Magit, so kindly review and suggest if I've missed something.

Cheers.