### PR TITLE
Make empty magit-log-remove-graph-args never remove --graph

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -938,9 +938,10 @@ Type \\[magit-reset] to reset `HEAD' to the commit at point.
         (unless (magit-file-tracked-p (car files))
           (setq args (cons "--full-history" args)))
       (setq args (remove "--follow" args)))
-    (when (--any-p (string-match-p
-                    (concat "^" (regexp-opt magit-log-remove-graph-args)) it)
-                   args)
+    (when (and (car magit-log-remove-graph-args)
+               (--any-p (string-match-p
+                         (concat "^" (regexp-opt magit-log-remove-graph-args)) it)
+                        args))
       (setq args (remove "--graph" args)))
     (unless (member "--graph" args)
       (setq args (remove "--color" args)))


### PR DESCRIPTION
This fix treats an empty list (or nil) `magit-log-remove-graph-args` as "never-match" so to never remove `--graph` in log commands.

Before this fix:

```lisp
;; Never remove `--graph`
(setq magit-log-remove-graph-args (list "something that will never match")) ;; Ugly

;; Remove `--graph` everywhere
(setq magit-log-remove-graph-args nil) ;; Confusing... (empty regex match everything)
```

Now:

```lisp
;; Never remove `--graph`
(setq magit-log-remove-graph-args nil)

;; Remove `--graph` everywhere
(setq magit-log-remove-graph-args (list "")) ;; empty string regex match everything
```

But, as a side note, **it doesn't mean users should actually do this**, because current switches like `-G` and `-- file` are broken due to literal `...` in git log output.
