### PR TITLE
magit-branch:  default read-upstream-first to nil

### DIFF
--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -39,7 +39,7 @@
 
 ;;; Options
 
-(defcustom magit-branch-read-upstream-first t
+(defcustom magit-branch-read-upstream-first nil
   "Whether to read upstream before name of new branch when creating a branch.
 
 `nil'      Read the branch name first.


### PR DESCRIPTION
to match the documentation and the behavior I expected.

See https://github.com/magit/magit/issues/4232#issuecomment-716592952