### PR TITLE
Show all untracked

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2113,10 +2113,8 @@ By default the following functions are also members of that hook:
 
   Maybe insert a list or tree of untracked files.
 
-  Do so depending on the value of ~status.showUntrackedFiles~.  Note
-  that even if the value is ~all~, Magit still initially only shows
-  directories.  But the directory sections can then be expanded using
-  ~TAB~.
+  Note that Magit initially shows only directories. But the
+  directory section can be expanded using ~TAB~.
 
 - Function: magit-insert-unstaged-changes
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -174,6 +174,7 @@ successfully.")
     "-c" "log.showSignature=false"
     "-c" "color.ui=false"
     "-c" "color.diff=false"
+    "-c" "status.showUntrackedFiles=all"
     ,@(and (eq system-type 'windows-nt)
            (list "-c" "i18n.logOutputEncoding=UTF-8")))
   "Global Git arguments.


### PR DESCRIPTION
## Idea
`Magit` with a default `git` setup only shows folders, but not their corresponding files in unexpected. The expected behavior when looking at a shown folder is that it can be expanded to show what it contains. Instead of staging a single file in an untracked directory, I found myself adding an entire folder only to unstage multiple files as it was the only way to add a single file, or even worse, just using `git` directly from the command line. 

## Changes
This tells `git` to show all untracked files, which are then already hidden by `Magit` in their folders. This does not change the observable behavior until folders are unhidden, at which point we can assume the change is desired. 

## Testing
I was unable to get all tests to pass on my computer. Tests 15-18 failed with and without the change. I have posted the test logs in case it is helpful. 
<details>
<summary> Test Results </summary>
$ make test
Loading /Users/ianwahbe/Projects/magit/t/magit-tests.el (source)...
Running 18 tests (2020-11-06 19:04:45+0100, selector ‘t’)
   passed   1/18  magit--with-safe-default-directory (0.050915 sec)
   passed   2/18  magit-get (1.502001 sec)
   passed   3/18  magit-get-boolean (0.623542 sec)
   passed   4/18  magit-get-{current|next}-tag (1.496892 sec)
   passed   5/18  magit-list-{|local-|remote-}branch-names (0.680586 sec)
   passed   6/18  magit-process:match-prompt-match-non-first-prompt (0.000053 sec)
   passed   7/18  magit-process:match-prompt-nil-when-no-match (0.000043 sec)
   passed   8/18  magit-process:match-prompt-non-nil-when-match (0.000042 sec)
   passed   9/18  magit-process:match-prompt-preserves-match-group (0.000050 sec)
   passed  10/18  magit-process:match-prompt-suffixes-prompt (0.000048 sec)
   passed  11/18  magit-process:password-prompt (0.000060 sec)
   passed  12/18  magit-process:password-prompt-observed (0.002094 sec)
   passed  13/18  magit-status:file-sections (1.548878 sec)
   passed  14/18  magit-status:log-sections (2.040154 sec)
Keeping test directory:
  /var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-92ZSgC/
Test magit-toplevel:basic backtrace:
  signal(ert-test-failed (((should (equal (magit-toplevel "subdir-link
  (condition-case err (let* ((vnew #'(lambda (&rest _))) (old (symbol-
  (let ((dir (file-name-as-directory (make-temp-file "magit-" t))) (pr
  (let ((find-file-visit-truename nil)) (let ((dir (file-name-as-direc
  (lambda nil (let ((find-file-visit-truename nil)) (let ((dir (file-n
  ert--run-test-internal(#s(ert--test-execution-info :test #s(ert-test
  ert-run-test(#s(ert-test :name magit-toplevel:basic :documentation n
  ert-run-or-rerun-test(#s(ert--stats :selector t :tests ... :test-map
  ert-run-tests(t #f(compiled-function (event-type &rest event-args) #
  ert-run-tests-batch(nil)
  ert-run-tests-batch-and-exit()
  (progn (load-file "t/magit-tests.el") (ert-run-tests-batch-and-exit)
  eval((progn (load-file "t/magit-tests.el") (ert-run-tests-batch-and-
  command-line-1(("-L" "./lisp" "-L" "./../dash" "-L" "./../libgit" "-
  command-line()
  normal-top-level()
Test magit-toplevel:basic condition:
    (ert-test-failed
     ((should
       (equal
        (magit-toplevel "subdir-link/")
        (expand-file-name "repo/")))
      :form
      (equal "/private/var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-92ZSgC/repo/" "/var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-92ZSgC/repo/")
      :value nil :explanation
      (arrays-of-different-length 75 67 "/private/var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-92ZSgC/repo/" "/var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-92ZSgC/repo/" first-mismatch-at 1)))
   FAILED  15/18  magit-toplevel:basic (0.284597 sec)
Keeping test directory:
  /var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-O6GdWj/
Test magit-toplevel:submodule backtrace:
  signal(ert-test-failed (((should (equal (magit-toplevel "subdir-link
  (condition-case err (let* ((vnew #'(lambda (&rest _))) (old (symbol-
  (let ((dir (file-name-as-directory (make-temp-file "magit-" t))) (pr
  (let ((find-file-visit-truename nil)) (let ((dir (file-name-as-direc
  (lambda nil (let ((find-file-visit-truename nil)) (let ((dir (file-n
  ert--run-test-internal(#s(ert--test-execution-info :test #s(ert-test
  ert-run-test(#s(ert-test :name magit-toplevel:submodule :documentati
  ert-run-or-rerun-test(#s(ert--stats :selector t :tests ... :test-map
  ert-run-tests(t #f(compiled-function (event-type &rest event-args) #
  ert-run-tests-batch(nil)
  ert-run-tests-batch-and-exit()
  (progn (load-file "t/magit-tests.el") (ert-run-tests-batch-and-exit)
  eval((progn (load-file "t/magit-tests.el") (ert-run-tests-batch-and-
  command-line-1(("-L" "./lisp" "-L" "./../dash" "-L" "./../libgit" "-
  command-line()
  normal-top-level()
Test magit-toplevel:submodule condition:
    (ert-test-failed
     ((should
       (equal
        (magit-toplevel "subdir-link/")
        (expand-file-name "repo/")))
      :form
      (equal "/private/var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-O6GdWj/super/repo/" "/var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-O6GdWj/super/repo/")
      :value nil :explanation
      (arrays-of-different-length 81 73 "/private/var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-O6GdWj/super/repo/" "/var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-O6GdWj/super/repo/" first-mismatch-at 1)))
   FAILED  16/18  magit-toplevel:submodule (0.846718 sec)
Keeping test directory:
  /var/folders/mn/5w8tjr6j4vg2n0__rpxq0r100000gn/T/magit-IDSOk1/
Test magit-toplevel:tramp backtrace:
  signal(file-error ("Timeout reached, see buffer ‘*tramp/sudo ianwahb
  (condition-case err (let* ((vnew #'(lambda (&rest _))) (old (symbol-
  (let ((dir (file-name-as-directory (make-temp-file "magit-" t))) (pr
  (progn (setcdr v nil) (let ((dir (file-name-as-directory (make-temp-
  (unwind-protect (progn (setcdr v nil) (let ((dir (file-name-as-direc
  (let* ((v (assq 'tramp-login-args sudo-method)) (old (cdr v))) (unwi
  (progn (setcdr v vnew) (let* ((v (assq 'tramp-login-args sudo-method
  (unwind-protect (progn (setcdr v vnew) (let* ((v (assq 'tramp-login-
  (let* ((v (assq 'tramp-login-program sudo-method)) (vnew (list shell
  (let ((sudo-method (cdr (assoc "sudo" tramp-methods)))) (let* ((v (a
  (let ((find-file-visit-truename nil)) (let ((sudo-method (cdr (assoc
  (lambda nil (let ((find-file-visit-truename nil)) (let ((sudo-method
  ert--run-test-internal(#s(ert--test-execution-info :test #s(ert-test
  ert-run-test(#s(ert-test :name magit-toplevel:tramp :documentation n
  ert-run-or-rerun-test(#s(ert--stats :selector t :tests ... :test-map
  ert-run-tests(t #f(compiled-function (event-type &rest event-args) #
  ert-run-tests-batch(nil)
  ert-run-tests-batch-and-exit()
  (progn (load-file "t/magit-tests.el") (ert-run-tests-batch-and-exit)
  eval((progn (load-file "t/magit-tests.el") (ert-run-tests-batch-and-
  command-line-1(("-L" "./lisp" "-L" "./../dash" "-L" "./../libgit" "-
  command-line()
  normal-top-level()
Test magit-toplevel:tramp condition:
    (file-error "Timeout reached, see buffer ‘*tramp/sudo ianwahbe@localhost*’ for details")
   FAILED  17/18  magit-toplevel:tramp (10.018083 sec)
   passed  18/18  magit-utils:add-face-text-property (0.000084 sec)

Ran 18 tests, 15 results as expected, 3 unexpected (2020-11-06 19:05:04+0100, 19.585710 sec)

3 unexpected results:
   FAILED  magit-toplevel:basic
   FAILED  magit-toplevel:submodule
   FAILED  magit-toplevel:tramp

make: *** [test] Error 1
</details>