### PR TITLE
Show message after creating patch

### DIFF
--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -127,7 +127,8 @@ which creates patches for all commits that are reachable from
             (or (--some (and (string-match "\\`--output-directory=\\(.+\\)" it)
                              (expand-file-name (match-string 1 it) topdir))
                         args)
-                topdir))))))))
+                topdir))))))
+    (message "Creating patch done.")))
 
 (transient-define-argument magit-format-patch:--in-reply-to ()
   :description "In reply to"


### PR DESCRIPTION
Previously, users couldn't see the completion of their work
because magit didn't show a message after the patch was created.
This message lets the user know that magit have done their job
correctly.