### PR TITLE
Bug fix for `magit--tramp-asserts'

### DIFF
--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -317,7 +317,7 @@ also contains other useful hints.")
       (if-let ((version (let ((default-directory directory))
                           (magit-git-version))))
           (if (version<= magit--minimal-git version)
-              (push version magit--remotes-using-recent-git)
+              (push remote magit--remotes-using-recent-git)
             (display-warning 'magit (format "\
 Magit requires Git >= %s, but on %s the version is %s.
 


### PR DESCRIPTION
Looks like a typo.  I think this fix saves a call to `(magit-git-version)` (and a consequent `git` process) for every single `magit-status` in a remote directory?
