### PR TITLE
Handle emulated symlinks created by straight.el

### DIFF
--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -1104,6 +1104,23 @@ the %s(1) manpage.
 (advice-add 'org-man-export :around
             'org-man-export--magit-gitman)
 
+;;; Kludges for Package Managers
+
+(defun magit--straight-chase-links (filename)
+  "Chase links in FILENAME until a name that is not a link.
+
+This is the same as `file-chase-links', except that it also
+handles fake symlinks that are created by the package manager
+straight.el on Windows.
+
+See <https://github.com/raxod502/straight.el/issues/520>."
+  (when (and (bound-and-true-p straight-symlink-emulation-mode)
+             (fboundp 'straight-chase-emulated-symlink))
+    (when-let ((target (straight-chase-emulated-symlink filename)))
+      (unless (eq target 'broken)
+        (setq filename target))))
+  (file-chase-links filename))
+
 ;;; Bitmaps
 
 (when (fboundp 'define-fringe-bitmap)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -403,7 +403,7 @@ and Emacs to it."
     (unless (and toplib
                  (equal (file-name-nondirectory toplib) "magit.el"))
       (setq toplib (locate-library "magit.el")))
-    (setq toplib (and toplib (file-chase-links toplib)))
+    (setq toplib (and toplib (magit--straight-chase-links toplib)))
     (push toplib debug)
     (when toplib
       (let* ((topdir (file-name-directory toplib))
@@ -411,7 +411,7 @@ and Emacs to it."
                       ".git" (file-name-directory
                               (directory-file-name topdir))))
              (static (locate-library "magit-version.el" nil (list topdir)))
-             (static (and static (file-chase-links static))))
+             (static (and static (magit--straight-chase-links static))))
         (or (progn
               (push 'repo debug)
               (when (and (file-exists-p gitdir)


### PR DESCRIPTION
As promised, this implements the logic that I proposed in https://github.com/raxod502/straight.el/issues/520#issuecomment-633645316 to fix the problem where Magit would not be able to determine its version when installed via straight.el on Windows.