### PR TITLE
Add "Unsaved changes" section inserter, and accompanying functionality

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2127,6 +2127,10 @@ By default the following functions are also members of that hook:
   directories.  But the directory sections can then be expanded using
   ~TAB~.
 
+- Function: magit-insert-unsaved-changes
+
+  Insert section showing a list of unsaved buffers.
+
 - Function: magit-insert-unstaged-changes
 
   Insert section showing unstaged changes.

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -2129,7 +2129,7 @@ By default the following functions are also members of that hook:
 
 - Function: magit-insert-unsaved-changes
 
-  Insert section showing a list of unsaved buffers.
+  Insert section showing unsaved changes in buffers.
 
 - Function: magit-insert-unstaged-changes
 

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -135,6 +135,10 @@ so causes the change to be applied to the index as well."
       (`(,_  hunks) (magit-apply-hunks  it args))
       (`(rebase-sequence file)
        (call-interactively 'magit-patch-apply))
+      (`(unsaved file)
+       (magit--apply-unsaved-file it))
+      (`(unsaved ,(or `files `list))
+       (magit--apply-unsaved-files it))
       (`(,_   file) (magit-apply-diff   it args))
       (`(,_  files) (magit-apply-diffs  it args)))))
 
@@ -270,6 +274,13 @@ adjusted as \"@@ -10,6 +10,7 @@\" and \"@@ -18,6 +19,7 @@\"."
                           "--ignore-blank-lines")
                         :test #'equal)
        t))
+
+(defun magit--apply-unsaved-file (section)
+  (magit--apply-unsaved-files (list section)))
+
+(defun magit--apply-unsaved-files (sections)
+  (when-let ((buffers (--map (find-buffer-visiting (oref it value)) sections)))
+    (save-some-buffers nil (lambda () (member (current-buffer) buffers)))))
 
 ;;;; Stage
 

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -226,25 +226,79 @@ adjusted as \"@@ -10,6 +10,7 @@\" and \"@@ -18,6 +19,7 @@\"."
   (let* ((files (if (atom section:s)
                     (list (oref section:s value))
                   (--map (oref it value) section:s)))
-         (command (symbol-name this-command))
-         (command (if (and command (string-match "^magit-\\([^-]+\\)" command))
-                      (match-string 1 command)
-                    "apply"))
-         (ignore-context (magit-diff-ignore-any-space-p)))
+         (ignore-context (magit-diff-ignore-any-space-p))
+         (args (append args
+                       '("-p0" "--ignore-space-change")
+                       (and ignore-context '("-C0")))))
     (unless (magit-diff-context-p)
       (user-error "Not enough context to apply patch.  Increase the context"))
+    (if (memq 'unsaved args)
+        (magit--apply-patch-to-buffers files (delq 'unsaved args) patch)
+      (magit--apply-patch-to-worktree files args patch))))
+
+(defun magit--apply-patch-to-worktree (files args patch)
+  (let* ((command (symbol-name this-command))
+         (command (if (and command (string-match "^magit-\\([^-]+\\)" command))
+                      (match-string 1 command)
+                    "apply")))
     (when (and magit-wip-before-change-mode (not magit-inhibit-refresh))
       (magit-wip-commit-before-change files (concat " before " command)))
     (with-temp-buffer
       (insert patch)
       (magit-run-git-with-input
-       "apply" args "-p0"
-       (and ignore-context "-C0")
-       "--ignore-space-change" "-"))
+       "apply" args "-"))
     (unless magit-inhibit-refresh
       (when magit-wip-after-apply-mode
         (magit-wip-commit-after-apply files (concat " after " command)))
       (magit-refresh))))
+
+(defun magit--apply-patch-to-buffers (files args patch)
+  (let ((old-buffer (current-buffer)))
+    (with-temp-buffer
+      (insert patch)
+      (let ((patch-buffer (current-buffer)))
+        (with-current-buffer old-buffer
+          (apply
+           #'magit--calc-apply
+           (lambda (dir)
+             (mapc
+              (lambda (file)
+                (let ((full-path (expand-file-name file dir)))
+                  (make-directory (file-name-directory full-path) t)
+                  (with-current-buffer (find-buffer-visiting file)
+                    (write-region nil nil full-path nil 'silent))))
+              files))
+           patch-buffer
+           (lambda (dir)
+             (mapc
+              (lambda (file)
+                (let ((full-path (expand-file-name file dir)))
+                  (with-current-buffer (find-buffer-visiting file)
+                    (insert-file-contents full-path nil nil nil t))))
+              files))
+           args)))))
+  (unless magit-inhibit-refresh
+    (magit-refresh)))
+
+(defun magit--calc-apply (old-writer diff-buffer new-reader &rest args)
+  "Obtain the result of applying a diff onto arbitrary data.
+
+OLD-WRITER takes a directory name, and should write the data to
+be patched to it.  DIFF-BUFFER is a buffer which contains the
+patch to apply.  ARGS may contain additional arguments to
+git-apply.  NEW-READER is called with the directory name
+containing the result.  (The directory is deleted when
+`magit--calc-apply' exits.)
+
+Returns the return value of NEW-READER."
+  (let ((dir (make-temp-file "magit-diff" t)))
+    (unwind-protect
+        (progn
+          (funcall old-writer dir)
+          (let ((default-directory dir))
+            (apply #'magit--process-input "git" diff-buffer nil nil "apply" args))
+          (funcall new-reader dir))
+      (delete-directory dir t))))
 
 (defun magit-apply--get-selection ()
   (or (magit-region-sections '(hunk file module) t)
@@ -485,17 +539,21 @@ without requiring confirmation."
   (magit-discard-apply section 'magit-apply-hunk))
 
 (defun magit-discard-apply (section apply)
-  (if (eq (magit-diff-type section) 'unstaged)
-      (funcall apply section "--reverse")
-    (if (magit-anything-unstaged-p
-         nil (if (magit-file-section-p section)
-                 (oref section value)
-               (magit-section-parent-value section)))
-        (progn (let ((magit-inhibit-refresh t))
-                 (funcall apply section "--reverse" "--cached")
-                 (funcall apply section "--reverse" "--reject"))
-               (magit-refresh))
-      (funcall apply section "--reverse" "--index"))))
+  (cond
+   ((eq (magit-diff-type section) 'unstaged)
+    (funcall apply section "--reverse"))
+   ((eq (magit-diff-type section) 'unsaved)
+    (funcall apply section "--reverse" 'unsaved))
+   ((magit-anything-unstaged-p
+     nil (if (magit-file-section-p section)
+             (oref section value)
+           (magit-section-parent-value section)))
+    (let ((magit-inhibit-refresh t))
+      (funcall apply section "--reverse" "--cached")
+      (funcall apply section "--reverse" "--reject"))
+    (magit-refresh))
+   (t
+    (funcall apply section "--reverse" "--index"))))
 
 (defun magit-discard-hunks (sections)
   (magit-confirm 'discard (format "Discard %s hunks from %s"
@@ -505,17 +563,21 @@ without requiring confirmation."
 
 (defun magit-discard-apply-n (sections apply)
   (let ((section (car sections)))
-    (if (eq (magit-diff-type section) 'unstaged)
-        (funcall apply sections "--reverse")
-      (if (magit-anything-unstaged-p
-           nil (if (magit-file-section-p section)
-                   (oref section value)
-                 (magit-section-parent-value section)))
-          (progn (let ((magit-inhibit-refresh t))
-                   (funcall apply sections "--reverse" "--cached")
-                   (funcall apply sections "--reverse" "--reject"))
-                 (magit-refresh))
-        (funcall apply sections "--reverse" "--index")))))
+    (cond
+     ((eq (magit-diff-type section) 'unstaged)
+      (funcall apply sections "--reverse"))
+     ((eq (magit-diff-type section) 'unsaved)
+      (funcall apply sections "--reverse" 'unsaved))
+     ((magit-anything-unstaged-p
+       nil (if (magit-file-section-p section)
+               (oref section value)
+             (magit-section-parent-value section)))
+      (let ((magit-inhibit-refresh t))
+        (funcall apply sections "--reverse" "--cached")
+        (funcall apply sections "--reverse" "--reject"))
+      (magit-refresh))
+     (t
+      (funcall apply sections "--reverse" "--index")))))
 
 (defun magit-discard-file (section)
   (magit-discard-files (list section)))

--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -247,7 +247,7 @@ adjusted as \"@@ -10,6 +10,7 @@\" and \"@@ -18,6 +19,7 @@\"."
       (let ((section (magit-current-section)))
         (pcase (oref section type)
           ((or `hunk `file `module) section)
-          ((or `staged `unstaged `untracked
+          ((or `staged `unstaged `unsaved `untracked
                `stashed-index `stashed-worktree `stashed-untracked)
            (oref section children))
           (_ (user-error "Cannot apply this, it's not a change"))))))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2758,6 +2758,12 @@ It the SECTION has a different type, then do nothing."
 
 (add-hook 'magit-section-goto-successor-hook #'magit-hunk-goto-successor)
 
+(defvar magit-unsaved-section-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [remap magit-delete-thing] 'magit-discard)
+    map)
+  "Keymap for the `unsaved' section.")
+
 (magit-define-section-jumper magit-jump-to-unsaved "Unsaved changes" unsaved)
 
 (defun magit--insert-unsaved-diff (buffer)
@@ -2850,12 +2856,12 @@ It the SECTION has a different type, then do nothing."
   "Return the diff type of SECTION.
 
 The returned type is one of the symbols `staged', `unstaged',
-`committed', or `undefined'.  This type serves a similar purpose
-as the general type common to all sections (which is stored in
-the `type' slot of the corresponding `magit-section' struct) but
-takes additional information into account.  When the SECTION
-isn't related to diffs and the buffer containing it also isn't
-a diff-only buffer, then return nil.
+`unsaved', `committed', or `undefined'.  This type serves a
+similar purpose as the general type common to all sections (which
+is stored in the `type' slot of the corresponding `magit-section'
+struct) but takes additional information into account.  When the
+SECTION isn't related to diffs and the buffer containing it also
+isn't a diff-only buffer, then return nil.
 
 Currently the type can also be one of `tracked' and `untracked'
 but these values are not handled explicitly everywhere they
@@ -2887,7 +2893,7 @@ Do not confuse this with `magit-diff-scope' (which see)."
                    (t 'committed))))
           ((derived-mode-p 'magit-status-mode)
            (let ((stype (oref it type)))
-             (if (memq stype '(staged unstaged tracked untracked))
+             (if (memq stype '(staged unstaged unsaved tracked untracked))
                  stype
                (pcase stype
                  ((or `file `module)
@@ -2949,7 +2955,7 @@ actually a `diff' but a `diffstat' section."
         (`(file  ,_  ,_  ,_) 'file)
         (`(module   t   t nil) 'files)
         (`(module  ,_  ,_  ,_) 'file)
-        (`(,(or `staged `unstaged `untracked)
+        (`(,(or `staged `unstaged `unsaved `untracked)
            nil ,_ ,_) 'list)))))
 
 (defun magit-diff-use-hunk-region-p ()

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2761,6 +2761,7 @@ It the SECTION has a different type, then do nothing."
 (defvar magit-unsaved-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap magit-delete-thing] 'magit-discard)
+    (define-key map [remap magit-cherry-apply] 'magit-apply)
     map)
   "Keymap for the `unsaved' section.")
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -835,7 +835,8 @@ and `:slant'."
 (defclass magit-file-section (magit-section)
   ((keymap :initform magit-file-section-map)
    (source :initform nil)
-   (header :initform nil)))
+   (header :initform nil)
+   (status :initform nil)))
 
 (defclass magit-module-section (magit-file-section)
   ((keymap :initform magit-hunk-section-map)))
@@ -2257,6 +2258,7 @@ section or a child thereof."
     (unless (equal orig file)
       (oset section source orig))
     (oset section header header)
+    (oset section status status)
     (when modes
       (magit-insert-section (hunk)
         (insert modes)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2762,9 +2762,12 @@ It the SECTION has a different type, then do nothing."
   "Insert diff for unsaved changes in BUFFER."
   (let* ((file-name     (buffer-file-name buffer))
          (relative-name (magit-file-relative-name file-name))
+         (diff-path     (if (file-exists-p file-name)
+                            relative-name
+                          "/dev/null"))
          (args          (-flatten (list "diff" magit-buffer-diff-args
                                         "--no-index" "--no-prefix" "--"
-                                        relative-name "-")))
+                                        diff-path "-")))
          (beg           (point)))
     (apply #'magit--git-insert-with-input buffer args)
     (when (< beg (point))

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -360,6 +360,8 @@ doesn't find the executable, then consult the info node
      :if (lambda () (memq 'magit-insert-tracked-files magit-status-sections-hook)))
     ("n " "Untracked" magit-jump-to-untracked
      :if (lambda () (memq 'magit-insert-untracked-files magit-status-sections-hook)))
+    ("m " "Unsaved" magit-jump-to-unsaved
+     :if (lambda () (memq 'magit-insert-unsaved-changes magit-status-sections-hook)))
     ("u " "Unstaged" magit-jump-to-unstaged
      :if (lambda () (memq 'magit-insert-unstaged-changes magit-status-sections-hook)))
     ("s " "Staged" magit-jump-to-staged


### PR DESCRIPTION
#4285

Implements:

- [x] Section construction
  - [X] Enumerate modified buffers belonging to the repository
    - [x] Also add entries for buffers visiting files that don't yet exist - show them as "new file"
  - [X] Show diff between buffer and file on disk
- [x] Section operations
  - [x] <kbd>RET</kbd> (`magit-visit-thing`)
    - [ ] ~~on section~~
    - [X] on file (go to buffer)
    - [X] on hunk (go to line in buffer)
      - [X] on deleted line in hunk (go to line in original file on disk)
  - [x] <kbd>k</kbd> (`magit-delete-thing` / `magit-discard`)
    - [x] on section (revert/kill all)
    - [x] on file
      - [x] existing files (revert)
      - [x] new files (kill buffer)
    - [x] on hunk (using a temporary file)
  - [x] <kbd>a</kbd> (`magit-cherry-apply` / `magit-apply`)
    - [x] on section (save all)
    - [x] on file (save file)
    - [x] on hunk
