### PR TITLE
libgit: add additional test infrastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,5 @@
 name: test
 on: [ push, pull_request ]
-env:
-  CURL: "curl -fsSkL --retry 9 --retry-delay 9"
-  GHRAW: "https://raw.githubusercontent.com"
-  BUILD_MAGIT_LIBGIT: "false"
 jobs:
   test:
     runs-on: ubuntu-20.04
@@ -19,17 +15,21 @@ jobs:
         - 27.1
         - snapshot
     steps:
-    - uses: purcell/setup-emacs@master
+    - uses: cachix/install-nix-action@v12
       with:
-        version: ${{ matrix.emacs_version }}
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v8
+      with:
+        name: emacs-ci
     - uses: actions/checkout@v2
     - name: Install
       run: |
-        $CURL -O ${GHRAW}/magnars/dash.el/master/dash.el
-        $CURL -O ${GHRAW}/magit/transient/master/lisp/transient.el
-        $CURL -O ${GHRAW}/magit/with-editor/master/with-editor.el
-        emacs -Q --batch -L . -f batch-byte-compile dash.el transient.el with-editor.el
+        # Build and install Emacs (+ magit dependencies) using Nix
+        emacs_ci_version=$(echo "emacs-${{ matrix.emacs_version }}" | sed -e "s/\./-/g")
+        nix-env -f ./t/default.nix -iA $emacs_ci_version
         emacs --version
+
+        # Configure Git
         git config --global user.name "A U Thor"
         git config --global user.email a.u.thor@example.com
         git tag 0
@@ -38,4 +38,4 @@ jobs:
         make lisp DASH_DIR=$PWD
     - name: Test
       run: |
-        make test DASH_DIR=$PWD
+        make test-in-ci DASH_DIR=$PWD

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ help:
 	$(info )
 	$(info make test             - run tests)
 	$(info make test-interactive - run tests interactively)
+	$(info make test-in-ci       - run tests in CI environment)
 	$(info make emacs-Q          - run emacs -Q plus Magit)
 	$(info )
 	$(info Release Management)
@@ -108,6 +109,13 @@ install-info: info
 test:
 	@$(BATCH) --eval "(progn\
         $$suppress_warnings\
+	(load-file \"t/magit-tests.el\")\
+	(ert-run-tests-batch-and-exit))"
+
+test-in-ci:
+	@$(BATCH) --eval "(progn\
+		$$suppress_warnings\
+	(setq magit--ensure-libgit-tests-run t)\
 	(load-file \"t/magit-tests.el\")\
 	(ert-run-tests-batch-and-exit))"
 

--- a/t/default.nix
+++ b/t/default.nix
@@ -1,0 +1,18 @@
+let
+  emacs-overlay = import (builtins.fetchTarball { url = https://github.com/nix-community/emacs-overlay/archive/master.tar.gz; });
+  emacs-ci = import (builtins.fetchTarball { url = https://github.com/purcell/nix-emacs-ci/archive/master.tar.gz; });
+
+  pkgs = import <nixpkgs> { overlays = [ emacs-overlay ]; };
+in
+builtins.mapAttrs
+  (version: emacs:
+    (pkgs.emacsPackagesGen emacs).emacsWithPackages
+      (emacsPackages: [
+        emacsPackages.dash
+        emacsPackages.transient
+      ] ++ (with emacsPackages.melpaPackages; [
+        libgit
+        with-editor
+      ])
+      ))
+  emacs-ci


### PR DESCRIPTION
This change is meant to make testing usages of libgit functions within magit easier and work within the CI environment.

- Add macros for defining magit tests that run with the Git CLI,
libgit, or both implementations.

- Add simple tests for `magit-bare-repo-p` and run them using both the
Git CLI and libgit.

- Add and use new `test-in-ci` MakeFile target that installs and
sources the libgit2 Emacs package before running tests.