### PR TITLE
Check XDG convention for elpa dirs in default.mk

### DIFF
--- a/default.mk
+++ b/default.mk
@@ -137,7 +137,15 @@ endif
 
 ifndef LOAD_PATH
 
-ELPA_DIR ?= $(HOME)/.emacs.d/elpa
+USER_EMACS_DIR = $(HOME)/.emacs.d
+ifeq "$(wildcard $(USER_EMACS_DIR))" ""
+  XDG_CONFIG_DIR = $(or $(XDG_CONFIG_HOME),$(HOME)/.config)
+  ifneq "$(wildcard $(XDG_CONFIG_DIR)/emacs)" ""
+    USER_EMACS_DIR = $(XDG_CONFIG_DIR)/emacs
+  endif
+endif
+
+ELPA_DIR ?= $(USER_EMACS_DIR)/elpa
 
 DASH_DIR ?= $(shell \
   find -L $(ELPA_DIR) -maxdepth 1 -regex '.*/dash-[.0-9]*' 2> /dev/null | \


### PR DESCRIPTION
Since Emacs 27.1 user-emacs-directory can also be in XDG_CONFIG_HOME or (~/.config).