### PR TITLE
git merge --X <option> -> git merge -X

### DIFF
--- a/lisp/magit-merge.el
+++ b/lisp/magit-merge.el
@@ -47,7 +47,7 @@
    ("-f" "Fast-forward only" "--ff-only")
    ("-n" "No fast-forward"   "--no-ff")
    (magit-merge:--strategy)
-   (5 magit-diff:--diff-algorithm :argument "--Xdiff-algorithm=")
+   (5 magit-diff:--diff-algorithm :argument "-Xdiff-algorithm=")
    (5 magit:--gpg-sign)]
   ["Actions"
    :if-not magit-merge-in-progress-p


### PR DESCRIPTION
git merge -X <option> only uses a a single `-` according to https://git-scm.com/docs/git-merge
