### PR TITLE
Quick fix git log output with `...` as first line

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1129,7 +1129,7 @@ Do not add this to a hook variable."
 (cl-defun magit-log-wash-rev (style abbrev)
   (when (derived-mode-p 'magit-log-mode 'magit-reflog-mode)
     (cl-incf magit-log-count))
-  (looking-at (pcase style
+  (unless (looking-at (pcase style
                 (`log        magit-log-heading-re)
                 (`cherry     magit-log-cherry-re)
                 (`module     magit-log-module-re)
@@ -1137,6 +1137,10 @@ Do not add this to a hook variable."
                 (`stash      magit-log-stash-re)
                 (`bisect-vis magit-log-bisect-vis-re)
                 (`bisect-log magit-log-bisect-log-re)))
+    ;; Here, the regexp did not match, leave text as-is (known to
+    ;; happen with "log --graph -G...", "log --follow -- files").
+    (forward-line)
+    (cl-return-from magit-log-wash-rev t))
   (magit-bind-match-strings
       (hash msg refs graph author date gpg cherry _ refsub side) nil
     (setq msg (substring-no-properties msg))


### PR DESCRIPTION
When running `log --graph -G<...>` or `log --graph --follow -- <file...>`, git can output `...` separators. Magit failed to parse `...` as first line.

This fix now displays as-is any line that doesn't match the expected regexp.

This is only a _quick_ fix because '...' are still not formatted properly: the first '...' is not aligned, and subsequent ones are displayed twice.

Note: I am not sure why git decides to output `...` separators, for example: `git log --graph -- file` is fine, but add `--follow` and then you have `...` everywhere, even if the shown histories are nearly the same.

Fixes #4048.

---

I couldn't think of a better fix without re-writing the last third of the function, and I wasn't confident enough to do that.

I kept it separate from #4047 because they are independent (one could merge/close one and not the other...).
