### PR TITLE
Fix regexp matching version from magit directory

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -445,8 +445,7 @@ and Emacs to it."
               (push 'dirname debug)
               (let ((dirname (file-name-nondirectory
                               (directory-file-name topdir))))
-                (when (string-match "\\`magit-\\([0-9]\\{8\\}\\.[0-9]*\\)"
-                                    dirname)
+                (when (string-match "\\`magit-\\([0-9].*\\)" dirname)
                   (setq magit-version (match-string 1 dirname)))))
             ;; If all else fails, just report the commit hash. It's
             ;; better than nothing and we cannot do better in the case


### PR DESCRIPTION
I am having the same problem as #4106 (my .emacs.d is also symlinked).
I believe `(magit-version)` fails due to the regexp for matching the version from the magit directory not being up-to-date. The regexp currently tries matching an 8-digit number, followed by a period, followed by any number of digits. I changed it to match a number, followed by more than one number or period, followed by a number.
If desired, I can make the regexp match the SemVer-scheme which it currently does not.

Due to symlinks being an issue in both regards, I initially suspected the usage of `file-chase-links` instead of `file-truename` to be the culprit. However, changing the method did not fix the problem.
Finally, I wonder if there is a better way to test changes than modifying `.emacs.d/elpa/magit-*/magit.el`. Thanks!