### PR TITLE
Adjust magit-reshelve-since for upstream changes

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -389,11 +389,11 @@ be used on highly rearranged and unpublished history."
                                      (magit-git-string "rev-list" "--count"
                                                        range))))))
           (push time-rev magit--reshelve-history)
-          (let ((date (floor
-                       (float-time
-                        (date-to-time
-                         (read-string "Date for first commit: "
-                                      time-now 'magit--reshelve-history)))))
+          (let ((tstamp (floor
+                         (float-time
+                          (date-to-time
+                           (read-string "Date for first commit: "
+                                        time-now 'magit--reshelve-history)))))
                 (process-environment process-environment))
             (push "FILTER_BRANCH_SQUELCH_WARNING=1" process-environment)
             (magit-with-toplevel
@@ -403,8 +403,8 @@ be used on highly rearranged and unpublished history."
                        (mapconcat (lambda (rev)
                                     (prog1 (format "%s) \
 export GIT_AUTHOR_DATE=\"%s\"; \
-export GIT_COMMITTER_DATE=\"%s\";;" rev date date)
-                                      (cl-incf date 60)))
+export GIT_COMMITTER_DATE=\"%s\";;" rev tstamp tstamp)
+                                      (cl-incf tstamp 60)))
                                   (magit-git-lines "rev-list" "--reverse"
                                                    range)
                                   " "))


### PR DESCRIPTION
As of Git v2.24, `magit-reshelve-since` will sit for ten seconds before doing anything while underneath Git warned to not use `git-filter-branch` and is waiting/hoping for users to cancel the call.  We can set an environment variable to get rid of that warning, as the second commit of this series does.  But I wondered how an implementation using `git-fast-{export,import}` would look.

After a couple of minor bug fixes in the surrounding code and some prep commits, the final commit of this series gets to that.  IMO the `fast-{export,import}` approach ends up being pretty nice.  While the `filter-branch` approach is shorter, much of the logic is injected into a shell `case` statement.  The `fast-*` approach, on there other hand, allows for pretty straightforward Emacs code, dumping to a buffer and processing the text.

Thoughts?  I'm open to the argument that this isn't worth the extra code for this obscure function; let's just set the environment variable and be done with it.
