### PR TITLE
git-commit: (Re)enable autoloading without all dependencies

### DIFF
--- a/lisp/git-commit-global.el
+++ b/lisp/git-commit-global.el
@@ -1,0 +1,78 @@
+;;; git-commit-global.el --- Support for autoloading git-commit.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2010-2021  The Magit Project Contributors
+;;
+;; You should have received a copy of the AUTHORS.md file which
+;; lists all contributors.  If not, see http://magit.vc/authors.
+
+;; Authors: Jonas Bernoulli <jonas@bernoul.li>
+;;	Sebastian Wiesner <lunaryorn@gmail.com>
+;;	Florian Ragwitz <rafl@debian.org>
+;;	Marius Vollmer <marius.vollmer@gmail.com>
+;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
+
+;; This file is not part of GNU Emacs.
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Implementation of `global-git-commit-mode'. This library has no
+;; dependencies, which makes it suitable for use during Emacs
+;; initialization when start times matter. Just put
+;;
+;;    (global-git-commit-mode 1)
+;;
+;; to the initialization file and git-commit.el will autoload later,
+;; when it is actually needed.
+
+;;; Code:
+
+;;;###autoload
+(define-minor-mode global-git-commit-mode
+  "Edit Git commit messages.
+
+This global mode arranges for `git-commit-setup' to be called
+when a Git commit message file is opened.  That usually happens
+when Git uses the Emacsclient as $GIT_EDITOR to have the user
+provide such a commit message.
+
+Loading of full `git-commit' library is deferred until it is
+actually needed. This helps to reduce Emacs start times."
+  :group 'git-commit
+  :type 'boolean
+  :global t
+  :init-value t
+  :initialize (lambda (symbol exp)
+                (custom-initialize-default symbol exp)
+                (when global-git-commit-mode
+                  (add-hook 'find-file-hook 'git-commit-setup-check-buffer)))
+  (if global-git-commit-mode
+      (add-hook  'find-file-hook 'git-commit-setup-check-buffer)
+    (remove-hook 'find-file-hook 'git-commit-setup-check-buffer)))
+
+;;;###autoload
+(defconst git-commit-filename-regexp "/\\(\
+\\(\\(COMMIT\\|NOTES\\|PULLREQ\\|MERGEREQ\\|TAG\\)_EDIT\\|MERGE_\\|\\)MSG\
+\\|\\(BRANCH\\|EDIT\\)_DESCRIPTION\\)\\'")
+
+(declare-function git-commit-setup "git-commit" ())
+
+(defun git-commit-setup-check-buffer ()
+  (and buffer-file-name
+       (string-match-p git-commit-filename-regexp buffer-file-name)
+       (git-commit-setup)))
+
+(provide 'git-commit-global)
+;;; git-commit-global.el ends here

--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -115,6 +115,7 @@
 (require 'dash)
 (require 'subr-x)
 
+(require 'git-commit-global)
 (require 'magit-git nil t)
 (require 'magit-utils nil t)
 
@@ -151,33 +152,6 @@
   :prefix "git-commit-"
   :link '(info-link "(magit)Editing Commit Messages")
   :group 'tools)
-
-(define-minor-mode global-git-commit-mode
-  "Edit Git commit messages.
-
-This global mode arranges for `git-commit-setup' to be called
-when a Git commit message file is opened.  That usually happens
-when Git uses the Emacsclient as $GIT_EDITOR to have the user
-provide such a commit message.
-
-Loading the library `git-commit' by default enables this mode,
-but the library is not automatically loaded because doing that
-would pull in many dependencies and increase startup time too
-much.  You can either rely on `magit' loading this library or
-you can load it explicitly.  Autoloading is not an alternative
-because in this case autoloading would immediately trigger
-full loading."
-  :group 'git-commit
-  :type 'boolean
-  :global t
-  :init-value t
-  :initialize (lambda (symbol exp)
-                (custom-initialize-default symbol exp)
-                (when global-git-commit-mode
-                  (add-hook 'find-file-hook 'git-commit-setup-check-buffer)))
-  (if global-git-commit-mode
-      (add-hook  'find-file-hook 'git-commit-setup-check-buffer)
-    (remove-hook 'find-file-hook 'git-commit-setup-check-buffer)))
 
 (defcustom git-commit-major-mode 'text-mode
   "Major mode used to edit Git commit messages.
@@ -439,10 +413,6 @@ This is only used if Magit is available."
 
 ;;; Hooks
 
-(defconst git-commit-filename-regexp "/\\(\
-\\(\\(COMMIT\\|NOTES\\|PULLREQ\\|MERGEREQ\\|TAG\\)_EDIT\\|MERGE_\\|\\)MSG\
-\\|\\(BRANCH\\|EDIT\\)_DESCRIPTION\\)\\'")
-
 (eval-after-load 'recentf
   '(add-to-list 'recentf-exclude git-commit-filename-regexp))
 
@@ -454,11 +424,6 @@ This is only used if Magit is available."
        (git-commit-setup-font-lock)))
 
 (add-hook 'after-change-major-mode-hook 'git-commit-setup-font-lock-in-buffer)
-
-(defun git-commit-setup-check-buffer ()
-  (and buffer-file-name
-       (string-match-p git-commit-filename-regexp buffer-file-name)
-       (git-commit-setup)))
 
 (defvar git-commit-mode)
 
@@ -494,6 +459,7 @@ Type \\[with-editor-finish] to finish, \
 \\[git-commit-prev-message] and \\[git-commit-next-message] \
 to recover older messages")
 
+;;;###autoload
 (defun git-commit-setup ()
   (when (fboundp 'magit-toplevel)
     ;; `magit-toplevel' is autoloaded and defined in magit-git.el,


### PR DESCRIPTION
As a response to #4293, commit 13f20763 ("No longer autoload
global-git-commit-mode", 2021-02-06) disabled autoloading of
git-commit.el to avoid loading its many dependencies at Emacs
initialization time. This made it harder to use git-commit.el as
$EDITOR invoked by `git commit`.

This commit re-enables the autoloads again, but also splits
git-commit.el to two files. For initialization, only a small file
without any dependencies is needed. The rest of git-commit.el and all
dependencies are loaded later, when needed.

Note that this change would require updating MELPA (and maybe other) receipes to include the new file. Alternatively, the same result could be achieved by "copying" the needed code to `git-commit-autoloads.el` by wrapping the needed functions in `progn` and prefixing them with autoload cookies. Let me know what is preferable.