### PR TITLE
magit-diff-wash-diff: add cases for both added and removed in local

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2120,12 +2120,15 @@ section or a child thereof."
           (insert ?\n))))
     t)
    ((looking-at (concat "^\\(merged\\|changed in both\\|"
-                        "added in remote\\|removed in remote\\)"))
+                        "added in remote\\|removed in remote\\|"
+                        "added in both\\|removed in local\\)"))
     (let ((status (pcase (match-string 1)
                     ("merged" "merged")
                     ("changed in both" "conflict")
                     ("added in remote" "new file")
-                    ("removed in remote" "deleted")))
+                    ("added in both" "conflict")
+                    ("removed in remote" "deleted")
+                    ("removed in local" "l.deleted")))
           file orig base modes)
       (magit-delete-line)
       (while (looking-at


### PR DESCRIPTION
using [m]erge [p]review, it seems not all possibilities for conflicts are supported. I just added the 2 I found so that they don't break hard, but I don't know exactly how should the 'proper' fix be.

Even the labels like "l.deleted" get easily missaligned. So this might not be the path to fix them, but at least is a quick pin at the relevant code area.

Cheers!