### PR TITLE
magit-remote-add: Handle lack of "origin" remote

### DIFF
--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -104,7 +104,8 @@ has to be used to view and change remote related variables."
      (list remote
            (magit-read-url
             "Remote url"
-            (and (string-match "\\([^:/]+\\)/[^/]+\\(\\.git\\)?\\'" origin)
+            (and origin
+                 (string-match "\\([^:/]+\\)/[^/]+\\(\\.git\\)?\\'" origin)
                  (replace-match remote t t origin 1)))
            (transient-args 'magit-remote))))
   (if (pcase (list magit-remote-add-set-remote.pushDefault


### PR DESCRIPTION
It is possible for a repo to have no remote called "origin".  In this case, magit-remote-add fails when attempting to construct a suggestion for the to-be-added remote's URL.

Check that we have an "origin" remote URL before using it.
