### PR TITLE
Rename magit-insert-submodules in doc to magit-insert-modules.

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -6613,7 +6613,7 @@ Also see [[man:git-submodule]]
 The command ~magit-list-submodules~ displays a list of the current
 repository's submodules in a separate buffer.  It's also possible to
 display information about submodules directly in the status buffer of
-the super-repository by adding ~magit-insert-submodules~ to the hook
+the super-repository by adding ~magit-insert-modules~ to the hook
 ~magit-status-sections-hook~ as described in [[*Status Module Sections]].
 
 - Command: magit-list-submodules
@@ -6637,7 +6637,7 @@ the super-repository by adding ~magit-insert-submodules~ to the hook
   has to return a string to be inserted or nil.  PROPS is an alist
   that supports the keys ~:right-align~ and ~:pad-right~.
 
-- Function: magit-insert-submodules
+- Function: magit-insert-modules
 
   Insert sections for all submodules.  For each section insert the
   path, the branch, and the output of ~git describe --tags~,


### PR DESCRIPTION
It appears that when the function `magit-insert-submodules` was renamed to `magit-insert-modules`, the documentation was not updated. 