### PR TITLE
Remove git-commit-major-mode entry from .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,6 +1,4 @@
 ((emacs-lisp-mode
   (indent-tabs-mode . nil))
  (makefile-gmake-mode
-  (outline-regexp . "##"))
- (git-commit-mode
-  (git-commit-major-mode . git-commit-elisp-text-mode)))
+  (outline-regexp . "##")))


### PR DESCRIPTION
This variable is not *safe* varibale, warning window is noisy for
new contributors.  Answering y to warnings is a bad habit to get
beginners into.  Think about what it means for .dir-locals to
show a warning for setting an unsafe variable, and if we need
this, we should do it in dir-locals-2.el.

This from https://github.com/emacs-lsp/lsp-mode/pull/2689 and 
https://github.com/emacs-lsp/lsp-mode/pull/2693 .

I know how dangerous it can be to change distrusted variables in
dir-locals.  `git-commit-major-mode` is not a safe variable, as
approved by Emacs maintainers.

If you still need it, you should do it in dir-locals-2.el instead
of forcing it in your project.

New contributors can reject it temporarily, but they will have to
answer n to this warning window every time they commit, and for
convenience they will have to answer ! for convenience.  This is
a bad habit.