### PR TITLE
bisect: Support specifying alternate terms

### DIFF
--- a/Documentation/RelNotes/3.0.0.org
+++ b/Documentation/RelNotes/3.0.0.org
@@ -186,6 +186,10 @@
 
 - ~git bisect~ is now run asynchronously.  #3802
 
+- ~magit-bisect~ now supports specifying alternate terms.  The new
+  infixes and suffix related to this functionality are disabled by
+  default.
+
 - ~magit-branch-or-commit-at-point~ now falls back to an abbreviated
   hash instead of something like "master~2", because the latter often
   leads to undesirable behavior.  fd5eb5b43

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -3669,7 +3669,7 @@ following suffix commands.
 
   Bisecting a bug means to find the commit that introduced it.
   This command starts such a bisect session by asking for a known
-  good and a bad commit.
+  good commit and a known bad commit.
 
 - Key: B s, magit-bisect-run
 

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-1133-g2fb44690b+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-1137-g596263bb+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-1133-g2fb44690b+1).
+This manual is for Magit version 2.90.1 (v2.90.1-1137-g596263bb+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2021 Jonas Bernoulli <jonas@bernoul.li>
@@ -3669,7 +3669,10 @@ following suffix commands.
 
   Bisecting a bug means to find the commit that introduced it.
   This command starts such a bisect session by asking for a known
-  good commit and a known bad commit.
+  good commit and a known bad commit.  If you're bisecting a change
+  that isn't a regression, you can select alternate terms that are
+  conceptually more fitting than "bad" and "good", but the infix
+  arguments to do so are disabled by default.
 
 - Key: B s, magit-bisect-run
 
@@ -3687,6 +3690,13 @@ following suffix commands.
 
   Mark the current commit as good.  Use this after you have asserted
   that the commit does not contain the bug in question.
+
+- Key: B m, magit-bisect-mark
+
+  Mark the current commit with one of the bisect terms.  This command
+  provides an alternative to ~magit-bisect-bad~ and
+  ~magit-bisect-good~ and is useful when using terms other than "bad"
+  and "good".  This suffix is disabled by default.
 
 - Key: B k, magit-bisect-skip
 

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-1133-g2fb44690b+1)
+@subtitle for version 2.90.1 (v2.90.1-1137-g596263bb+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-1133-g2fb44690b+1).
+This manual is for Magit version 2.90.1 (v2.90.1-1137-g596263bb+1).
 
 @quotation
 Copyright (C) 2015-2021 Jonas Bernoulli <jonas@@bernoul.li>
@@ -4969,7 +4969,10 @@ Start a bisect session.
 
 Bisecting a bug means to find the commit that introduced it.
 This command starts such a bisect session by asking for a known
-good and a bad commit.
+good commit and a known bad commit.  If you're bisecting a change
+that isn't a regression, you can select alternate terms that are
+conceptually more fitting than "bad" and "good", but the infix
+arguments to do so are disabled by default.
 
 @kindex B s
 @cindex magit-bisect-run
@@ -4995,6 +4998,15 @@ that the commit does contain the bug in question.
 
 Mark the current commit as good.  Use this after you have asserted
 that the commit does not contain the bug in question.
+
+@kindex B m
+@cindex magit-bisect-mark
+@item @kbd{B m} @tie{}@tie{}@tie{}@tie{}(@code{magit-bisect-mark})
+
+Mark the current commit with one of the bisect terms.  This command
+provides an alternative to @code{magit-bisect-bad} and
+@code{magit-bisect-good} and is useful when using terms other than "bad"
+and "good".  This suffix is disabled by default.
 
 @kindex B k
 @cindex magit-bisect-skip

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -80,8 +80,8 @@
   "Start a bisect session.
 
 Bisecting a bug means to find the commit that introduced it.
-This command starts such a bisect session by asking for a know
-good and a bad commit.  To move the session forward use the
+This command starts such a bisect session by asking for a known
+good and a known bad commit.  To move the session forward use the
 other actions from the bisect transient command (\
 \\<magit-status-mode-map>\\[magit-bisect])."
   (interactive (if (magit-bisect-in-progress-p)

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1121,7 +1121,7 @@ Do not add this to a hook variable."
 
 (defconst magit-log-bisect-log-re
   (concat "^# "
-          "\\(?3:bad:\\|skip:\\|good:\\) "         ; "refs"
+          "\\(?3:[^: \n]+:\\) "                    ; "refs"
           "\\[\\(?1:[^]\n]+\\)\\] "                ; sha1
           "\\(?2:.*\\)$"))                         ; msg
 


### PR DESCRIPTION
I find alternate terms for bisecting very useful, and it's a common reason I resort to the command line.  I've tried to force the "good" and "bad" terms onto bisects a good number of times, and in most cases my brain isn't capable of keeping things straight.

This series adds support for parsing the status buffer when bisecting with alternate terms (second commit) and for running a bisect with alternate terms (third commit).

While I think more people than just myself will find this useful, I doubt most users will, given that I don't recall support for alternate terms being requested.  For this reason, I've put this functionality at a hidden level (6).

(The texi file hasn't been regenerated yet.)
