### PR TITLE
Add documentation on using absolute git path in Catalina

### DIFF
--- a/Documentation/magit-section.org
+++ b/Documentation/magit-section.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit-Section: (magit-section).
 #+TEXINFO_DIR_DESC: Use Magit sections in your own packages.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-944-g1916e83aa+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-945-g99d09ff72+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -26,7 +26,7 @@ user options see [[info:magit#Sections]].  This manual documents how you
 can use sections in your own packages.
 
 #+TEXINFO: @noindent
-This manual is for Magit-Section version 2.90.1 (v2.90.1-944-g1916e83aa+1).
+This manual is for Magit-Section version 2.90.1 (v2.90.1-945-g99d09ff72+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2020 Jonas Bernoulli <jonas@bernoul.li>

--- a/Documentation/magit-section.texi
+++ b/Documentation/magit-section.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit-Section Developer Manual
-@subtitle for version 2.90.1 (v2.90.1-944-g1916e83aa+1)
+@subtitle for version 2.90.1 (v2.90.1-945-g99d09ff72+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -54,7 +54,7 @@ user options see @ref{Sections,,,magit,}.  This manual documents how you
 can use sections in your own packages.
 
 @noindent
-This manual is for Magit-Section version 2.90.1 (v2.90.1-944-g1916e83aa+1).
+This manual is for Magit-Section version 2.90.1 (v2.90.1-945-g99d09ff72+1).
 
 @quotation
 Copyright (C) 2015-2020 Jonas Bernoulli <jonas@@bernoul.li>

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-944-g1916e83aa+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-945-g99d09ff72+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-944-g1916e83aa+1).
+This manual is for Magit version 2.90.1 (v2.90.1-945-g99d09ff72+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -7626,6 +7626,12 @@ So make sure that you are using at least Emacs 26.1, in which case the
 faster ~vfork~ will be used.  (The creation of child processes still
 takes about twice as long on Darwin compared to Linux.)  See [fn:mac1]
 for more information.
+
+On Catalina, and potentially other macOS releases, there may be a
+performance problem where any action takes 20 times longer on Darwin
+than on Linux.  This can be fixed by setting ~magit-git-executable~ to
+the absolute path of the ~git~ executable, instead of relying on
+resolving the ~$PATH~.
 
 [fn:mac1] https://lists.gnu.org/archive/html/bug-gnu-emacs/2017-04/msg00201.html
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-944-g1916e83aa+1)
+@subtitle for version 2.90.1 (v2.90.1-945-g99d09ff72+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-944-g1916e83aa+1).
+This manual is for Magit version 2.90.1 (v2.90.1-945-g99d09ff72+1).
 
 @quotation
 Copyright (C) 2015-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -10273,6 +10273,12 @@ So make sure that you are using at least Emacs 26.1, in which case the
 faster @code{vfork} will be used.  (The creation of child processes still
 takes about twice as long on Darwin compared to Linux.)  See @footnote{@uref{https://lists.gnu.org/archive/html/bug-gnu-emacs/2017-04/msg00201.html}}
 for more information.
+
+On Catalina, and potentially other macOS releases, there may be a
+performance problem where any action takes 20 times longer on Darwin
+than on Linux.  This can be fixed by setting @code{magit-git-executable} to
+the absolute path of the @code{git} executable, instead of relying on
+resolving the @code{$PATH}.
 
 @node Plumbing
 @chapter Plumbing


### PR DESCRIPTION
Add documentation on using absolute `git` path in Darwin in `magit-git-executable`. Using the default results in a 20 times slowdown for some reason.

This was reported in #2982 and seems to have been confirmed by a few people [on reddit](https://www.reddit.com/r/emacs/comments/ffwxc9/performance_problem_with_magit_on_macos/).

Let me know if I should change or reword anything.