### PR TITLE
Ability to hide patches of deleted files, significantly speeding up `magit-status` (#2982)

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2713,7 +2713,7 @@ It the SECTION has a different type, then do nothing."
   (magit-insert-section (unstaged)
     (magit-insert-heading "Unstaged changes:")
     (magit--insert-diff
-      "diff" magit-buffer-diff-args "--no-prefix"
+      "diff" (if magit-diff-hide-deleted-file-patches (append magit-buffer-diff-args '("-D")) magit-buffer-diff-args) "--no-prefix"
       "--" magit-buffer-diff-files)))
 
 (defvar magit-staged-section-map
@@ -2735,7 +2735,7 @@ It the SECTION has a different type, then do nothing."
     (magit-insert-section (staged)
       (magit-insert-heading "Staged changes:")
       (magit--insert-diff
-        "diff" "--cached" magit-buffer-diff-args "--no-prefix"
+        "diff" "--cached" (if magit-diff-hide-deleted-file-patches (append magit-buffer-diff-args '("-D")) magit-buffer-diff-args) "--no-prefix"
         "--" magit-buffer-diff-files))))
 
 ;;; Diff Type

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -268,6 +268,12 @@ that many spaces.  Otherwise, highlight neither."
                                (integer :tag "Spaces" :value ,tab-width)
                                (const :tag "Neither" nil)))))
 
+(defcustom magit-diff-hide-deleted-file-patches nil
+  "Whether to hide deleted file patches (for performance reasons)."
+  :package-version '(magit . "3.0.0")
+  :group 'magit-diff
+  :type 'boolean)
+
 (defcustom magit-diff-hide-trailing-cr-characters
   (and (memq system-type '(ms-dos windows-nt)) t)
   "Whether to hide ^M characters at the end of a line in diffs."


### PR DESCRIPTION
Hi,

Before this patch, simply updating a package like org-plus-contrib, then running `magit-status` on my .emacs.d git repo would take 20 seconds, followed by similar delays upon (un)staging of files due to refreshing the magit buffer. The main reason was that deleted files have their entire contents shown in the patch subsections of the (un)staged sections of `magit-status`. This issue is similar to for example https://github.com/magit/magit/issues/3808, and is also related to https://github.com/magit/magit/issues/2982.

With this patch, `magit-status` and subsequent refreshes only take a couple of seconds.

The only thing the patch is doing is to invoke "git diff" with the "-D" (--irreversible-delete) option for the (un)staged file sections, see https://git-scm.com/docs/diff-options/2.14.2#diff-options---irreversible-delete. This option still shows the deleted file in the summary of the diff, but excludes the actual contents of the file. As such the buffer of `magit-status` is much smaller, which speeds up `magit-status-refresh-buffer`, while one can still (un)stage deleted files as before. The only thing that has become impossible is opening the deleted file by hitting enter.

Since some people might not like this idea, the patch also introduces a defcustom named `magit-diff-hide-deleted-file-patches` to toggle whether or not deleted files should have their patch shown by `magit-status` for the (un)staged change sections. Default value is `nil`, i.e., the current (slow) behaviour.

Unfortunately, "git diff" does not have an equivalent argument for new files, hence large added files could still slow down `magit-status-refresh-buffer`.

In practice, though, this might not be as bad as it sounds: in case of renamed files
or, for example, updated MELPA packages, if one first stages the old, deleted version of a file or folder (which prompts the now faster refresh), then the new (untracked) version, git's rename detection will kick in, which automatically hides the contents of the renamed files and hence significantly speeds up the second refresh.

TL;DR Significantly faster magit refresh by hiding deleted files' patches during (un)staging; in case of renaming, first stage the deleted file/folder.