### PR TITLE
Fix autoloading of magit-file-mode-map

### DIFF
--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -347,6 +347,7 @@ Currently this only adds the following key bindings.
 ;; variable but does not cause the mode function to be called, and we
 ;; cannot use `:initialize' to call that explicitly because the option
 ;; is defined before the functions, so we have to do it here.
+;;;###autoload
 (cl-eval-when (load eval)
   (when global-magit-file-mode
     (global-magit-file-mode 1)))


### PR DESCRIPTION
Hello!

This is a followup to [the discussion on gitter](https://gitter.im/magit/magit?at=5eab4ca67a24ff01b0f415b0) about letting <kbd>C-x g</kbd> and friends work without calling `(require 'magit)` first (I sifted through the issue tracker as [suggested](https://gitter.im/magit/magit?at=5ee8ec92a85de30394190568), but I could not find a report about this).

While looking at recent commits to the Emacs repository, I noticed that one can just [autoload arbitrary forms](https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=5142149758333cfddc25c8c696e0e6f322e37d62).  I thus tried the following:

1. In `~/.emacs.d/elpa/magit-…/magit-files.el`, I added an `;;;###autoload` on the code that activates `global-magit-file-mode`.

2. I byte-compiled `magit-files.el` (<kbd>B</kbd> on `magit-files.el` in Dired).

3. `M-: (package-generate-autoloads "magit" "~/.emacs.d/elpa/magit-…/")`

4. `emacs -Q`

5. `M-x package-initialize`

6. Open a file inside a Git repository.

7. Lo!  <kbd>C-x g</kbd> et al. work without `requir`ing `'magit` first.

I'm far from certain that this is TRT; I didn't notice any side-effect when testing, but I'm not very familiar with the autoload machinery so I might be missing something.

CCing @npostavs who took part in the discussion back then.
