### PR TITLE
Ensure that git-commit-read-ident-history variable is defined

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -131,6 +131,7 @@
 (defvar flyspell-generic-check-word-predicate)
 (defvar font-lock-beg)
 (defvar font-lock-end)
+(defvar git-commit-read-ident-history nil)
 
 (declare-function magit-completing-read "magit-utils"
                   (prompt collection &optional predicate require-match


### PR DESCRIPTION
Fixes #4035. Ensures that `git-commit-read-ident-history` variable is defined which allows to use `git-commit-read-ident` function without errors.