### PR TITLE
Support naming the primary (upstream) remote something other than "origin"

### DIFF
--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -193,11 +193,15 @@ Then show the status buffer for the new repository."
 
 (defun magit-clone-internal (repository directory args)
   (let* ((checkout (not (memq (car args) '("--bare" "--mirror"))))
+         (remote (or (transient-arg-value "--origin" args)
+                     (magit-get "clone.defaultRemote")
+                     "origin"))
          (set-push-default
           (and checkout
                (or (eq  magit-clone-set-remote.pushDefault t)
                    (and magit-clone-set-remote.pushDefault
-                        (y-or-n-p "Set `remote.pushDefault' to \"origin\"? "))))))
+                        (y-or-n-p (format "Set `remote.pushDefault' to %S? "
+                                          remote)))))))
     (run-hooks 'magit-credential-hook)
     (setq directory (file-name-as-directory (expand-file-name directory)))
     (when (file-exists-p directory)
@@ -225,9 +229,9 @@ Then show the status buffer for the new repository."
          (when checkout
            (let ((default-directory directory))
              (when set-push-default
-               (setf (magit-get "remote.pushDefault") "origin"))
+               (setf (magit-get "remote.pushDefault") remote))
              (unless magit-clone-set-remote-head
-               (magit-remote-unset-head "origin"))))
+               (magit-remote-unset-head remote))))
          (with-current-buffer (process-get process 'command-buf)
            (magit-status-setup-buffer directory)))))))
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1453,7 +1453,7 @@ according to the branch type."
       (when-let ((remotes (magit-list-remotes))
                  (remote (if (= (length remotes) 1)
                              (car remotes)
-                           (car (member "origin" remotes)))))
+                           (magit-primary-remote))))
         (magit--propertize-face remote 'magit-branch-remote))))
 
 (defun magit-get-push-remote (&optional branch)
@@ -1488,9 +1488,34 @@ according to the branch type."
   (or (magit-get-remote branch)
       (when-let ((main (magit-main-branch)))
         (magit-get-remote main))
-      (let ((remotes (magit-list-remotes)))
-        (or (car (member "origin" remotes))
-            (car remotes)))))
+      (magit-primary-remote)
+      (car (magit-list-remotes))))
+
+(defvar magit-primary-remote-names
+  '("upstream" "origin"))
+
+(defun magit-primary-remote ()
+  "Return the primary remote.
+
+The primary remote is the remote that tracks the repository that
+other repositories are forked from.  It often is called \"origin\"
+but because many people name their own fork \"origin\", using that
+term would be ambigious.  Likewise we avoid the term \"upstream\"
+because a branch's @{upstream} branch may be a local branch or a
+branch from a remote other than the primary remote.
+
+If a remote exists whose name matches `magit.primaryRemote', then
+that is considered the primary remote.  If no remote by that name
+exists, then remotes in `magit-primary-remote-names' are tried in
+order and the first remote from that list that actually exists in
+the current repository is considered its primary remote."
+  (let ((remotes (magit-list-remotes)))
+    (seq-find (lambda (name)
+                (member name remotes))
+              (delete-dups
+               (delq nil
+                     (cons (magit-get "magit.primaryRemote")
+                           magit-primary-remote-names))))))
 
 (defun magit-branch-merged-p (branch &optional target)
   "Return non-nil if BRANCH is merged into its upstream and TARGET.

--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -292,7 +292,7 @@ what this command will do.  For example:
   (let ((default (magit-get "push.default")))
     (unless (equal default "nothing")
       (or (when-let ((remote (or (magit-get-remote)
-                                 (magit-remote-p "origin")))
+                                 (magit-primary-remote)))
                      (refspec (magit-get "remote" remote "push")))
             (format "%s using %s"
                     (magit--propertize-face remote 'magit-branch-remote)


### PR DESCRIPTION
I am currently running a poll and early results indicate that I was wrong in assuming that the vast majority name the upstream (primary, original, official ...) remote "origin".  Many users call their own fork "origin" and it seems we can quite easily accommodate them.

I'll probably say more about this once the results are in but until then we can just silently make their lives a bit better.