### PR TITLE
magit-log: add marker " .." for non-empty bodies

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -435,7 +435,8 @@ the upstream isn't ahead of the current branch) show."
    ("=S" "Show signatures"     "--show-signature") ;1
    ("-h" "Show header"         "++header")         ;4
    ("-p" "Show diffs"          ("-p" "--patch"))   ;2
-   ("-s" "Show diffstats"      "--stat")]          ;2
+   ("-s" "Show diffstats"      "--stat")           ;2
+   ("-b" "Show body indicator" "++body")]
   [["Log"
     ("l" "current"        magit-log-current)
     ("o" "other"          magit-log-other)
@@ -494,7 +495,8 @@ the upstream isn't ahead of the current branch) show."
     ("=S" "Show signatures"         "--show-signature")
     ("-h" "Show header"             "++header")
     ("-p" "Show diffs"              ("-p" "--patch"))
-    ("-s" "Show diffstats"          "--stat")]]
+    ("-s" "Show diffstats"          "--stat")
+    ("-b" "Show body indicator"     "++body")]]
   [:if-not-mode magit-log-mode
    :description "Arguments"
    (magit-log:-n)
@@ -1065,7 +1067,9 @@ Do not add this to a hook variable."
                       (concat "\n" magit-log-revision-headers-format "\n")
                     (concat "\n" magit-log-revision-headers-format "\n"))
                 "")
-              "%>|(1,ltrunc)% b")
+              (if (member "++body" args)
+                  (progn (setq args (remove "++body" args)) "%>|(1,ltrunc)% b")
+                ""))
       (progn
         (--when-let (--first (string-match "^\\+\\+order=\\(.+\\)$" it) args)
           (setq args (cons (format "--%s-order" (match-string 1 it))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1062,13 +1062,13 @@ Do not add this to a hook variable."
               "%x0c%aN%x0c" ; author name
               (if magit-log-margin-show-committer-date "%ct" "%at")
               "%x0c%s" ; subject
+              (when (member "++body" args)
+                  (unless (member "++header" (setq args (remove "++body" args)))
+                    "%>|(1,ltrunc)% b"))
               (if (member "++header" args)
                   (if (member "--graph" (setq args (remove "++header" args)))
                       (concat "\n" magit-log-revision-headers-format "\n")
                     (concat "\n" magit-log-revision-headers-format "\n"))
-                "")
-              (if (member "++body" args)
-                  (progn (setq args (remove "++body" args)) "%>|(1,ltrunc)% b")
                 ""))
       (progn
         (--when-let (--first (string-match "^\\+\\+order=\\(.+\\)$" it) args)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1046,21 +1046,26 @@ Do not add this to a hook variable."
          (remove "--literal-pathspecs" magit-git-global-arguments)))
     (magit-git-wash (apply-partially #'magit-log-wash-log 'log)
       "log"
-      (format "--format=%s%%h%%x0c%s%%x0c%s%%x0c%%aN%%x0c%s%%x0c%%s%s%%>|(1,ltrunc)%% b"
+      (concat "--format="
               (if (and (member "--left-right" args)
                        (not (member "--graph" args)))
                   "%m "
                 "")
+              "%h%x0c" ; commit hash
               (if (member "--decorate" args) "%D" "")
+              "%x0c"
               (if (member "--show-signature" args)
                   (progn (setq args (remove "--show-signature" args)) "%G?")
                 "")
+              "%x0c%aN%x0c" ; author name
               (if magit-log-margin-show-committer-date "%ct" "%at")
+              "%x0c%s" ; subject
               (if (member "++header" args)
                   (if (member "--graph" (setq args (remove "++header" args)))
                       (concat "\n" magit-log-revision-headers-format "\n")
                     (concat "\n" magit-log-revision-headers-format "\n"))
-                ""))
+                "")
+              "%>|(1,ltrunc)% b")
       (progn
         (--when-let (--first (string-match "^\\+\\+order=\\(.+\\)$" it) args)
           (setq args (cons (format "--%s-order" (match-string 1 it))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1046,7 +1046,7 @@ Do not add this to a hook variable."
          (remove "--literal-pathspecs" magit-git-global-arguments)))
     (magit-git-wash (apply-partially #'magit-log-wash-log 'log)
       "log"
-      (format "--format=%s%%h%%x0c%s%%x0c%s%%x0c%%aN%%x0c%s%%x0c%%s%s"
+      (format "--format=%s%%h%%x0c%s%%x0c%s%%x0c%%aN%%x0c%s%%x0c%%s%s%%>|(1,ltrunc)%% b"
               (if (and (member "--left-right" args)
                        (not (member "--graph" args)))
                   "%m "


### PR DESCRIPTION
Show " .." at the end of subject if a text body is available. The term
"%% b" will insert the (truncated) body with a space in front, which
effectively expands to " ..". If no body is present, the space will also
be omitted.


----

# 

I think this is a useful addition as one can immediately see which commits have
more explanation available.