### PR TITLE
Show magit manual for magit-dispatch

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -287,6 +287,7 @@ Also see info node `(magit)Commands for Buffers Visiting Files'."
 ;;;###autoload (autoload 'magit-dispatch "magit" nil t)
 (transient-define-prefix magit-dispatch ()
   "Invoke a Magit command from a list of available commands."
+  :info-manual "(magit)Top"
   ["Transient and dwim commands"
    [("A" "Apply"          magit-cherry-pick)
     ("b" "Branch"         magit-branch)


### PR DESCRIPTION
Had no manual defined before, so nothing lost, but it is more newbie
friendly to end after repetitive panic "?"-s in the manual.

At least it would have been a tiny bit easier for me.
