### PR TITLE
Add project.el integration

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -30,6 +30,8 @@
 (require 'magit)
 
 (declare-function dired-read-shell-command "dired-aux" (prompt arg files))
+;; For `magit-project-status'.
+(declare-function project-root "project" (project))
 
 (defvar ido-exit)
 (defvar ido-fallback)
@@ -130,6 +132,20 @@ like pretty much every other keymap:
   (setq ido-fallback 'magit-status)                ; for Emacs >= 26.2
   (with-no-warnings (setq fallback 'magit-status)) ; for Emacs 25
   (exit-minibuffer))
+
+;;;###autoload
+(defun magit-project-status ()
+  "Run `magit-status' in the current project's root."
+  (interactive)
+  (magit-status-setup-buffer (project-root (project-current t))))
+
+(with-eval-after-load 'project
+  ;; Only more recent versions of project.el have `project-prefix-map' and
+  ;; `project-switch-commands', though project.el is available in Emacs 25.
+  (when (boundp 'project-prefix-map)
+    (define-key project-prefix-map "m" #'magit-project-status))
+  (when (boundp 'project-switch-commands)
+    (add-to-list 'project-switch-commands '(?m "Magit" magit-status))))
 
 ;;;###autoload
 (defun magit-dired-jump (&optional other-window)


### PR DESCRIPTION
Add some integration with project.el.  The `C-x p` map is the main way I navigate within and between projects nowadays, and so this is very nice to have.  It's modelled on the vc-dir integration which comes with project.el.  I also thought about somehow replacing vc-dir for git projects, but I think in the end it is more useful to have a separate key.