### PR TITLE
Expand symlinks in top-level test directory

### DIFF
--- a/t/magit-tests.el
+++ b/t/magit-tests.el
@@ -29,7 +29,7 @@
        (push "GIT_AUTHOR_EMAIL=a.u.thor@example.com" process-environment)
        (condition-case err
            (cl-letf (((symbol-function #'message) (lambda (&rest _))))
-             (let ((default-directory ,dir))
+             (let ((default-directory (file-truename ,dir)))
                ,@body))
          (error (message "Keeping test directory:\n  %s" ,dir)
                 (signal (car err) (cdr err))))


### PR DESCRIPTION
This change ensures symlinks in the base test directory for toplevel tests are expanded within the `magit-with-test-directory` macro. Doing this ensures that the fully expanded paths returned from `magit-toplevel` will match expanded relative paths (e.g., `(expand-file-name "repo/")`).

This issue was found on macOS (11.2.2) where temp files/directories are created under `/var/...` which is symlinked to `/private/var/...`.