### PR TITLE
magit-process: Add prompt regexps for GnuPG.

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -166,6 +166,8 @@ itself from the hook, to avoid further futile attempts."
   '("^\\(Enter \\)?[Pp]assphrase\\( for \\(RSA \\)?key '.*'\\)?: ?$"
     ;; Match-group 99 is used to identify the "user@host" part.
     "^\\(Enter \\)?[Pp]assword\\( for '?\\(https?://\\)?\\(?99:[^']*\\)'?\\)?: ?$"
+    "Please enter the passphrase for the ssh key"
+    "Please enter the passphrase to unlock the OpenPGP secret key"
     "^.*'s password: ?$"
     "^Yubikey for .*: ?$"
     "^Enter PIN for .*: ?$")


### PR DESCRIPTION
Fixes <https://github.com/magit/magit/issues/4076>.

When using Magit on a remote Git repository via TRAMP (using SSH), the
gpg-agent of the remote may prompt for a password.  Pinentry displays
the prompt through the terminal of the remote process, which until now
was not being handled by magit-process.

* lisp/magit-process.el (magit-process-password-prompt-regexps): Add
regexps to match the GnuPG prompts when requesting a password for a PGP
or SSH key through pinentry.