### PR TITLE
bookmark: mending incompatibilities with bookmark+ package

### DIFF
--- a/lisp/magit-bookmark.el
+++ b/lisp/magit-bookmark.el
@@ -84,6 +84,9 @@ with the variables' values as arguments, which were recorded by
                       hidden)
               (magit-section-hide child)
             (magit-section-show child)))))
+    ;; Compatibility with `bookmark+' package.  See #4356.
+    (when (bound-and-true-p bmkp-jump-display-function)
+      (funcall bmkp-jump-display-function (current-buffer)))
     nil))
 
 (cl-defgeneric magit-bookmark-name ()

--- a/lisp/magit-bookmark.el
+++ b/lisp/magit-bookmark.el
@@ -40,7 +40,11 @@ Input values are the major-mode's `magit-bookmark-name' method,
 and the buffer-local values of the variables referenced in its
 `magit-bookmark-variables' property."
   (if (plist-member (symbol-plist major-mode) 'magit-bookmark-variables)
-      (let ((bookmark (bookmark-make-record-default 'no-file)))
+      ;; `bookmark-make-record-default's return value does not match
+      ;; (NAME . ALIST), even though it is used as the default value
+      ;; of `bookmark-make-record-function', which states that such
+      ;; functions must do that.  See #4356.
+      (let ((bookmark (cons nil (bookmark-make-record-default 'no-file))))
         (bookmark-prop-set bookmark 'handler  'magit--handle-bookmark)
         (bookmark-prop-set bookmark 'mode     major-mode)
         (bookmark-prop-set bookmark 'filename (magit-toplevel))


### PR DESCRIPTION
Currently there is an issue in both **creating** and **visiting** bookmarks for Magit buffers while using the Bookmark+ package. Upon investigation, a quick fix can be made that's compatible with both vanilla bookmarks and Bookmark+.

- Manually creating alist instead of using the (bookmark+ based)`bookmark-prop-set` function, which expects
    the bookmark to have the structure `(bookmark-name . alist)`, which is not ready yet at the time of that call.

- Explicitly calling bookmark+ jumping function. In bookmark+, custom handlers are expected to handle
   the buffer jumping.

After this PR was created, a patch was made to the bookmark+ package that solves the first issue. The original PR was composed of 2 fixes to the `magit-bookmark` file. I then forced pushed in order to have only the 2nd fix for the visiting issue. 