### PR TITLE
magit-copy-section-value: Fix copying of last line

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -654,7 +654,7 @@ argument."
                    (region-beginning)
                    (region-end))
        (replace-regexp-in-string
-        (format "^\\%c.*\n" (if (< (prefix-numeric-value arg) 0) ?+ ?-))
+        (format "^\\%c.*\n?" (if (< (prefix-numeric-value arg) 0) ?+ ?-))
         "")
        (replace-regexp-in-string "^[ \\+\\-]" "")))
     (deactivate-mark))


### PR DESCRIPTION
+/- are not properly stripped from the last line in the active region due to no
trailing newline being in that region.
