### PR TITLE
magit-extras: Do not modify customized project-switch-commands

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -149,7 +149,7 @@ like pretty much every other keymap:
              (equal project-switch-commands
                     (custom--standard-value 'project-switch-commands)))
     (define-key project-prefix-map "m" #'magit-project-status)
-    (add-to-list 'project-switch-commands '(magit-project-status "Magit"))))
+    (add-to-list 'project-switch-commands '(magit-project-status "Magit") t)))
 
 ;;;###autoload
 (defun magit-dired-jump (&optional other-window)

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -144,7 +144,10 @@ like pretty much every other keymap:
 (with-eval-after-load 'project
   ;; Only more recent versions of project.el have `project-prefix-map' and
   ;; `project-switch-commands', though project.el is available in Emacs 25.
-  (when (boundp 'project-prefix-map)
+  (when (and (boundp 'project-prefix-map)
+             ;; Only modify if it hasn't already been modified.
+             (equal project-switch-commands
+                    (custom--standard-value 'project-switch-commands)))
     (define-key project-prefix-map "m" #'magit-project-status)
     (add-to-list 'project-switch-commands '(magit-project-status "Magit"))))
 


### PR DESCRIPTION
Problem: Magit messes with my `project-switch-commands`.

The variable `project-switch-commands` is customizable, and I configure it to contain the commands I want. Since I use `use-package` to load `magit`, `project-switch-commands` may be set before either `magit` or `magit-extras` is loaded. 

However, once `magit-extras` is loaded it unconditionally modifies `project-switch-commands`. This is not ideal.

This PR only adds the "Magit" command if the variable hasn't been customized. If also ensures that the "Magit" command is added _after_ the default ones, which is a better default in my opinion.
