### PR TITLE
Defer Diff Calculation Until Section Expansion

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2091,19 +2091,7 @@ Staging and applying changes is documented in info node
                   (`("U" ,file . ,tail)
                    (unless (and (derived-mode-p 'magit-status-mode)
                                 (not (member "--cached" args)))
-                     (magit-insert-section (file file)
-                       (insert (propertize
-                                (format "unmerged   %s%s" file
-                                        (pcase (cddr (car (magit-file-status file)))
-                                          (`(?D ?D) " (both deleted)")
-                                          (`(?D ?U) " (deleted by us)")
-                                          (`(?U ?D) " (deleted by them)")
-                                          (`(?A ?A) " (both added)")
-                                          (`(?A ?U) " (added by us)")
-                                          (`(?U ?A) " (added by them)")
-                                          (`(?U ?U) "")))
-                                'font-lock-face 'magit-diff-file-heading))
-                       (insert ?\n)))
+                     (magit--insert-unmerged-file-section file))
                    (setq items tail))
                   (_ (signal 'error items))))
     (insert ?\n)))
@@ -2225,19 +2213,7 @@ section or a child thereof."
       (magit-delete-line)
       (unless (and (derived-mode-p 'magit-status-mode)
                    (not (member "--cached" args)))
-        (magit-insert-section (file file)
-          (insert (propertize
-                   (format "unmerged   %s%s" file
-                           (pcase (cddr (car (magit-file-status file)))
-                             (`(?D ?D) " (both deleted)")
-                             (`(?D ?U) " (deleted by us)")
-                             (`(?U ?D) " (deleted by them)")
-                             (`(?A ?A) " (both added)")
-                             (`(?A ?U) " (added by us)")
-                             (`(?U ?A) " (added by them)")
-                             (`(?U ?U) "")))
-                   'font-lock-face 'magit-diff-file-heading))
-          (insert ?\n))))
+        (magit--insert-unmerged-file-section file)))
     t)
    ((looking-at magit-diff-conflict-headline-re)
     (let ((long-status (match-string 0))
@@ -2357,6 +2333,22 @@ section or a child thereof."
       (magit-insert-section (hunk)
         (insert modes)
         (magit-insert-heading)))))
+
+(defun magit--insert-unmerged-file-section (file)
+  "Insert a bodyless file section for an unmerged file FILE."
+  (magit-insert-section (file file)
+    (insert (propertize
+             (format "unmerged   %s%s" file
+                     (pcase (cddr (car (magit-file-status file)))
+                       (`(?D ?D) " (both deleted)")
+                       (`(?D ?U) " (deleted by us)")
+                       (`(?U ?D) " (deleted by them)")
+                       (`(?A ?A) " (both added)")
+                       (`(?A ?U) " (added by us)")
+                       (`(?U ?A) " (added by them)")
+                       (`(?U ?U) "")))
+             'font-lock-face 'magit-diff-file-heading))
+    (insert ?\n)))
 
 (defun magit-diff-wash-submodule ()
   ;; See `show_submodule_summary' in submodule.c and "this" commit.

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2010,12 +2010,13 @@ Staging and applying changes is documented in info node
 
 (defun magit-insert-diff ()
   "Insert the diff into this `magit-diff-mode' buffer."
-  (magit--insert-diff
-    "diff" magit-buffer-range "-p" "--no-prefix"
-    (and (member "--stat" magit-buffer-diff-args) "--numstat")
-    magit-buffer-typearg
-    magit-buffer-diff-args "--"
-    magit-buffer-diff-files))
+  (magit--insert-name-status-diff
+   (apply 'list
+          magit-buffer-range "--no-prefix"
+          (and (member "--stat" magit-buffer-diff-args) "--numstat")
+          magit-buffer-typearg
+          magit-buffer-diff-args)
+   magit-buffer-diff-files))
 
 (defun magit--insert-diff (&rest args)
   (declare (indent 0))
@@ -2865,9 +2866,9 @@ It the SECTION has a different type, then do nothing."
   "Insert section showing unstaged changes."
   (magit-insert-section (unstaged)
     (magit-insert-heading "Unstaged changes:")
-    (magit--insert-diff
-      "diff" magit-buffer-diff-args "--no-prefix"
-      "--" magit-buffer-diff-files)))
+    (magit--insert-name-status-diff
+     `(,@magit-buffer-diff-args "--no-prefix")
+     magit-buffer-diff-files)))
 
 (defvar magit-staged-section-map
   (let ((map (make-sparse-keymap)))
@@ -2887,9 +2888,9 @@ It the SECTION has a different type, then do nothing."
   (unless (magit-bare-repo-p)
     (magit-insert-section (staged)
       (magit-insert-heading "Staged changes:")
-      (magit--insert-diff
-        "diff" "--cached" magit-buffer-diff-args "--no-prefix"
-        "--" magit-buffer-diff-files))))
+      (magit--insert-name-status-diff
+       `("--cached" ,@magit-buffer-diff-args "--no-prefix")
+       magit-buffer-diff-files))))
 
 ;;; Diff Type
 


### PR DESCRIPTION
Adds an alternative diff function, magit-insert-name-status-diff, which uses git diff --name-status output to generate the appropriate file sections. These sections are initially left empty and populated with a separate git diff call when the section is first shown. This change greatly improves the performance of magit-status when dealing with large changes such as a complicated merge or large changes to vendored or generated code so long as most sections are left unexpanded.

In order to accomplish this I've added a new magit-section method, magit-section-insert-body, which is responsible for computing the section's body on initial expansion. After doing so I realized that this is mostly duplicating the functionality of washer although I ended up needing to perform additional steps such as fiddling with the parent's end markers and fixing the body's section and keymap text properties. If desired I can add these additional steps around the section washer and refactor the unexpanded file sections to use washer instead.