### PR TITLE
Fix magit-file-dispatch for dired buffers

### DIFF
--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -315,7 +315,7 @@ to `magit-dispatch'."
     (5 "C-c c" "Checkout file" magit-file-checkout)]]
   (interactive)
   (transient-setup
-   (if (or buffer-file-name magit-buffer-file-name)
+   (if (magit-file-relative-name)
        'magit-file-dispatch
      'magit-dispatch)))
 


### PR DESCRIPTION
As of 5a38e1bb0fffa0326a1b5073c0ce9b05386e5109, `magit-file-dispatch` forwards to `magit-dispatch` for dired buffers, which prevents using it to e.g. request a git log only for the currently visited directory.

I think this was an unintended change, but I'm not sure. On one hand, many of the `magit-file-dispatch` commands, such as blame, are not relevant to dired buffers. On the other hand, the description of 5a38e1bb0fffa0326a1b5073c0ce9b05386e5109 doesn't seem to mention this change at all.