### PR TITLE
Add three global key bindings by default

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-1078-gff8a616cd+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-1083-gb18be6c14+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-1078-gff8a616cd+1).
+This manual is for Magit version 2.90.1 (v2.90.1-1083-gb18be6c14+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2020 Jonas Bernoulli <jonas@bernoul.li>
@@ -282,13 +282,8 @@ tutorial.  Alternatively you can use an existing local repository, but
 if you do that, then you should commit all uncommitted changes before
 proceeding.
 
-To display information about the current Git repository, type ~M-x
-magit-status RET~.  You will be using this command a lot, and should
-therefore give it a global key binding.  This is what we recommend:
-
-#+BEGIN_SRC emacs-lisp
-  (global-set-key (kbd "C-x g") 'magit-status)
-#+END_SRC
+Type ~C-x g~ to display information about the current Git repository in
+a dedicated buffer, called the status buffer.
 
 Most Magit commands are commonly invoked from the status buffer.  It
 can be considered the primary interface for interacting with Git using
@@ -351,28 +346,24 @@ local branch onto the remote configured as the push-remote.  (If the
 push-remote is not configured yet, then you would first be prompted
 for the remote to push to.)
 
-So far we have mentioned the commit, push, and log transient prefix
-commands.  These are probably among the transients you will be using
-the most, but many others exist.  To show a transient that lists all
-other transients (as well as the various apply commands and some other
-essential commands), type ~h~.  Try a few.
+So far we have mentioned the commit, push, and log menu commands.
+These are probably among the menus you will be using the most, but
+many others exist.  To show a menu that lists all other menus (as well
+as the various apply commands and some other essential commands), type
+~h~.  Try a few.  (Such menus are also called "transient prefix
+commands" or just "transients".)
 
-The key bindings in that transient correspond to the bindings in Magit
+The key bindings in that menu correspond to the bindings in Magit
 buffers, including but not limited to the status buffer.  So you could
-type ~h d~ to bring up the diff transient, but once you remember that
-"d" stands for "diff", you would usually do so by just typing ~d~.  But
-this "prefix of prefixes" is useful even once you have memorized all
-the bindings, as it can provide easy access to Magit commands from
-non-Magit buffers.  You should create a global key binding for this
-command too:
+type ~h d~ to bring up the diff menu, but once you remember that "d"
+stands for "diff", you would usually do so by just typing ~d~.  But this
+"prefix of prefixes" is useful even once you have memorized all the
+bindings, as it can provide easy access to Magit commands from
+non-Magit buffers.  The global binding is ~C-x M-g~.
 
-#+BEGIN_SRC emacs-lisp
-  (global-set-key (kbd "C-x M-g") 'magit-dispatch)
-#+END_SRC
-
-In the same vein, you might also want to enable ~global-magit-file-mode~
-to get some more Magit key bindings in regular file-visiting buffers
-(see [[*Minor Mode for Buffers Visiting Files]]).
+In file visiting buffers ~C-c M-g~ brings up a similar menu featuring
+commands that act on just the visited file, see [[*Commands for Buffers
+Visiting Files]].
 
 It is not necessary that you do so now, but if you stick with Magit,
 then it is highly recommended that you read the next section too.
@@ -2534,11 +2525,10 @@ The log transient also features several reflog commands.  See [[*Reflog]].
 
   Show log for all references and ~HEAD~.
 
-
-Two additional commands that show the log for the file or blob that
-is being visited in the current buffer exists, see [[*Minor Mode for
-Buffers Visiting Files]].  The command ~magit-cherry~ also shows a log,
-see [[*Cherries]].
+Two additional commands that show the log for the file or blob that is
+being visited in the current buffer exists, see [[*Commands for Buffers
+Visiting Files]].  The command ~magit-cherry~ also shows a log, see
+[[*Cherries]].
 
 *** Refreshing Logs
 
@@ -2950,7 +2940,7 @@ in another buffer:
   Show all diffs of a stash in a buffer.
 
 Two additional commands that show the diff for the file or blob that
-is being visited in the current buffer exists, see [[*Minor Mode for
+is being visited in the current buffer exists, see [[*Commands for
 Buffers Visiting Files]].
 
 *** Refreshing Diffs
@@ -3808,10 +3798,7 @@ argument.
 Also see [[man:git-blame]]
 
 To start blaming invoke the ~magit-file-dispatch~ transient prefix
-command by pressing ~C-c M-g~.  (This is only the default binding and
-the recommended binding is ~C-c g~.  Also neither binding may be
-available if you disabled ~global-magit-file-mode~.  Also see [[*Minor
-Mode for Buffers Visiting Files]].)
+command by pressing ~C-c M-g~.
 
 The blaming suffix commands can be invoked from the dispatch
 transient.  However if you want to set an infix argument, then you
@@ -7074,54 +7061,21 @@ before making changes that could cause the loss of earlier changes.
 
   Mode-line lighter for ~magit-wip-initial-backup-mode~.
 
-** Minor Mode for Buffers Visiting Files
+** Commands for Buffers Visiting Files
 
-The minor-mode ~magit-file-mode~ enables certain Magit features in
-file-visiting buffers belonging to a Git repository.  The globalized
-variant ~global-magit-file-mode~ enables the local mode in all such
-buffers.  It is enabled by default.  Currently the local mode only
-establishes a few key bindings, but this might be extended in the
-future.
+Magit defines a few global key bindings unless the user sets
+~magit-define-global-key-bindings~ to ~nil~.  This includes binding ~C-c
+M-g~ to ~magit-file-dispatch~.  ~C-c g~ would be a much better binding
+but the ~C-c <letter>~ namespace is reserved for users, meaning that
+packages are not allowed to use it.  If you want to use ~C-c g~, then
+you have to add that binding yourself.  Also see [[*Default Bindings]]
+and [[info:elisp#Key Binding Conventions]].
 
-- User Option: global-magit-file-mode
+If you want a better binding, you have to add it yourself:
 
-  Whether to establish certain Magit key bindings in all file-visiting
-  buffers belonging to any Git repository.  This is enabled by default.
-  This globalized mode turns on the local minor-mode ~magit-file-mode~
-  in all suitable buffers.
-
-- Variable: magit-file-mode-map
-
-  This keymap is used by the local minor-mode ~magit-file-mode~ and
-  establishes the key bindings described below.
-
-  Note that the default binding for ~magit-file-dispatch~ is very
-  cumbersome to use and that we recommend that you add a better
-  binding.
-
-  Instead of ~C-c M-g~ I would have preferred to use ~C-c g~ because (1)
-  it is similar to ~C-x g~ (the recommended global binding for
-  ~~magit-status~), (2) we cannot use ~C-c C-g~ because we have been
-  recommending that that be bound to ~magit-dispatch~ for a long time,
-  (3) we cannot use ~C-x C-g~ because that is a convenient way of
-  aborting the incomplete key sequence ~C-x~, and most importantly (4)
-  it would make it much easier to type the next key (a suffix binding)
-  because most of those are letters.
-
-  For example ~C-c g b~ is much easier to type than ~C-c M-g b~.  For
-  suffix bindings that use uppercase letters, the default is just
-  horrible—having to use e.g. ~C-c M-g B~ (~Control+c Meta+g Shift+b~)
-  would drive anyone up the walls (or to Vim).
-
-  However ~C-c LETTER~ bindings are reserved for users (see
-  [[info:elisp#Key Binding Conventions]]).  Packages are forbidden from
-  using those.  Doing so anyway is considered heresy.  Therefore if
-  you want a better binding, you have to add it yourself:
-
-  #+BEGIN_SRC emacs-lisp
-    (define-key magit-file-mode-map
-      (kbd "C-c g") 'magit-file-dispatch)
-  #+END_SRC
+#+BEGIN_SRC emacs-lisp
+  (global-set-key (kbd "C-c g") 'magit-file-dispatch)
+#+END_SRC
 
 The key bindings shown below assume that you have not improved the
 binding for ~magit-file-dispatch~.
@@ -7130,6 +7084,9 @@ binding for ~magit-file-dispatch~.
 
   This transient prefix command binds the following suffix commands
   and displays them in a temporary buffer until a suffix is invoked.
+
+  When invoked in a buffer that does not visit a file, then it falls
+  back to regular ~magit-dispatch~.
 
 - Key: C-c M-g s, magit-stage-file
 
@@ -7616,6 +7573,38 @@ the absolute path of the ~git~ executable, instead of relying on
 resolving the ~$PATH~.
 
 [fn:mac1] https://lists.gnu.org/archive/html/bug-gnu-emacs/2017-04/msg00201.html
+
+*** Default Bindings
+
+- User Option: magit-define-global-key-bindings
+
+  This option controls whether to bind some Magit commands in the
+  global keymap.
+
+  If this variable is non-nil, which it is by default, then the
+  following bindings are added to the global keymap.
+
+  | ~C-x g~   | ~magit-status~        |
+  | ~C-x M-g~ | ~magit-dispatch~      |
+  | ~C-c M-g~ | ~magit-file-dispatch~ |
+
+  To prevent this, you must set this variable to nil *before*
+  ~magit~ is loaded or autoloaded, afterwards it has no effect.
+
+  Even if you use the above bindings, you may still wish to
+  bind ~C-c g~ instead of ~C-c M-g~ to `magit-file-dispatch'.
+  The former is a much better binding but the ~C-c <letter>~
+  namespace is strictly reserved for users; preventing Magit
+  from using it by default.
+
+  If you want a better binding, you have to add it yourself:
+
+  #+BEGIN_SRC emacs-lisp
+    (global-set-key (kbd "C-c g") 'magit-file-dispatch)
+  #+END_SRC
+
+  Also see [[*Commands for Buffers Visiting Files]] and [[info:elisp#Key
+  Binding Conventions]].
 
 * Plumbing
 ** _ :ignore:

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-1078-gff8a616cd+1)
+@subtitle for version 2.90.1 (v2.90.1-1083-gb18be6c14+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-1078-gff8a616cd+1).
+This manual is for Magit version 2.90.1 (v2.90.1-1083-gb18be6c14+1).
 
 @quotation
 Copyright (C) 2015-2020 Jonas Bernoulli <jonas@@bernoul.li>
@@ -263,7 +263,7 @@ Miscellaneous
 * Worktree::
 * Common Commands::
 * Wip Modes::
-* Minor Mode for Buffers Visiting Files::
+* Commands for Buffers Visiting Files::
 * Minor Mode for Buffers Visiting Blobs::
 
 Submodules
@@ -287,6 +287,7 @@ Essential Settings
 
 * Safety::
 * Performance::
+* Default Bindings::
 
 
 Plumbing
@@ -607,13 +608,8 @@ tutorial.  Alternatively you can use an existing local repository, but
 if you do that, then you should commit all uncommitted changes before
 proceeding.
 
-To display information about the current Git repository, type @code{M-x
-magit-status RET}.  You will be using this command a lot, and should
-therefore give it a global key binding.  This is what we recommend:
-
-@lisp
-(global-set-key (kbd "C-x g") 'magit-status)
-@end lisp
+Type @code{C-x g} to display information about the current Git repository in
+a dedicated buffer, called the status buffer.
 
 Most Magit commands are commonly invoked from the status buffer.  It
 can be considered the primary interface for interacting with Git using
@@ -676,28 +672,23 @@ local branch onto the remote configured as the push-remote.  (If the
 push-remote is not configured yet, then you would first be prompted
 for the remote to push to.)
 
-So far we have mentioned the commit, push, and log transient prefix
-commands.  These are probably among the transients you will be using
-the most, but many others exist.  To show a transient that lists all
-other transients (as well as the various apply commands and some other
-essential commands), type @code{h}.  Try a few.
+So far we have mentioned the commit, push, and log menu commands.
+These are probably among the menus you will be using the most, but
+many others exist.  To show a menu that lists all other menus (as well
+as the various apply commands and some other essential commands), type
+@code{h}.  Try a few.  (Such menus are also called "transient prefix
+commands" or just "transients".)
 
-The key bindings in that transient correspond to the bindings in Magit
+The key bindings in that menu correspond to the bindings in Magit
 buffers, including but not limited to the status buffer.  So you could
-type @code{h d} to bring up the diff transient, but once you remember that
-"d" stands for "diff", you would usually do so by just typing @code{d}.  But
-this "prefix of prefixes" is useful even once you have memorized all
-the bindings, as it can provide easy access to Magit commands from
-non-Magit buffers.  You should create a global key binding for this
-command too:
+type @code{h d} to bring up the diff menu, but once you remember that "d"
+stands for "diff", you would usually do so by just typing @code{d}.  But this
+"prefix of prefixes" is useful even once you have memorized all the
+bindings, as it can provide easy access to Magit commands from
+non-Magit buffers.  The global binding is @code{C-x M-g}.
 
-@lisp
-(global-set-key (kbd "C-x M-g") 'magit-dispatch)
-@end lisp
-
-In the same vein, you might also want to enable @code{global-magit-file-mode}
-to get some more Magit key bindings in regular file-visiting buffers
-(see @ref{Minor Mode for Buffers Visiting Files}).
+In file visiting buffers @code{C-c M-g} brings up a similar menu featuring
+commands that act on just the visited file, see @ref{Commands for Buffers Visiting Files}.
 
 It is not necessary that you do so now, but if you stick with Magit,
 then it is highly recommended that you read the next section too.
@@ -3393,10 +3384,9 @@ Show log for all local and remote branches and @code{HEAD}.
 Show log for all references and @code{HEAD}.
 @end table
 
-
-Two additional commands that show the log for the file or blob that
-is being visited in the current buffer exists, see @ref{Minor Mode for Buffers Visiting Files}.  The command @code{magit-cherry} also shows a log,
-see @ref{Cherries}.
+Two additional commands that show the log for the file or blob that is
+being visited in the current buffer exists, see @ref{Commands for Buffers Visiting Files}.  The command @code{magit-cherry} also shows a log, see
+@ref{Cherries}.
 
 @menu
 * Refreshing Logs::
@@ -3997,7 +3987,7 @@ Show all diffs of a stash in a buffer.
 @end table
 
 Two additional commands that show the diff for the file or blob that
-is being visited in the current buffer exists, see @ref{Minor Mode for Buffers Visiting Files}.
+is being visited in the current buffer exists, see @ref{Commands for Buffers Visiting Files}.
 
 @menu
 * Refreshing Diffs::
@@ -5171,9 +5161,7 @@ the git-blame(1) manpage.
 @end iftex
 
 To start blaming invoke the @code{magit-file-dispatch} transient prefix
-command by pressing @code{C-c M-g}.  (This is only the default binding and
-the recommended binding is @code{C-c g}.  Also neither binding may be
-available if you disabled @code{global-magit-file-mode}.  Also see @ref{Minor Mode for Buffers Visiting Files}.)
+command by pressing @code{C-c M-g}.
 
 The blaming suffix commands can be invoked from the dispatch
 transient.  However if you want to set an infix argument, then you
@@ -8858,7 +8846,7 @@ discards all changes made since the sequence started.
 * Worktree::
 * Common Commands::
 * Wip Modes::
-* Minor Mode for Buffers Visiting Files::
+* Commands for Buffers Visiting Files::
 * Minor Mode for Buffers Visiting Blobs::
 @end menu
 
@@ -9637,57 +9625,22 @@ Mode-line lighter for @code{magit-wip-before-change-mode}.
 Mode-line lighter for @code{magit-wip-initial-backup-mode}.
 @end defopt
 
-@node Minor Mode for Buffers Visiting Files
-@section Minor Mode for Buffers Visiting Files
+@node Commands for Buffers Visiting Files
+@section Commands for Buffers Visiting Files
 
-The minor-mode @code{magit-file-mode} enables certain Magit features in
-file-visiting buffers belonging to a Git repository.  The globalized
-variant @code{global-magit-file-mode} enables the local mode in all such
-buffers.  It is enabled by default.  Currently the local mode only
-establishes a few key bindings, but this might be extended in the
-future.
+Magit defines a few global key bindings unless the user sets
+@code{magit-define-global-key-bindings} to @code{nil}.  This includes binding @code{C-c
+M-g} to @code{magit-file-dispatch}.  @code{C-c g} would be a much better binding
+but the @code{C-c <letter>} namespace is reserved for users, meaning that
+packages are not allowed to use it.  If you want to use @code{C-c g}, then
+you have to add that binding yourself.  Also see @ref{Default Bindings}
+and @ref{Key Binding Conventions,,,elisp,}.
 
-@defopt global-magit-file-mode
-
-Whether to establish certain Magit key bindings in all file-visiting
-buffers belonging to any Git repository.  This is enabled by default.
-This globalized mode turns on the local minor-mode @code{magit-file-mode}
-in all suitable buffers.
-@end defopt
-
-@defvar magit-file-mode-map
-
-This keymap is used by the local minor-mode @code{magit-file-mode} and
-establishes the key bindings described below.
-
-Note that the default binding for @code{magit-file-dispatch} is very
-cumbersome to use and that we recommend that you add a better
-binding.
-
-Instead of @code{C-c M-g} I would have preferred to use @code{C-c g} because (1)
-it is similar to @code{C-x g} (the recommended global binding for
-@code{~magit-status}), (2) we cannot use @code{C-c C-g} because we have been
-recommending that that be bound to @code{magit-dispatch} for a long time,
-(3) we cannot use @code{C-x C-g} because that is a convenient way of
-aborting the incomplete key sequence @code{C-x}, and most importantly (4)
-it would make it much easier to type the next key (a suffix binding)
-because most of those are letters.
-
-For example @code{C-c g b} is much easier to type than @code{C-c M-g b}.  For
-suffix bindings that use uppercase letters, the default is just
-horrible—having to use e.g. @code{C-c M-g B} (@code{Control+c Meta+g Shift+b})
-would drive anyone up the walls (or to Vim).
-
-However @code{C-c LETTER} bindings are reserved for users (see
-@ref{Key Binding Conventions,,,elisp,}).  Packages are forbidden from
-using those.  Doing so anyway is considered heresy.  Therefore if
-you want a better binding, you have to add it yourself:
+If you want a better binding, you have to add it yourself:
 
 @lisp
-(define-key magit-file-mode-map
-  (kbd "C-c g") 'magit-file-dispatch)
+(global-set-key (kbd "C-c g") 'magit-file-dispatch)
 @end lisp
-@end defvar
 
 The key bindings shown below assume that you have not improved the
 binding for @code{magit-file-dispatch}.
@@ -9699,6 +9652,9 @@ binding for @code{magit-file-dispatch}.
 
 This transient prefix command binds the following suffix commands
 and displays them in a temporary buffer until a suffix is invoked.
+
+When invoked in a buffer that does not visit a file, then it falls
+back to regular @code{magit-dispatch}.
 
 @kindex C-c M-g s
 @cindex magit-stage-file
@@ -10029,6 +9985,7 @@ users might want to customize, for safety and/or performance reasons.
 @menu
 * Safety::
 * Performance::
+* Default Bindings::
 @end menu
 
 @node Safety
@@ -10266,6 +10223,44 @@ performance problem where any action takes 20 times longer on Darwin
 than on Linux.  This can be fixed by setting @code{magit-git-executable} to
 the absolute path of the @code{git} executable, instead of relying on
 resolving the @code{$PATH}.
+
+@node Default Bindings
+@subsection Default Bindings
+
+@defopt magit-define-global-key-bindings
+
+This option controls whether to bind some Magit commands in the
+global keymap.
+
+If this variable is non-nil, which it is by default, then the
+following bindings are added to the global keymap.
+
+@multitable {aaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaa}
+@item @code{C-x g}
+@tab @code{magit-status}
+@item @code{C-x M-g}
+@tab @code{magit-dispatch}
+@item @code{C-c M-g}
+@tab @code{magit-file-dispatch}
+@end multitable
+
+To prevent this, you must set this variable to nil @strong{before}
+@code{magit} is loaded or autoloaded, afterwards it has no effect.
+
+Even if you use the above bindings, you may still wish to
+bind @code{C-c g} instead of @code{C-c M-g} to `magit-file-dispatch'.
+The former is a much better binding but the @code{C-c <letter>}
+namespace is strictly reserved for users; preventing Magit
+from using it by default.
+
+If you want a better binding, you have to add it yourself:
+
+@lisp
+(global-set-key (kbd "C-c g") 'magit-file-dispatch)
+@end lisp
+
+Also see @ref{Commands for Buffers Visiting Files} and @ref{Key Binding Conventions,,,elisp,}.
+@end defopt
 
 @node Plumbing
 @chapter Plumbing

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -279,19 +279,13 @@ directory, while reading the FILENAME."
                           (confirm-nonexistent-file-or-buffer))))
   (find-file-other-frame filename wildcards))
 
-;;; File Mode
-
-(defvar magit-file-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map "\C-xg"    'magit-status)
-    (define-key map "\C-x\M-g" 'magit-dispatch)
-    (define-key map "\C-c\M-g" 'magit-file-dispatch)
-    map)
-  "Keymap for `magit-file-mode'.")
+;;; File Dispatch
 
 ;;;###autoload (autoload 'magit-file-dispatch "magit" nil t)
 (transient-define-prefix magit-file-dispatch ()
-  "Invoke a Magit command that acts on the visited file."
+  "Invoke a Magit command that acts on the visited file.
+When invoked outside a file-visiting buffer, then fall back
+to `magit-dispatch'."
   :info-manual "(magit) Minor Mode for Buffers Visiting Files"
   ["Actions"
    [("s" "Stage"      magit-stage-file)
@@ -317,45 +311,17 @@ directory, while reading the FILENAME."
    [(5 "C-c r" "Rename file"   magit-file-rename)
     (5 "C-c d" "Delete file"   magit-file-delete)
     (5 "C-c u" "Untrack file"  magit-file-untrack)
-    (5 "C-c c" "Checkout file" magit-file-checkout)]])
-
-(defvar magit-file-mode-lighter "")
-
-(define-minor-mode magit-file-mode
-  "Enable some Magit features in a file-visiting buffer.
-
-Currently this only adds the following key bindings.
-\n\\{magit-file-mode-map}"
-  :package-version '(magit . "2.2.0")
-  :lighter magit-file-mode-lighter
-  :keymap  magit-file-mode-map)
-
-(defun magit-file-mode-turn-on ()
-  (and buffer-file-name
-       (magit-inside-worktree-p t)
-       (magit-file-mode)))
-
-;;;###autoload
-(define-globalized-minor-mode global-magit-file-mode
-  magit-file-mode magit-file-mode-turn-on
-  :package-version '(magit . "2.13.0")
-  :link '(info-link "(magit)Minor Mode for Buffers Visiting Files")
-  :group 'magit-essentials
-  :group 'magit-modes
-  :init-value t)
-;; Unfortunately `:init-value t' only sets the value of the mode
-;; variable but does not cause the mode function to be called, and we
-;; cannot use `:initialize' to call that explicitly because the option
-;; is defined before the functions, so we have to do it here.
-(cl-eval-when (load eval)
-  (when global-magit-file-mode
-    (global-magit-file-mode 1)))
+    (5 "C-c c" "Checkout file" magit-file-checkout)]]
+  (interactive)
+  (transient-setup
+   (if (or buffer-file-name magit-buffer-file-name)
+       'magit-file-dispatch
+     'magit-dispatch)))
 
 ;;; Blob Mode
 
 (defvar magit-blob-mode-map
   (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map magit-file-mode-map)
     (define-key map "p" 'magit-blob-previous)
     (define-key map "n" 'magit-blob-next)
     (define-key map "b" 'magit-blame-addition)

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -219,6 +219,46 @@ and/or `magit-branch-remote-head'."
   "Face for filenames."
   :group 'magit-faces)
 
+;;; Global Bindings
+
+;;;###autoload
+(define-obsolete-variable-alias 'global-magit-file-mode
+  'magit-define-global-key-bindings "Magit 3.0.0")
+
+;;;###autoload
+(defcustom magit-define-global-key-bindings t
+  "Whether to bind some Magit commands in the global keymap.
+
+If this variable is non-nil, then the following bindings are
+added to the global keymap.  The default is t.
+
+key             binding
+---             -------
+C-x g           magit-status
+C-x M-g         magit-dispatch
+C-c M-g         magit-file-dispatch
+
+To prevent this, you must set this variable to nil *before*
+`magit' is loaded or autoloaded, afterwards it has no effect.
+
+Even if you use the above bindings, you may still wish to
+bind \"C-c g\" instead of \"C-c M-g\" to `magit-file-dispatch'.
+The former is a much better binding but the \"C-c <letter>\"
+namespace is strictly reserved for users; preventing Magit
+from using it by default.
+
+Also see info node `(magit)Commands for Buffers Visiting Files'."
+  :package-version '(magit . "3.0.0")
+  :group 'magit-essentials
+  :type 'boolean)
+
+;;;###autoload
+(when magit-define-global-key-bindings
+  (let ((map (current-global-map)))
+    (define-key map (kbd "C-x g")   'magit-status)
+    (define-key map (kbd "C-x M-g") 'magit-dispatch)
+    (define-key map (kbd "C-c M-g") 'magit-file-dispatch)))
+
 ;;; Dispatch Popup
 
 ;;;###autoload (autoload 'magit-dispatch "magit" nil t)


### PR DESCRIPTION
For the longest time we have tried hard to avoid doing this but
it is just not worth the effort and leads to an inferior result.

Now we add three bindings by default.

```elisp
  ;;;###autoload
  (when magit-define-global-key-bindings
    (let ((map (current-global-map)))
      (define-key map (kbd "C-x g")   'magit-status)
      (define-key map (kbd "C-x M-g") 'magit-dispatch)
      (define-key map (kbd "C-c M-g") 'magit-file-dispatch)))
```

As you can see is easy to prevent these bindings from being added
and I hope having to do so won't upset anyone too much.  While we
did not add global bindings we already added these bindings in all
file-visiting buffers and we did not get any complaints about that.

This completely replaces `magit-file-mode` and the global variant,
which we define as an alias of the new variable.

---

This is an alternative to #4213, which goes in the opposite direction.
