### PR TITLE
git-rebase: Region support for -kill-line and commit action commands

### DIFF
--- a/Documentation/RelNotes/3.0.0.org
+++ b/Documentation/RelNotes/3.0.0.org
@@ -141,6 +141,10 @@
 - New command ~git-rebase-break~ inserts a "break" action in the
   rebase to-do sequence (available as of Git v2.20).  #3762
 
+- ~git-rebase-kill-line~ and the commands for changing the action of a
+  commit line (e.g., ~git-rebase-squash~) learned to work on all lines
+  selected by the region.  #4172
+
 - The ~--color-moved~ diff argument is supported now, but isn't
   available from the diff transients by default.  To enable it
   use "C-x l" in those transients.  #3424

--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -428,8 +428,7 @@ current line."
   (goto-char (line-beginning-position))
   (unless (oref (git-rebase-current-line) comment-p)
     (let ((inhibit-read-only t))
-      (insert comment-start)
-      (insert " "))
+      (insert comment-start " "))
     (goto-char (line-beginning-position))
     (when git-rebase-auto-advance
       (forward-line))))

--- a/lisp/git-rebase.el
+++ b/lisp/git-rebase.el
@@ -355,15 +355,24 @@ regardless of its action type."
     (and (oref (git-rebase-current-line) action-type)
          t)))
 
-(defun git-rebase-region-bounds ()
-  (when (use-region-p)
+(defun git-rebase-region-bounds (&optional fallback)
+  "Return region bounds if both ends touch rebase lines.
+Each bound is extended to include the entire line touched by the
+point or mark.  If the region isn't active and FALLBACK is
+non-nil, return the beginning and end of the current rebase line,
+if any."
+  (cond
+   ((use-region-p)
     (let ((beg (save-excursion (goto-char (region-beginning))
                                (line-beginning-position)))
           (end (save-excursion (goto-char (region-end))
                                (line-end-position))))
       (when (and (git-rebase-line-p beg)
                  (git-rebase-line-p end))
-        (list beg (1+ end))))))
+        (list beg (1+ end)))))
+   ((and fallback (git-rebase-line-p))
+    (list (line-beginning-position)
+          (1+ (line-end-position))))))
 
 (defun git-rebase-move-line-down (n)
   "Move the current commit (or command) N lines down.


### PR DESCRIPTION
This series updates `git-rebase-kill-line` to support killing lines selected with the region (as proposed in gh-4172).  It also adds region support to commands that operate on "commit" lines (`git-rebase-pick`, `git-rebase-reword`, `git-rebase-edit`, `git-rebase-squash`, and `git-rebase-fixup`).

---

@Stebalien @aesyondu Care to give this a try?

I'll plan to merge this in a few days if there are no objections.
