### PR TITLE
magit-extras: Update project.el integration

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -145,9 +145,8 @@ like pretty much every other keymap:
   ;; Only more recent versions of project.el have `project-prefix-map' and
   ;; `project-switch-commands', though project.el is available in Emacs 25.
   (when (boundp 'project-prefix-map)
-    (define-key project-prefix-map "m" #'magit-project-status))
-  (when (boundp 'project-switch-commands)
-    (add-to-list 'project-switch-commands '(?m "Magit" magit-status))))
+    (define-key project-prefix-map "m" #'magit-project-status)
+    (add-to-list 'project-switch-commands '(magit-project-status "Magit"))))
 
 ;;;###autoload
 (defun magit-dired-jump (&optional other-window)


### PR DESCRIPTION
The format of `project-switch-commands` changed.  The `car` is now the command, and its key binding is looked up in `project-prefix-map`:

> Remove the duplication from project-switch-commands's config
> 51698f77dd 2020-12-13 22:50:55 +0200
> https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=51698f77dd6356049fcacdb01ebe80cfe4c67272

This change is included in `project.el` version `0.5.4` of `2021-03-09`, which also lowers the minimum required Emacs version from `26.3` to `26.1`: https://elpa.gnu.org/packages/project.html

Consistently calling `magit-project-status` instead of `magit-status` has the benefit of going through [`project-remember-project`](http://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/progmodes/project.el#n1201), which marks the selected project as the most recently used, for the benefit of completion.