### PR TITLE
magit-process: Respect process decoding user-setting

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -577,7 +577,7 @@ Magit status buffer."
     (when (eq system-type 'windows-nt)
       ;; On w32, git expects UTF-8 encoded input, ignore any user
       ;; configuration telling us otherwise.
-      (set-process-coding-system process 'utf-8-unix))
+      (set-process-coding-system process nil 'utf-8-unix))
     (process-put process 'section section)
     (process-put process 'command-buf (current-buffer))
     (process-put process 'default-dir default-directory)


### PR DESCRIPTION
Otherwise, on Windows an issue shows up with processes that output
CRLF-endings (e.g. python): the process-output is deleted due to the
subsequent code (which tries to improve output of counters).

---

On windows I encounter an issue that I don't see any output from processes (namely python), when executed via magit's "Run shell command". Python is supposed to output `\r\n` as line ending on windows (see e.g. https://bugs.python.org/issue13119).

I wrote a patch that fixes the issue, while still properly showing counting processes (which only output `\r` without `\n`, in order to erase the current line).

However, I'm not sure if this is the right place to fix the issue, or if it should be rather fixed outside magit (I have set `default-process-coding-system` to `(utf-8-dos . utf-8-unix)` if that matters).

Could you please have a look and tell me if this is the right way to go?

I'm sorry if this is somehow a mix between a merge request and an issue description; as I already had a possible fix available, I wrote it up like this. If requested I can of course transfer it to an issue.