### PR TITLE
Fix display of magit-blame's show-lines option for Emacs 27.1

### DIFF
--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -674,9 +674,10 @@ modes is toggled, then this mode also gets toggled automatically.
   (propertize
    (concat (propertize "\s" 'display '(space :height (2)))
            (propertize "\n" 'line-height t))
-   'font-lock-face (list :background
-                         (face-attribute 'magit-blame-heading
-                                         :background nil t))))
+   'font-lock-face `(:background
+                     ,(face-attribute 'magit-blame-heading
+                                      :background nil t)
+                     ,@(and (>= emacs-major-version 27) '(:extend t)))))
 
 (defun magit-blame--format-time-string (time tz)
   (let* ((time-format (or (magit-blame--style-get 'time-format)


### PR DESCRIPTION
In Emacs 27.1, the `:extend t` face attribute needs to be applied in order
to extend it until the edge of the window, see Emacs' NEWS file.

See also 891ebdca where this was done for other faces.

IIUC it's not necessary to hide this behind a version check, since earlier versions of Emacs will simply ignore the unknown face attribute.