### PR TITLE
Match yes-or-no prompts not ending in ? or :

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -163,7 +163,7 @@ itself from the hook, to avoid further futile attempts."
           "\\([Nn]o?\\)"
           ;; OpenSSH v8 prints this.  See #3969.
           "\\(?:/\\[fingerprint\\]\\)?"
-          "[\])] ?[?:] ?$")
+          "[\])] ?[?:]? ?$")
   "Regexp matching Yes-or-No prompts of Git and its subprocesses."
   :package-version '(magit . "2.1.0")
   :group 'magit-process


### PR DESCRIPTION
A magit subprocess can prompt for input by a user with a prompt not matching a
prompt ending in `?` or `:`.

Example arc [phabricator](https://www.phacility.com/phabricator/) provided via [magit-arcanist](https://github.com/sideshowcoder/magit-arcanist):
```
 Amend HEAD with lint patches? [Y/n]
```
This patch makes the ending in `?` or `:` optional.