### PR TITLE
Improve suggestion for magit after-save hook

### DIFF
--- a/Documentation/magit.org
+++ b/Documentation/magit.org
@@ -645,7 +645,8 @@ whenever a buffer is saved to a file inside the respective repository
 by adding a hook, like so:
 
 #+BEGIN_SRC emacs-lisp
-  (add-hook 'after-save-hook 'magit-after-save-refresh-status t)
+  (with-eval-after-load 'magit-mode
+    (add-hook 'after-save-hook 'magit-after-save-refresh-status t))
 #+END_SRC
 
 Automatically refreshing Magit buffers ensures that the displayed

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -824,7 +824,7 @@ exist that hasn't been looked to its value.  Return that buffer
 \(or nil if there is no such buffer) unless VALUE is non-nil, in
 which case return the buffer that has been looked to that value.
 
-If FRAME nil or omitted, then consider all buffers.  Otherwise
+If FRAME is nil or omitted, then consider all buffers.  Otherwise
   only consider buffers that are displayed in some live window
   on some frame.
 If `all', then consider all buffers on all frames.

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -295,6 +295,7 @@ Also see info node `(magit)Commands for Buffers Visiting Files'."
     ("E" "Ediff"          magit-ediff)]
    [("f" "Fetch"          magit-fetch)
     ("F" "Pull"           magit-pull)
+    ("I" "Init"           magit-init)
     ("l" "Log"            magit-log)
     ("L" "Log (change)"   magit-log-refresh)
     ("m" "Merge"          magit-merge)


### PR DESCRIPTION
This changes the suggestion to set the hook only after magit is loaded.

Currently, copy-pasting from the manual leads to messages like 
`Symbol’s function definition is void: magit-after-save-refresh-status` when trying to
exit emacs and, even worse, strange debugger errors after files are saved.
I wasn't enough of an Emacs expert to know how hooks work, so this was unexpected
and annoying to me.

This commit replaces the suggested way to implement the hook with the answer from
https://emacs.stackexchange.com/questions/56309/auto-refresh-magit-status-only-when-magit-is-running.

==========

After making this, I saw that this doesn't quite fit the contribution guidelines in that I edited the file in Github and didn't add a feature branch. I hope that is OK for such a small change, but feel free to dispose of my edit and treat this as a bug report instead.