### PR TITLE
Expand magit-patch-create transient

### DIFF
--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -132,7 +132,13 @@ which creates patches for all commits that are reachable from
   :description "Thread style"
   :class 'transient-option
   :key "C-m s  "
-  :argument "--thread=")
+  :argument "--thread="
+  :reader #'magit-format-patch-select-thread-style)
+
+(defun magit-format-patch-select-thread-style (&rest _ignore)
+  (magit-read-char-case "Thread style " t
+    (?d "[d]eep" "deep")
+    (?s "[s]hallow" "shallow")))
 
 (define-infix-argument magit-format-patch:--reroll-count ()
   :description "Reroll count"

--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -72,11 +72,11 @@ which creates patches for all commits that are reachable from
 `HEAD' but not from the specified commit)."
   :man-page "git-format-patch"
   ["Mail arguments"
-   (magit-format-patch:--in-reply-to)
-   (magit-format-patch:--thread)
-   (magit-format-patch:--from)
-   (magit-format-patch:--to)
-   (magit-format-patch:--cc)]
+   (6 magit-format-patch:--in-reply-to)
+   (6 magit-format-patch:--thread)
+   (6 magit-format-patch:--from)
+   (6 magit-format-patch:--to)
+   (6 magit-format-patch:--cc)]
   ["Patch arguments"
    (magit-format-patch:--reroll-count)
    (magit-format-patch:--subject-prefix)

--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -83,6 +83,8 @@ which creates patches for all commits that are reachable from
    (magit-format-patch:--subject-prefix)
    ("C-m r  " "RFC subject prefix" "--rfc")
    ("C-m l  " "Add cover letter" "--cover-letter")
+   (5 magit-format-patch:--cover-from-description)
+   (5 magit-format-patch:--notes)
    (magit-format-patch:--output-directory)]
   ["Diff arguments"
    (magit-diff:-U)
@@ -155,6 +157,27 @@ which creates patches for all commits that are reachable from
   :class 'transient-option
   :key "C-m p  "
   :argument "--subject-prefix=")
+
+(define-infix-argument magit-format-patch:--cover-from-description ()
+  :description "Use branch description"
+  :class 'transient-option
+  :key "C-m D  "
+  :argument "--cover-from-description="
+  :reader #'magit-format-patch-select-description-mode)
+
+(defun magit-format-patch-select-description-mode (&rest _ignore)
+  (magit-read-char-case "Use description as " t
+    (?m "[m]essage" "message")
+    (?s "[s]ubject" "subject")
+    (?a "[a]uto"    "auto")
+    (?n "[n]othing" "none")))
+
+(define-infix-argument magit-format-patch:--notes ()
+  :description "Insert commentary from notes"
+  :class 'transient-option
+  :key "C-m n  "
+  :argument "--notes="
+  :reader #'magit-notes-read-ref)
 
 (define-infix-argument magit-format-patch:--from ()
   :description "From"

--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -71,6 +71,7 @@ changes introduced by that commit (unlike 'git format-patch'
 which creates patches for all commits that are reachable from
 `HEAD' but not from the specified commit)."
   :man-page "git-format-patch"
+  :incompatible '(("--subject-prefix=" "--rfc"))
   ["Mail arguments"
    (6 magit-format-patch:--in-reply-to)
    (6 magit-format-patch:--thread)
@@ -80,6 +81,7 @@ which creates patches for all commits that are reachable from
   ["Patch arguments"
    (magit-format-patch:--reroll-count)
    (magit-format-patch:--subject-prefix)
+   ("C-m r  " "RFC subject prefix" "--rfc")
    ("C-m l  " "Add cover letter" "--cover-letter")
    (magit-format-patch:--output-directory)]
   ["Diff arguments"

--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -124,7 +124,7 @@ which creates patches for all commits that are reachable from
 (define-infix-argument magit-format-patch:--in-reply-to ()
   :description "In reply to"
   :class 'transient-option
-  :key "C-m r  "
+  :key "C-m C-r"
   :argument "--in-reply-to=")
 
 (define-infix-argument magit-format-patch:--thread ()

--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -80,6 +80,8 @@ which creates patches for all commits that are reachable from
    (6 magit-format-patch:--cc)]
   ["Patch arguments"
    (magit-format-patch:--reroll-count)
+   (5 magit-format-patch:--interdiff)
+   (magit-format-patch:--range-diff)
    (magit-format-patch:--subject-prefix)
    ("C-m r  " "RFC subject prefix" "--rfc")
    ("C-m l  " "Add cover letter" "--cover-letter")
@@ -151,6 +153,23 @@ which creates patches for all commits that are reachable from
   :shortarg "-v"
   :argument "--reroll-count="
   :reader 'transient-read-number-N+)
+
+(define-infix-argument magit-format-patch:--interdiff ()
+  :description "Insert interdiff"
+  :class 'transient-option
+  :key "C-m d i"
+  :argument "--interdiff="
+  :reader #'magit-transient-read-revision)
+
+(define-infix-argument magit-format-patch:--range-diff ()
+  :description "Insert range-diff"
+  :class 'transient-option
+  :key "C-m d r"
+  :argument "--range-diff="
+  :reader #'magit-format-patch-select-range-diff)
+
+(defun magit-format-patch-select-range-diff (prompt _initial-input _history)
+  (magit-read-range-or-commit prompt))
 
 (define-infix-argument magit-format-patch:--subject-prefix ()
   :description "Subject Prefix"

--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -79,6 +79,7 @@ which creates patches for all commits that are reachable from
    (6 magit-format-patch:--to)
    (6 magit-format-patch:--cc)]
   ["Patch arguments"
+   (magit-format-patch:--base)
    (magit-format-patch:--reroll-count)
    (5 magit-format-patch:--interdiff)
    (magit-format-patch:--range-diff)
@@ -145,6 +146,18 @@ which creates patches for all commits that are reachable from
   (magit-read-char-case "Thread style " t
     (?d "[d]eep" "deep")
     (?s "[s]hallow" "shallow")))
+
+(define-infix-argument magit-format-patch:--base ()
+  :description "Insert base commit"
+  :class 'transient-option
+  :key "C-m b  "
+  :argument "--base="
+  :reader #'magit-format-patch-select-base)
+
+(defun magit-format-patch-select-base (prompt initial-input history)
+  (or (magit-completing-read prompt (cons "auto" (magit-list-refnames))
+                             nil nil initial-input history "auto")
+      (user-error "Nothing selected")))
 
 (define-infix-argument magit-format-patch:--reroll-count ()
   :description "Reroll count"

--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -74,12 +74,13 @@ which creates patches for all commits that are reachable from
   ["Mail arguments"
    (magit-format-patch:--in-reply-to)
    (magit-format-patch:--thread)
+   (magit-format-patch:--from)
+   (magit-format-patch:--to)
+   (magit-format-patch:--cc)]
+  ["Patch arguments"
    (magit-format-patch:--reroll-count)
    (magit-format-patch:--subject-prefix)
    ("C-m l  " "Add cover letter" "--cover-letter")
-   (magit-format-patch:--from)
-   (magit-format-patch:--to)
-   (magit-format-patch:--cc)
    (magit-format-patch:--output-directory)]
   ["Diff arguments"
    (magit-diff:-U)


### PR DESCRIPTION
This PR was prompted by gh-4028.  It reorganizes the `magit-patch-create` transient a bit (in terms of levels, sections, and one binding change) and adds the following options: `--base`, `--interdiff`, `--range-diff`, `--rfc`, `--cover-from-description`, and `--notes`.

I've lazily decided not to add release notes because there's already a catch-all entry for the Transient switch that says "many popups gained new arguments and/or commands, most of which are not mentioned explicitly in these release notes".

I'd be interested to hear alternative suggestions for levels and bindings.

Closes #4028.