### PR TITLE
Allow marking stashes to delete in helm stashes completion (#4185)

### DIFF
--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -224,6 +224,8 @@ and forgo removing the stash."
       (magit-stash-drop stash)
     (magit-run-git "stash" "apply" stash)))
 
+(defvar helm-comp-read-use-marked)
+
 ;;;###autoload
 (defun magit-stash-drop (stash)
   "Remove a stash from the stash list.

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -231,7 +231,8 @@ When the region is active offer to drop all contained stashes."
   (interactive
    (list (--if-let (magit-region-values 'stash)
              (magit-confirm 'drop-stashes nil "Drop %i stashes" nil it)
-           (magit-read-stash "Drop stash"))))
+           (let ((helm-comp-read-use-marked t))
+             (magit-read-stash "Drop stash")))))
   (dolist (stash (if (listp stash)
                      (nreverse (prog1 stash (setq stash (car stash))))
                    (list stash)))

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -477,7 +477,7 @@ acts similarly to `completing-read', except for the following:
                           predicate
                           require-match initial-input hist def)))
       (setq this-command command)
-      (if (string= reply "")
+      (if (equal reply "")
           (if require-match
               (user-error "Nothing selected")
             nil)


### PR DESCRIPTION
Fixes issue #4185. I only bound the variable for stashes deletion.
Please review before merging, I don't know how to use `--if-let`, maybe it can be used to bind the variable instead of adding an extra let, dunno.  This is a proof of concept, maybe other people will find it useful and use it elsewhere in Magit.
Thanks.