### PR TITLE
Enabling `magit-file-mode-map` automatically

### DIFF
--- a/default.mk
+++ b/default.mk
@@ -51,6 +51,7 @@ ELS  = git-commit.el
 ELS += magit-transient.el
 ELS += magit-utils.el
 ELS += magit-section.el
+ELS += magit-file-modes.el
 ifeq "$(BUILD_MAGIT_LIBGIT)" "true"
 ELS += magit-libgit.el
 endif

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -12,6 +12,7 @@ all: lisp
 git-commit.elc:
 magit-utils.elc:
 magit-section.elc:
+magit-file-modes.elc:
 ifeq "$(BUILD_MAGIT_LIBGIT)" "true"
 magit-libgit.elc:
 magit-git.elc:          magit-utils.elc magit-section.elc magit-libgit.elc

--- a/lisp/magit-file-modes.el
+++ b/lisp/magit-file-modes.el
@@ -1,0 +1,100 @@
+;;; magit-file-modes.el --- modes for files and blobs  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2020  The Magit Project Contributors
+;;
+;; You should have received a copy of the AUTHORS.md file which
+;; lists all contributors.  If not, see http://magit.vc/authors.
+
+;; Author: Jonas Bernoulli <jonas@bernoul.li>
+;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
+
+;; Magit is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; Magit is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+;; License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Magit.  If not, see http://www.gnu.org/licenses.
+
+;;; Commentary:
+
+;; This library defines modes useful in buffers visiting files and
+;; blobs.
+
+;;; Code:
+
+(require 'cl-lib)
+
+(declare-function magit-inside-worktree-p "magit-git")
+
+;;; File Mode
+
+(defvar magit-file-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map "\C-xg"    'magit-status)
+    (define-key map "\C-x\M-g" 'magit-dispatch)
+    (define-key map "\C-c\M-g" 'magit-file-dispatch)
+    map)
+  "Keymap for `magit-file-mode'.")
+
+(defvar magit-file-mode-lighter "")
+
+(define-minor-mode magit-file-mode
+  "Enable some Magit features in a file-visiting buffer.
+
+Currently this only adds the following key bindings.
+\n\\{magit-file-mode-map}"
+  :package-version '(magit . "2.2.0")
+  :lighter magit-file-mode-lighter
+  :keymap  magit-file-mode-map)
+
+(defun magit-file-mode-turn-on ()
+  (and buffer-file-name
+       (magit-inside-worktree-p t)
+       (magit-file-mode)))
+
+;;;###autoload
+(define-globalized-minor-mode global-magit-file-mode
+  magit-file-mode magit-file-mode-turn-on
+  :package-version '(magit . "2.13.0")
+  :link '(info-link "(magit)Minor Mode for Buffers Visiting Files")
+  :group 'magit-essentials
+  :group 'magit-modes
+  :init-value t)
+;; Unfortunately `:init-value t' only sets the value of the mode
+;; variable but does not cause the mode function to be called, and we
+;; cannot use `:initialize' to call that explicitly because the option
+;; is defined before the functions, so we have to do it here.
+(cl-eval-when (load eval)
+  (when global-magit-file-mode
+    (global-magit-file-mode 1)))
+
+;;; Blob Mode
+
+(defvar magit-blob-mode-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map magit-file-mode-map)
+    (define-key map "p" 'magit-blob-previous)
+    (define-key map "n" 'magit-blob-next)
+    (define-key map "b" 'magit-blame-addition)
+    (define-key map "r" 'magit-blame-removal)
+    (define-key map "f" 'magit-blame-reverse)
+    (define-key map "q" 'magit-kill-this-buffer)
+    map)
+  "Keymap for `magit-blob-mode'.")
+
+(define-minor-mode magit-blob-mode
+  "Enable some Magit features in blob-visiting buffers.
+
+Currently this only adds the following key bindings.
+\n\\{magit-blob-mode-map}"
+  :package-version '(magit . "2.3.0"))
+
+;;; _
+(provide 'magit-file-modes)
+;;; magit-file-modes.el ends here

--- a/lisp/magit-file-modes.el
+++ b/lisp/magit-file-modes.el
@@ -66,13 +66,27 @@ Currently this only adds the following key bindings.
   :group 'magit-essentials
   :group 'magit-modes
   :init-value t)
+
 ;; Unfortunately `:init-value t' only sets the value of the mode
 ;; variable but does not cause the mode function to be called, and we
 ;; cannot use `:initialize' to call that explicitly because the option
 ;; is defined before the functions, so we have to do it here.
+
+;;;###autoload
+(defvar global-magit-file-mode--activated nil)
+
 (cl-eval-when (load eval)
-  (when global-magit-file-mode
+  (when (and global-magit-file-mode
+             (not global-magit-file-mode--activated))
+    (setq global-magit-file-mode--activated t)
     (global-magit-file-mode 1)))
+
+;; Autoload the same form without `cl-eval-when' so that the loaddefs
+;; file does not need to require cl-lib.
+;;;###autoload(when (and global-magit-file-mode
+;;;###autoload           (not global-magit-file-mode--activated))
+;;;###autoload  (setq global-magit-file-mode--activated t)
+;;;###autoload  (global-magit-file-mode 1))
 
 ;;; Blob Mode
 

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -24,9 +24,8 @@
 ;;; Commentary:
 
 ;; This library implements support for finding blobs, staged files,
-;; and Git configuration files.  It also implements modes useful in
-;; buffers visiting files and blobs, and the commands used by those
-;; modes.
+;; and Git configuration files, as well as commands for buffers
+;; visiting files and blobs.
 
 ;;; Code:
 
@@ -34,6 +33,8 @@
   (require 'subr-x))
 
 (require 'magit)
+
+(declare-function magit-blob-mode "magit-file-modes")
 
 ;;; Find Blob
 
@@ -279,15 +280,7 @@ directory, while reading the FILENAME."
                           (confirm-nonexistent-file-or-buffer))))
   (find-file-other-frame filename wildcards))
 
-;;; File Mode
-
-(defvar magit-file-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map "\C-xg"    'magit-status)
-    (define-key map "\C-x\M-g" 'magit-dispatch)
-    (define-key map "\C-c\M-g" 'magit-file-dispatch)
-    map)
-  "Keymap for `magit-file-mode'.")
+;;; Commands for file buffers
 
 ;;;###autoload (autoload 'magit-file-dispatch "magit" nil t)
 (transient-define-prefix magit-file-dispatch ()
@@ -319,58 +312,7 @@ directory, while reading the FILENAME."
     (5 "C-c u" "Untrack file"  magit-file-untrack)
     (5 "C-c c" "Checkout file" magit-file-checkout)]])
 
-(defvar magit-file-mode-lighter "")
-
-(define-minor-mode magit-file-mode
-  "Enable some Magit features in a file-visiting buffer.
-
-Currently this only adds the following key bindings.
-\n\\{magit-file-mode-map}"
-  :package-version '(magit . "2.2.0")
-  :lighter magit-file-mode-lighter
-  :keymap  magit-file-mode-map)
-
-(defun magit-file-mode-turn-on ()
-  (and buffer-file-name
-       (magit-inside-worktree-p t)
-       (magit-file-mode)))
-
-;;;###autoload
-(define-globalized-minor-mode global-magit-file-mode
-  magit-file-mode magit-file-mode-turn-on
-  :package-version '(magit . "2.13.0")
-  :link '(info-link "(magit)Minor Mode for Buffers Visiting Files")
-  :group 'magit-essentials
-  :group 'magit-modes
-  :init-value t)
-;; Unfortunately `:init-value t' only sets the value of the mode
-;; variable but does not cause the mode function to be called, and we
-;; cannot use `:initialize' to call that explicitly because the option
-;; is defined before the functions, so we have to do it here.
-(cl-eval-when (load eval)
-  (when global-magit-file-mode
-    (global-magit-file-mode 1)))
-
-;;; Blob Mode
-
-(defvar magit-blob-mode-map
-  (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map magit-file-mode-map)
-    (define-key map "p" 'magit-blob-previous)
-    (define-key map "n" 'magit-blob-next)
-    (define-key map "b" 'magit-blame-addition)
-    (define-key map "r" 'magit-blame-removal)
-    (define-key map "f" 'magit-blame-reverse)
-    (define-key map "q" 'magit-kill-this-buffer)
-    map)
-  "Keymap for `magit-blob-mode'.")
-
-(define-minor-mode magit-blob-mode
-  "Enable some Magit features in blob-visiting buffers.
-
-Currently this only adds the following key bindings.
-\n\\{magit-blob-mode-map}"
-  :package-version '(magit . "2.3.0"))
+;;; Commands for blob buffers
 
 (defun magit-blob-next ()
   "Visit the next blob which modified the current file."

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -774,6 +774,7 @@ is non-nil, in which case return nil."
                (noerror nil)
                (t (signal 'magit-outside-git-repo default-directory))))))
 
+;;;###autoload
 (defun magit-inside-worktree-p (&optional noerror)
   "Return t if `default-directory' is below the working directory.
 If it is below the repository directory, then return nil.

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -400,6 +400,7 @@ Process output goes into a new section in the buffer returned by
        (apply #'magit-process-file program nil process-buf nil args))
      process-buf (current-buffer) default-directory section)))
 
+;;;###autoload
 (defun magit-process-file (process &optional infile buffer display &rest args)
   "Process files synchronously in a separate process.
 Identical to `process-file' but temporarily enable Cygwin's


### PR DESCRIPTION
Hello again!

This is a followup to #4207, where I tried `;;;###autoload`ing forms willy-nilly, and it turned out not to be a great idea.  I have now moved `magit-file-mode` and `magit-blob-mode` from `magit-files.el` into a new file (tentatively called `magit-file-modes.el`), as suggested.  To be more specific, I moved everything under `;;; File Mode`, `;;; Blob Mode` and `;;; File Commands` to this new library.

In addition to actually enabling `magit-file-mode-map` when `global-magit-file-mode` is unset and defaults to `t`, this PR makes startup a bit faster when it *is* customized, IIUC by virtue of not loading `magit-files.el`, which `require`s `'magit`.  FWIW, on my laptop:

branch    | `global-magit-file-mode`¹  | startup time² (s) | keymap enabled?
----------|----------------------------|-------------------|----------------
master    | unset                      | 0.72              | ❌
this PR   | unset                      | 0.92              | ✔
master    | nil                        | 1.49              | ❌
this PR   | nil                        | 0.93              | ❌ 
master    | t                          | 1.48              | ✔
this PR   | t                          | 0.92              | ✔

(NB: the default case is *slower* though, since the new library where the globalized mode is defined is always loaded now.  More on that below)


I'll submit this as a draft because I'm sure there will be things I messed up; to start off, here are some things I'm unsure about:

1. While my final set of `require`s, `defvar`s and `declare-function`s quenches all compiler warnings, I ended up having to `(require 'magit-process)` despite `magit-file-modes.el` not using this library directly, because
    - `magit-file-mode-turn-on` calls `magit-inside-worktree-p` (defined in `magit-git.el`),
    - `magit-inside-worktree-p` eventually calls `magit-process-file` (defined in `magit-process.el`),
    - since `magit-process.el` `require`s `'magit-git`, we can't `(require 'magit-process)` in `magit-git.el`, otherwise we get circular imports;
    - my workaround does not feel very satisfying; should more time be spent untying this knot?

2. Should we actually enable `global-magit-file-mode` by default?  It does slow things down a bit in the default case, IIUC because Emacs loads `magit-autoloads.el` before customizations are applied, so the autoloaded `when` condition is always true, therefore Emacs runs `(global-magit-file-mode 1)` unconditionally (before turning it back off if it's customized to nil), which I assume loads `magit-file-modes.el` and everything it `require`s.  Here are the options I see:

    1. Keep the autoload and stop thinking about this.
    2. Keep the autoload, and try to shave off some milliseconds by `requir`ing fewer things.
    3. Drop the autoload, drop `:init-value t`, amend "Minor Mode for Buffers Visiting Files" in `magit.org`.
    4. Find another way to ensure `magit-file-mode-map` is enabled when `global-magit-file-mode` is enabled by default?

(FWIW I've [discussed the issue with Stefan Monnier on help-gnu-emacs](https://lists.gnu.org/archive/html/help-gnu-emacs/2020-09/msg00130.html); from my understanding, while out-of-core minor modes are not *strictly forbidden* to auto-enable themselves, it does seem to be something of a legally gray area.)


Aside from these points, I hope I didn't make too much of a mess with this PR.  Thank you very much for your patience.


## Footnotes

¹ "unset" = uncustomized; otherwise, set with `custom-set-variables`.

² With `/tmp/.emacs`:

``` elisp
(defun pr/startup ()
  (princ
   (format "startup: %s\n"
           (float-time (time-subtract after-init-time before-init-time)))
   'external-debugging-output))

(add-to-list 'load-path "/path/to/with-editor/")
(add-to-list 'load-path "/path/to/transient/")
(add-to-list 'load-path "/path/to/dash/")
(add-to-list 'load-path "/path/to/magit/lisp/")

(load "magit-autoloads.el")

;; Depending on the setup:
;; (custom-set-variables '(global-magit-file-mode …))
```

Then run:

``` sh
HOME=/tmp emacs --eval '(pr/startup)' --eval '(kill-emacs)'
```
