### PR TITLE
magit-read-file-trace: By default, suggest to trace the evolution of …

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -579,11 +579,12 @@ the upstream isn't ahead of the current branch) show."
   :reader 'magit-read-file-trace)
 
 (defun magit-read-file-trace (&rest _ignored)
-  (let ((file  (magit-read-file-from-rev "HEAD" "File"))
-        (trace (magit-read-string
-                "Trace" nil nil
-                ;; By default, suggest to trace the evolution of the current line.
-                (concat (number-to-string (1+ (current-line))) ",+1"))))
+  (let* ((file  (magit-read-file-from-rev "HEAD" "File"))
+         (trace (magit-read-string
+                 "Trace" nil nil
+                 (if (string= file (magit-current-file))
+                     ;; Suggest to trace the evolution of the current line.
+                     (format "%i,+1" (line-number-at-pos))))))
     (concat trace ":" file)))
 
 ;;;; Setup Commands

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -580,7 +580,10 @@ the upstream isn't ahead of the current branch) show."
 
 (defun magit-read-file-trace (&rest _ignored)
   (let ((file  (magit-read-file-from-rev "HEAD" "File"))
-        (trace (magit-read-string "Trace")))
+        (trace (magit-read-string
+                "Trace" nil nil
+                ;; By default, suggest to trace the evolution of the current line.
+                (concat (number-to-string (1+ (current-line))) ",+1"))))
     (concat trace ":" file)))
 
 ;;;; Setup Commands


### PR DESCRIPTION
…the current line

----

Rationale: assumption that this is the most frequently use case for `magit-log`/`-L`. Otherwise, it is necessary to glance at the mode line to find out the current line and enter it manually, which is error prone (for me), especially with source files with line counts in the thousands.

So, in the sequence of keystrokes to trace the evolution of the current line,

1. `magit-log` (can be bound to a keystroke)
2. `-L`
3. (accept the default -- current file)
4. (find out the current line and enter it)
5. `l`

this turns point 4 into just pressing Enter.

On a general note: I haven't found anything in the documentation concerning how to make sequences of input events like these into single key chords. (If it's a short Lisp function, that would be fine too.) My assumption is just that you'd want in general to have frequently used features bound to shorter key sequences.

On a positive note: `magit-log`/`-L` is really, really useful to me. Thanks for all the effort!
