### PR TITLE
magit-branch-checkout: Ignore submodule modifications

### DIFF
--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -340,7 +340,7 @@ when using `magit-branch-and-checkout'."
             (list choice (magit-read-starting-point "Create" choice))))))
   (if (not start-point)
       (magit-checkout branch)
-    (when (magit-anything-modified-p)
+    (when (magit-anything-modified-p t)
       (user-error "Cannot checkout when there are uncommitted changes"))
     (magit-branch-and-checkout branch start-point)
     (when (magit-remote-branch-p start-point)


### PR DESCRIPTION
Submodules can be completely up-to-date, yet still show as modified
because of a dirty worktree. Even if they weren't up-to-date, switching
branches with Git on the command-line ignores submodules, so we should
too. Otherwise this prevents the user from switching branches unless
they completely update and clean every submodule, which is unfriendly.