### PR TITLE
Customization of ANSI escape sequence processing in diff hunks

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -56,7 +56,7 @@
 (declare-function magit--merge-range "magit-merge" (&optional head))
 ;; For `magit-diff--dwim'
 (declare-function forge--pullreq-ref "forge-pullreq" (pullreq))
-;; For `magit-diff-wash-diff'
+;; For `magit-diff-wash-diffs'
 (declare-function ansi-color-apply-on-region "ansi-color" (begin end))
 
 (eval-when-compile
@@ -2015,6 +2015,9 @@ Staging and applying changes is documented in info node
     (magit-git-wash #'magit-diff-wash-diffs args)))
 
 (defun magit-diff-wash-diffs (args &optional limit)
+  (when (--some (string-prefix-p "--color-moved" it) args)
+    (require 'ansi-color)
+    (ansi-color-apply-on-region (point-min) (point-max)))
   (when (member "--show-signature" args)
     (magit-diff-wash-signature))
   (when (member "--stat" args)
@@ -2093,9 +2096,6 @@ section or a child thereof."
         (if (looking-at "^$") (forward-line) (insert "\n"))))))
 
 (defun magit-diff-wash-diff (args)
-  (when (cl-member-if (lambda (arg) (string-prefix-p "--color-moved" arg)) args)
-    (require 'ansi-color)
-    (ansi-color-apply-on-region (point-min) (point-max)))
   (cond
    ((looking-at "^Submodule")
     (magit-diff-wash-submodule))


### PR DESCRIPTION
This PR adds two new user options:

- `magit-diff-preprocess-git-output-function`
  Function to perform initial processing of git output.

- `magit-diff-preprocess-git-output-always`
  Whether to always call the git output preprocessor function.

These options make it possible to use  a terminal git diff viewer such as [delta](https://github.com/dandavison/delta)<sup>1</sup> to apply 256-color and truecolor (24-bit) ANSI color escape sequences color to the git diff output, and to use [xterm-color](https://github.com/atomontage/xterm-color) instead of `ansi-color` to process the ANSI escape sequences ariving in the magit buffer. Here's a screenshot of Magit using delta (a minor-mode to do this is [here](https://github.com/dandavison/magit-delta)):

<table><tr><td><img width=500px src="https://user-images.githubusercontent.com/52205/79934267-2acb2e00-8420-11ea-8bc4-546508fd3581.png" alt="image" /></td></tr></table>

The magit diff buffer is fully functional (e.g. for staging hunks and lines) since `delta --color-only` guarantees that, after stripping ANSI escape sequences, the diff output is identical to that produced by git.

While this is a rather niche way to use Magit, it is fun to have the option. The main attraction of using delta with Magit is that one gets color syntax highlighting in the magit diff buffer (somewhat like GitLab, GitHub, etc; the syntax highlighting uses the same color themes as [bat](https://github.com/sharkdp/bat/)). Other possible benefits are

- Responsiblities for within-line string edit inference algorithms (`diff-refine-hunk`) are handed over to a dedicated external application
- Visual consistency between diffs displayed by Magit and diffs viewed in a terminal emulator

A minor-mode toggle for using delta with magit is here: https://github.com/dandavison/magit-delta (I'll submit that to MELPA once this PR is resolved).

I can add documentation of the new variables, but I wanted to check first whether it would be more appropriate to leave them undocumented for now (e.g. pending future work on unifying handling of ANSI escape sequences in contexts other than diffs).

### Testing

- I've checked that `--color-moved` still works (e.g. `-m d u` in the diff transient)
- Incidental magit usage on this branch.
- `make test` output is the same locally on this branch as on master

----------------------------------
<sup>1</sup> I'm the author of delta.
