### PR TITLE
Escape function name for magit-log-trace-definition

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -727,7 +727,7 @@ restrict the log to the lines that the region touches."
   (magit-log-setup-buffer
    (list rev)
    (cons (format "-L:%s%s:%s"
-                 (regexp-quote fn)
+                 (replace-regexp-in-string ":" "\\:" (regexp-quote fn) nil t)
                  (if (derived-mode-p 'lisp-mode 'emacs-lisp-mode)
                      ;; Git doesn't treat "-" the same way as
                      ;; "_", leading to false-positives such as


### PR DESCRIPTION
This is useful when the xfuncname is defined for Clojure's defmethod.

Here is the setup:

In .gitconfig:

[diff "clojure"]
        xfuncname = (^\\(.*|\\s*\\(def|defn|defrecord|defmulti|defmacro|deftest|ns).*

In .gitattributes:

*.clj  diff=clojure
*.cljc diff=clojure
*.cljs diff=clojure
*.cljx diff=clojure

When the pointer is on the line where I have defn declared, that is
under git, and I run: M-x magit-log-trace-definition RET, it works as
expected: it narrows to the defined defn and I can see the git log
just for that sexp.

Where it fails is when I try to narrow it to a sexp where I have
defmethod defined, which will look something like:

(defmethod process :foo:bar
...

If I were to run this via:

git log -L'/process :foo:bar/':src/app/foo/bar.clj

I do get the desired results back.

With the previous setup the magit-log-trace-definition didn't work on
defmethods from Magit.

Reference: https://github.com/magit/magit/issues/4051

All credit to Kyle Meyer