### PR TITLE
Set the diffstat width to window's width with new customization

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2024,14 +2024,16 @@ Staging and applying changes is documented in info node
   ;; Don't add any of width arguments unless --stat is present - adding
   ;; any of these arguments implies a --stat.
   (if (member "--stat" args)
-      (let ((diffstat-width (if (functionp magit-diffstat-width)
-                                (funcall magit-diffstat-width)
-                              magit-diffstat-width)))
-        (when-let ((graph-width (nth 2 diffstat-width)))
-          (push (format "--stat-graph-width=%d" graph-width) args))
-        (when-let ((name-width (nth 1 diffstat-width)))
-          (push (format "--stat-name-width=%d" name-width) args))
-        (push (format "--stat-width=%d" (car diffstat-width)) args))
+      (if-let ((window (get-buffer-window (current-buffer) 'visible)))
+          (with-selected-window window
+            (let ((diffstat-width (if (functionp magit-diffstat-width)
+                                      (funcall magit-diffstat-width)
+                                    magit-diffstat-width)))
+              (when-let ((graph-width (nth 2 diffstat-width)))
+                (push (format "--stat-graph-width=%d" graph-width) args))
+              (when-let ((name-width (nth 1 diffstat-width)))
+                (push (format "--stat-name-width=%d" name-width) args))
+              (push (format "--stat-width=%d" (car diffstat-width)) args))))
     args))
 
 (defun magit-insert-diff ()

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1069,7 +1069,7 @@ Do not add this to a hook variable."
           (setq args (cons "--decorate=full" (remove "--decorate" args))))
         (when (member "--reverse" args)
           (setq args (remove "--graph" args)))
-        (setq args (magit-diffstat-add-width-arguments args))
+        (setq args (magit-diffstat-maybe-add-width-arguments args))
         args)
       "--use-mailmap" "--no-prefix" revs "--" files)))
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1069,6 +1069,7 @@ Do not add this to a hook variable."
           (setq args (cons "--decorate=full" (remove "--decorate" args))))
         (when (member "--reverse" args)
           (setq args (remove "--graph" args)))
+        (setq args (magit-diffstat-add-width-arguments args))
         args)
       "--use-mailmap" "--no-prefix" revs "--" files)))
 


### PR DESCRIPTION
Before this patch the filename + graph lines of diffstat are limited to 78 characters by
git (according with the git documentation this is 80 characters, but the limit is actually 78 in my
tests). This causes part of the directory structure and/or filename to be abbreviated to 78
characters even if the buffer has enough space to display the full directory structure and filename.

This patch set the default width of diffstat to the same as the window's width and add 3 new custom
variables to customize this behavior in the same way as available when using git in a terminal.

This patch affects the magit-diff, magit-revision and the magit-log buffers.