### PR TITLE
magit-autorevert: Don't ask if .git/ files are tracked

### DIFF
--- a/lisp/magit-autorevert.el
+++ b/lisp/magit-autorevert.el
@@ -113,9 +113,13 @@ seconds of user inactivity.  That is not desirable."
                      (condition-case nil
                          (executable-find magit-git-executable t) ; see #3684
                        (wrong-number-of-arguments t)))) ; very old 27 built
-               (magit-toplevel)
-               (or (not magit-auto-revert-tracked-only)
-                   (magit-file-tracked-p buffer-file-name))
+               (if magit-auto-revert-tracked-only
+                   ;; We're only interested in working tree files, so
+                   ;; avoid `magit-toplevel'.
+                   (and (magit--with-safe-default-directory nil
+                          (magit-rev-parse-safe "--show-toplevel"))
+                        (magit-file-tracked-p buffer-file-name))
+                 (magit-toplevel))
                (not auto-revert-mode)         ; see #3014
                (not global-auto-revert-mode)) ; see #3460
       (auto-revert-mode 1))))


### PR DESCRIPTION
```
When magit-auto-revert-tracked-only is non-nil, visiting a file in
.git/ (e.g., COMMIT_EDITMSG) leads to
magit-turn-on-auto-revert-mode-if-desired asking whether the file is
tracked by running `ls-files --error-unmatch' on the file from within
.git/.

While that ls-files query is pointless (we already know files under
.git/ are untracked), it should be safe to assume that ls-files will
always give a non-zero exit in this case.  Due to a bug in the most
recent Git release candidate, the above ls-files call leads to a
segfault [0], but this is fixed with 5c20398699 (prefix_path: show
gitdir if worktree unavailable, 2020-03-02).

... justify why this is worth it ...

[0]: https://lore.kernel.org/git/20200228195805.GA190372@google.com/
     https://lore.kernel.org/git/87h7yr8omj.fsf@kyleam.com/
```

---

I'm posting this for posterity.  On the git list, [I said][0] I'd propose a change to avoid this `ls-files` call.  However, after thinking about it more and trying to draft the commit message, I couldn't convince myself that the additional code path and complexity (even if it's small) is justified given that (1) the git bug didn't make it into a release and (2) it seems very safe to assume that `ls-files --error-unmatch $PWD/.git/<file>` will continue to exit with a non-zero status, as `magit-turn-on-auto-revert-mode-if-desired` expects.

[0]: https://lore.kernel.org/git/87h7yr8omj.fsf@kyleam.com/