### PR TITLE
Fix edebug spec for ‘magit-insert-section’.

### DIFF
--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -1027,7 +1027,7 @@ form `(eval FORM)' in which case FORM is evaluated at runtime.
 \(fn [NAME] (TYPE &optional VALUE HIDE) &rest BODY)"
   (declare (indent defun)
            (debug ([&optional symbolp]
-                   (&or [("eval" symbolp) &optional form form]
+                   (&or [("eval" form) &optional form form]
                         [symbolp &optional form form])
                    body)))
   (let ((tp (cl-gensym "type"))


### PR DESCRIPTION
As described in the docstring, the form for ‘eval’ is ‘(eval FORM)', and FORM
doesn’t need to be a symbol.

Without this, functions like ‘magit-insert-recent-commits' can’t be edebugged
if ‘magit-insert-section' is edebugged.