### PR TITLE
magit-display-buffer-same-window-except-diff-v1: inhibit-same-window

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -695,7 +695,7 @@ other buffers in the selected window."
   (display-buffer
    buffer (if (with-current-buffer buffer
                 (derived-mode-p 'magit-diff-mode 'magit-process-mode))
-              nil  ; display in another window
+              '(nil (inhibit-same-window . t))
             '(display-buffer-same-window))))
 
 (defun magit--display-buffer-fullframe (buffer alist)


### PR DESCRIPTION
The intention of `magit-display-buffer-same-window-except-diff-v1' is
to display diff buffers in a separate window. A nil action argument
passed to `display-buffer' is not always enough to accomplish this
when `display-buffer-base-action' has been customized, as in the
following example from section 28.13.4 of the Elisp
manual (Additional Options for Displaying Buffers):

(customize-set-variable
 'display-buffer-base-action
 '((display-buffer-reuse-window display-buffer-same-window
    display-buffer-in-previous-window
    display-buffer-use-some-window)))

For example, when used with
`magit-display-buffer-same-window-except-diff-v1', the above
customization will result in the diff buffer popping up in the same
window, and the commit message buffer not being displayed, when
`magit-commit-create' is called. This is due to the behavior of
`display-buffer-same-window'. To have the diff buffer display in
another window, the `inhibit-same-window' action alist entry should
be passed in the action argument to `display-buffer'.
`display-buffer-same-window' will respect the `inhibit-same-window'
entry.

For more information, see section 28.13.6 (The Zen of Buffer Display)
of the Elisp manual.

Note that this commit deliberately does not change
`magit-display-buffer-traditional', since that is the default for
`magit-display-buffer-function', and changing its behavior might
annoy people who have `display-buffer-base-action' customized but
rely on magit defaults.
