### PR TITLE
magit-branch/magit-checkout: add recurse-submodules option

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -8,7 +8,7 @@
 #+TEXINFO_DIR_CATEGORY: Emacs
 #+TEXINFO_DIR_TITLE: Magit: (magit).
 #+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version 2.90.1 (v2.90.1-1171-gb4cf9fa9c+1)
+#+SUBTITLE: for version 2.90.1 (v2.90.1-1193-g49fbb7c2d+1)
 
 #+TEXINFO_DEFFN: t
 #+OPTIONS: H:4 num:3 toc:2
@@ -25,7 +25,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 #+TEXINFO: @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-1171-gb4cf9fa9c+1).
+This manual is for Magit version 2.90.1 (v2.90.1-1193-g49fbb7c2d+1).
 
 #+BEGIN_QUOTE
 Copyright (C) 2015-2021 Jonas Bernoulli <jonas@bernoul.li>

--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -4749,8 +4749,8 @@ command.
 - User Option: magit-branch-direct-configure
 
   This option controls whether the transient command ~magit-branch~ can
-  be used directly change the values Git variables.  This defaults to
-  ~t~ (to avoid changing key bindings).  When set to ~nil~, then no
+  be used to directly change the values of Git variables.  This defaults
+  to ~t~ (to avoid changing key bindings).  When set to ~nil~, then no
   variables are displayed by that transient command, and its suffix
   command ~magit-branch-configure~ has to be used instead to view and
   change branch related variables.

--- a/Documentation/magit.texi
+++ b/Documentation/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version 2.90.1 (v2.90.1-1171-gb4cf9fa9c+1)
+@subtitle for version 2.90.1 (v2.90.1-1193-g49fbb7c2d+1)
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version 2.90.1 (v2.90.1-1171-gb4cf9fa9c+1).
+This manual is for Magit version 2.90.1 (v2.90.1-1193-g49fbb7c2d+1).
 
 @quotation
 Copyright (C) 2015-2021 Jonas Bernoulli <jonas@@bernoul.li>
@@ -1037,7 +1037,8 @@ whenever a buffer is saved to a file inside the respective repository
 by adding a hook, like so:
 
 @lisp
-(add-hook 'after-save-hook 'magit-after-save-refresh-status t)
+(with-eval-after-load 'magit-mode
+  (add-hook 'after-save-hook 'magit-after-save-refresh-status t))
 @end lisp
 
 Automatically refreshing Magit buffers ensures that the displayed
@@ -6433,8 +6434,8 @@ branch-related Git variables and allows changing their values.
 @defopt magit-branch-direct-configure
 
 This option controls whether the transient command @code{magit-branch} can
-be used directly change the values Git variables.  This defaults to
-@code{t} (to avoid changing key bindings).  When set to @code{nil}, then no
+be used to directly change the values of Git variables.  This defaults
+to @code{t} (to avoid changing key bindings).  When set to @code{nil}, then no
 variables are displayed by that transient command, and its suffix
 command @code{magit-branch-configure} has to be used instead to view and
 change branch related variables.


### PR DESCRIPTION
# Change description and rationale

When using submodules, having to switch the submodules manually after each (branch and) checkout operation is quite cumbersome, even with the nice "o u" keyboard shortcuts.

This PR adds the git option "--recurse-submodules" to the magit-branch (sub-) commands that checkout branches, visibility controlled by transient level.