### PR TITLE
Fix git-commit fontification when comments contain brackets

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -877,7 +877,7 @@ Added to `font-lock-extend-region-functions'."
   `(,@git-commit-font-lock-keywords-1
     ;; Comments
     (eval . `(,(format "^%s.*" comment-start)
-              (0 'font-lock-comment-face)))
+              (0 'font-lock-comment-face append)))
     (eval . `(,(format "^%s On branch \\(.*\\)" comment-start)
               (1 'git-commit-comment-branch-local t)))
     (eval . `(,(format "^%s \\(HEAD\\) detached at" comment-start)


### PR DESCRIPTION
Hi!

This is a pretty minor itch: the way the
`git-commit-font-lock-keywords-*` variables are written right now,
square brackets cause comments to lose the comment face. From `make
emacs-Q`[^1]:

- `M-x magit-status RET`
- `c -e c`
- `# Write down some text RET`
- `# Add brackets around a [word] RET`

What I observe:

- the first line has the comment face,
- the second line has the default face,
- `[word]` has the keyword face.

What I expect:

- both lines have the comment face,
- … I can't tell whether it would make more sense to highlight
  `[word]` or not.

This PR highlights the keyword.  My use-case is a commit.template file
containing comments with instructions about project-specific bracketed
keywords; it's actually nice that the keywords remain highlighted in
the comments.

Not highlighting keywords is as simple as replacing `append` with `t`.
Alternatively, `keep` can be used instead to make sure no property of
font-lock-comment-face is applied; with this PR, if e.g.
git-commit-keyword only defines a foreground color and
font-lock-comment-face adds italics, the keyword will be slanted.

Thank you for your time.


[^1] Magit v2.90.1-909-g752a3f94, Git 2.20.1, Emacs 28.0.50, gnu/linux
     (Emacs revision: d3ead37509)
