### PR TITLE
magit-fetch: Add -u for --unshallow option

### DIFF
--- a/lisp/magit-fetch.el
+++ b/lisp/magit-fetch.el
@@ -46,7 +46,8 @@ Ignored for Git versions before v2.8.0."
   :man-page "git-fetch"
   ["Arguments"
    ("-p" "Prune deleted branches" ("-p" "--prune"))
-   ("-t" "Fetch all tags" ("-t" "--tags"))]
+   ("-t" "Fetch all tags" ("-t" "--tags"))
+   (7 "-u" "Fetch full history" "--unshallow")]
   ["Fetch from"
    ("p" magit-fetch-from-pushremote)
    ("u" magit-fetch-from-upstream)


### PR DESCRIPTION
Add support for --unshallow.  Set this to level 7 in transient, since
this is a relatively uncommon command, and is the inverse of a shallow
clone which magit already has at level 7.


----

#