### PR TITLE
Add magit-patch-apply-buffer

### DIFF
--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -249,7 +249,8 @@ which creates patches for all commits that are reachable from
    ("-c" "Only apply to index" "--cached")
    ("-3" "Fall back on 3way merge" ("-3" "--3way"))]
   ["Actions"
-   ("a"  "Apply patch" magit-patch-apply)]
+   ("a"  "Apply patch" magit-patch-apply)
+   (6 "b"  "Apply patch in buffer" magit-patch-apply-buffer)]
   (interactive
    (if (not (eq current-transient-command 'magit-patch-apply))
        (list nil)
@@ -262,6 +263,17 @@ which creates patches for all commits that are reachable from
   (if (not file)
       (transient-setup 'magit-patch-apply)
     (magit-run-git "apply" args "--" (magit-convert-filename-for-git file))))
+
+;;;###autoload
+(defun magit-patch-apply-buffer (buffer &rest args)
+  "Apply the patch buffer BUFFER."
+  (interactive
+   (list (read-buffer "Apply patch in buffer: " nil t)
+         (transient-args 'magit-patch-apply)))
+  (with-temp-buffer
+    (insert-buffer-substring-no-properties buffer)
+    (magit-run-git-with-input "apply" args "-")
+    (magit-refresh)))
 
 ;;;###autoload
 (defun magit-patch-save (file &optional arg)


### PR DESCRIPTION
This command applies a patch buffer, instead of a file. This is useful when you have opened a patch file (for review, etc) and don't want the hassle to find the file when applying. 

In this command I write the buffer's content to a temp file in `/tmp`. Is this ok to do? I.e., any potential trouble we might encounter?