### PR TITLE
Respect vc-tor when invoicing a subprocess

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -401,6 +401,9 @@ Process output goes into a new section in the buffer returned by
 Identical to `process-file' but temporarily enable Cygwin's
 \"noglob\" option during the call and ensure unix eol
 conversion."
+  (when (bound-and-true-p vc-tor)
+    (push process args)
+    (setq process "torsocks"))
   (when magit-process-extreme-logging
     (let ((inhibit-message t))
       (message "$ %s" (magit-process--format-arguments process args))))


### PR DESCRIPTION
The user option `vc-tor` was [added in Emacs 27.1](http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=626e0a6aad6b0f3c7348f37c9b2c9854b06b449b) that routes all VC commands through torsocks.

This patch makes magit check if the option exists and is enabled, in which case it replicates VC's behaviour.