### PR TITLE
Install magit-git.el when BUILD_MAGIT_LIBGIT is false

### DIFF
--- a/default.mk
+++ b/default.mk
@@ -53,6 +53,8 @@ ELS += magit-utils.el
 ELS += magit-section.el
 ifeq "$(BUILD_MAGIT_LIBGIT)" "true"
 ELS += magit-libgit.el
+else
+ELS += magit-git.el
 endif
 ELS += magit-mode.el
 ELS += magit-margin.el


### PR DESCRIPTION
Currently `make install` doesn't install magit-git.el when BUILD_MAGIT_LIBGIT is false. So make it install.
