### PR TITLE
Use eq instead of = when comparing magit-git-exit-code with integer

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -324,11 +324,11 @@ to do the following.
 
 (defun magit-git-success (&rest args)
   "Execute Git with ARGS, returning t if its exit code is 0."
-  (= (magit-git-exit-code args) 0))
+  (eq (magit-git-exit-code args) 0))
 
 (defun magit-git-failure (&rest args)
   "Execute Git with ARGS, returning t if its exit code is 1."
-  (= (magit-git-exit-code args) 1))
+  (eq (magit-git-exit-code args) 1))
 
 (defun magit-git-string-p (&rest args)
   "Execute Git with ARGS, returning the first line of its output.


### PR DESCRIPTION
Recently when calling `magit-commit-amend` through tramp, it is
possible (no idea why) that `magit-git-exit-code` returns `"Signal 1"`
instead of an integer. When compared using `=`, an error is raised:

```
Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p "Signal 1")
  magit-git-success("merge-base" "--is-ancestor" nil "origin/master")
  magit-rev-ancestor-p(nil "origin/master")
  magit-list-publishing-branches(nil)
  magit-commit-amend-assert()
  magit-commit-amend(nil)
  funcall-interactively(magit-commit-amend nil)
  call-interactively(magit-commit-amend nil nil)
  command-execute(magit-commit-amend)
```

Further investigation in IELM results:
```
*** Welcome to IELM ***  Type (describe-mode) for help.
ELISP> (magit-git-exit-code "merge-base" "--is-ancestor" nil "origin/master")
"Signal 1"
ELISP> (= (magit-git-exit-code "merge-base" "--is-ancestor" nil "origin/master") 0)
*** Eval error ***  Wrong type argument: number-or-marker-p, "Signal 1"
```
And appears only in tramp.

To avoid this error, `=` is replaced with `eq` so it won't break any
    existing functionality and just enough to surpass the error.