### PR TITLE
Fixing GPG key suggestions

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -161,7 +161,7 @@ Also see `git-commit-post-finish-hook'."
                                                  (epg-decode-dn id-obj))))
                               append (cl-loop for subkey in (epg-key-sub-key-list key)
                                               if (and (memq 'sign (epg-sub-key-capability subkey))
-                                                      (time-less-p (float-time nil) (epg-sub-key-expiration-time subkey)))
+                                                      (time-less-p (float-time) (epg-sub-key-expiration-time subkey)))
                                               collect (let ((subkey-id (epg-sub-key-id subkey)))
                                                         (propertize
                                                          subkey-id 'display (string-join (list subkey-id author) " "))))))

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -160,7 +160,8 @@ Also see `git-commit-post-finish-hook'."
                                                    id-str
                                                  (epg-decode-dn id-obj))))
                               append (cl-loop for subkey in (epg-key-sub-key-list key)
-                                              if (memq 'sign (epg-sub-key-capability subkey))
+                                              if (and (memq 'sign (epg-sub-key-capability subkey))
+                                                      (> (epg-sub-key-expiration-time subkey) (time-convert nil 'integer)))
                                               collect (let ((subkey-id (epg-sub-key-id subkey)))
                                                         (propertize
                                                          subkey-id 'display (string-join (list subkey-id author) " "))))))

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -161,7 +161,7 @@ Also see `git-commit-post-finish-hook'."
                                                  (epg-decode-dn id-obj))))
                               append (cl-loop for subkey in (epg-key-sub-key-list key)
                                               if (and (memq 'sign (epg-sub-key-capability subkey))
-                                                      (> (epg-sub-key-expiration-time subkey) (time-convert nil 'integer)))
+                                                      (time-less-p (float-time) (epg-sub-key-expiration-time subkey)))
                                               collect (let ((subkey-id (epg-sub-key-id subkey)))
                                                         (propertize
                                                          subkey-id 'display (string-join (list subkey-id author) " "))))))

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -164,7 +164,8 @@ Also see `git-commit-post-finish-hook'."
                                               collect (let ((subkey-id (epg-sub-key-id subkey)))
                                                         (propertize
                                                          subkey-id 'display (string-join (list subkey-id author) " "))))))
-         (choice (completing-read "Some stutff:" by-subkeys)))
+         (choice (completing-read prompt by-subkeys nil nil nil
+                                  history nil initial-input)))
     (set-text-properties 0 (length choice) nil choice)
     choice))
 

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -161,7 +161,7 @@ Also see `git-commit-post-finish-hook'."
                                                  (epg-decode-dn id-obj))))
                               append (cl-loop for subkey in (epg-key-sub-key-list key)
                                               if (and (memq 'sign (epg-sub-key-capability subkey))
-                                                      (time-less-p (float-time) (epg-sub-key-expiration-time subkey)))
+                                                      (time-less-p (float-time nil) (epg-sub-key-expiration-time subkey)))
                                               collect (let ((subkey-id (epg-sub-key-id subkey)))
                                                         (propertize
                                                          subkey-id 'display (string-join (list subkey-id author) " "))))))

--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -161,7 +161,7 @@ Also see `git-commit-post-finish-hook'."
                                                  (epg-decode-dn id-obj))))
                               append (cl-loop for subkey in (epg-key-sub-key-list key)
                                               if (and (memq 'sign (epg-sub-key-capability subkey))
-                                                      (time-less-p (float-time) (epg-sub-key-expiration-time subkey)))
+                                                      (time-less-p nil (epg-sub-key-expiration-time subkey)))
                                               collect (let ((subkey-id (epg-sub-key-id subkey)))
                                                         (propertize
                                                          subkey-id 'display (string-join (list subkey-id author) " "))))))


### PR DESCRIPTION
Prior: would suggest the first key for each keyring

Current: only suggests any subkey that is capable of signing

-----

A common setup for GPG is to have the primary (root) key only have certification capabilities.
The primary key is then used to certify subkeys which typically do the actual functions.
This is common because it allows the primary key to not be in the gpg keychain; it is left stored away in safe-keeping to expire (renew) keys, create new keys, etc.

The previous behavior would suggest the key ID of the primary key, _even if it didn't have signing capabilities_.

This new behavior will suggest all subkey combinations of each keychain that contain a sign-capable private key, including

* a user having more than one signing key per keychain (unwise, but possible)
* a user having more than one key in their keychain (possible e.g. to sign for work vs. personal commits)

Please do suggest `cl-loop` or formatting fixes. I tried my best to format it nicely and use what I could figure out about the `cl-loop` construct, but if there is a better way of writing this I'm happy to give it another go.
