### PR TITLE
Run tests using both Git and libgit implementations in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ jobs:
         - 26.3
         - 27.1
         - snapshot
+        git_impl:
+        - git
+        - libgit
     steps:
     - uses: cachix/install-nix-action@v12
       with:
@@ -33,9 +36,11 @@ jobs:
         git config --global user.name "A U Thor"
         git config --global user.email a.u.thor@example.com
         git tag 0
-    - name: Compile
+    - name: Test with Git
+      if: ${{ matrix.git_impl == 'git' }}
       run: |
-        make lisp DASH_DIR=$PWD
-    - name: Test
+        make test-git DASH_DIR=$PWD
+    - name: Test with libgit
+      if: ${{ matrix.git_impl == 'libgit' }}
       run: |
-        make test DASH_DIR=$PWD
+        make test-libgit DASH_DIR=$PWD

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,5 @@
 name: test
 on: [ push, pull_request ]
-env:
-  CURL: "curl -fsSkL --retry 9 --retry-delay 9"
-  GHRAW: "https://raw.githubusercontent.com"
-  BUILD_MAGIT_LIBGIT: "false"
 jobs:
   test:
     runs-on: ubuntu-20.04
@@ -19,17 +15,21 @@ jobs:
         - 27.1
         - snapshot
     steps:
-    - uses: purcell/setup-emacs@master
+    - uses: cachix/install-nix-action@v12
       with:
-        version: ${{ matrix.emacs_version }}
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v8
+      with:
+        name: emacs-ci
     - uses: actions/checkout@v2
     - name: Install
       run: |
-        $CURL -O ${GHRAW}/magnars/dash.el/master/dash.el
-        $CURL -O ${GHRAW}/magit/transient/master/lisp/transient.el
-        $CURL -O ${GHRAW}/magit/with-editor/master/with-editor.el
-        emacs -Q --batch -L . -f batch-byte-compile dash.el transient.el with-editor.el
+        # Build and install Emacs (+ magit dependencies) using Nix
+        emacs_ci_version=$(echo "emacs-${{ matrix.emacs_version }}" | sed -e "s/\./-/g")
+        nix-env -f ./t/default.nix -iA $emacs_ci_version
         emacs --version
+
+        # Configure Git
         git config --global user.name "A U Thor"
         git config --global user.email a.u.thor@example.com
         git tag 0

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ help:
 	$(info ====)
 	$(info )
 	$(info make test             - run tests)
+	$(info make test-git         - run tests using Git functions)
+	$(info make test-libgit      - run tests using libgit functions)
 	$(info make test-interactive - run tests interactively)
 	$(info make emacs-Q          - run emacs -Q plus Magit)
 	$(info )
@@ -108,6 +110,27 @@ install-info: info
 test:
 	@$(BATCH) --eval "(progn\
         $$suppress_warnings\
+	(load-file \"t/magit-tests.el\")\
+	(ert-run-tests-batch-and-exit))"
+
+test-git:
+	@$(BATCH) --eval "(progn\
+        $$suppress_warnings\
+	(require 'magit)\
+	(setq magit-inhibit-libgit t)\
+	(unless (eq 'git (magit-gitimpl))\
+	  (message \"Git implementation not being used.\")\
+	  (kill-emacs 1))\
+	(load-file \"t/magit-tests.el\")\
+	(ert-run-tests-batch-and-exit))"
+
+test-libgit:
+	@$(BATCH) --eval "(progn\
+		$$suppress_warnings\
+	(require 'magit)\
+	(unless (eq 'libgit (magit-gitimpl))\
+	  (message \"libgit not available.\")\
+	  (kill-emacs 1))\
 	(load-file \"t/magit-tests.el\")\
 	(ert-run-tests-batch-and-exit))"
 

--- a/t/default.nix
+++ b/t/default.nix
@@ -1,0 +1,18 @@
+let
+  emacs-overlay = import (builtins.fetchTarball { url = https://github.com/nix-community/emacs-overlay/archive/master.tar.gz; });
+  emacs-ci = import (builtins.fetchTarball { url = https://github.com/purcell/nix-emacs-ci/archive/master.tar.gz; });
+
+  pkgs = import <nixpkgs> { overlays = [ emacs-overlay ]; };
+in
+builtins.mapAttrs
+  (version: emacs:
+    (pkgs.emacsPackagesGen emacs).emacsWithPackages
+      (emacsPackages: [
+        emacsPackages.dash
+        emacsPackages.transient
+      ] ++ (with emacsPackages.melpaPackages; [
+        libgit
+        with-editor
+      ])
+      ))
+  emacs-ci

--- a/t/magit-tests.el
+++ b/t/magit-tests.el
@@ -14,11 +14,11 @@
 
 (require 'magit)
 
-(defun magit-test-init-repo (dir)
+(defun magit-test-init-repo (dir &rest args)
   (let ((magit-git-global-arguments
          (nconc (list "-c" "init.defaultBranch=master")
                 magit-git-global-arguments)))
-    (magit-git "init" dir)))
+    (magit-git "init" args dir)))
 
 (defmacro magit-with-test-directory (&rest body)
   (declare (indent 0) (debug t))
@@ -38,6 +38,10 @@
 (defmacro magit-with-test-repository (&rest body)
   (declare (indent 0) (debug t))
   `(magit-with-test-directory (magit-test-init-repo ".") ,@body))
+
+(defmacro magit-with-bare-test-repository (&rest body)
+  (declare (indent 1) (debug t))
+  `(magit-with-test-directory (magit-test-init-repo "." "--bare") ,@body))
 
 ;;; Git
 
@@ -331,6 +335,18 @@ Enter passphrase for key '/home/user/.ssh/id_rsa': "
     (should (magit-test-get-section
              '(unpushed . "@{upstream}..")
              (magit-rev-parse "--short" "master")))))
+
+;;; libgit
+
+(ert-deftest magit-in-bare-repo ()
+  "Test `magit-bare-repo-p' in a bare repository."
+  (magit-with-bare-test-repository
+    (should (magit-bare-repo-p))))
+
+(ert-deftest magit-in-non-bare-repo ()
+  "Test `magit-bare-repo-p' in a non-bare repository."
+  (magit-with-test-repository
+    (should-not (magit-bare-repo-p))))
 
 ;;; Utils
 


### PR DESCRIPTION
- Add simple tests for `magit-bare-repo-p`, which is implemented with both Git and libgit.
- Install Emacs with libegit in CI via a custom Nix install.
- Run tests using both Git and libgit functions in CI by adding a `git_impl` dimension to the build matrix.