### PR TITLE
magit-extras: Forward-declare project variables for byte-compiler

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -35,6 +35,8 @@
 
 (defvar ido-exit)
 (defvar ido-fallback)
+(defvar project-prefix-map)
+(defvar project-switch-commands)
 
 (defgroup magit-extras nil
   "Additional functionality for Magit."


### PR DESCRIPTION
Follow-up to commit fccd3cff.