### PR TITLE
magit--maybe-update-revision-buffer: Honor log's file filter

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1364,9 +1364,8 @@ If there is no revision buffer in the same frame, then do nothing."
       (setq magit--update-revision-buffer (list commit buffer))
       (run-with-idle-timer
        magit-update-other-window-delay nil
-       (let ((args (with-current-buffer buffer
-                     (let ((magit-direct-use-buffer-arguments 'selected))
-                       (magit-show-commit--arguments)))))
+       (let ((args (let ((magit-direct-use-buffer-arguments 'selected))
+                     (magit-show-commit--arguments))))
          (lambda ()
            (pcase-let ((`(,rev ,buf) magit--update-revision-buffer))
              (setq magit--update-revision-buffer nil)


### PR DESCRIPTION
magit--maybe-update-revision-buffer sets up an idle timer function
that captures the result of calling magit-show-commit--arguments.
Before the call, the revision buffer is set as the current buffer.

Changing to the revision buffer interferes with toggling the file
restriction from the log buffer via magit-diff-toggle-file-filter.
The filter can be turned off, but, if the caller moves to another
line, the filter can't be turned back on again because, in order to
find the file arguments, magit-show-commit--arguments needs to be
called from the log buffer.

Call magit-show-commit--arguments without changing the buffer so that
the file arguments can still be grabbed from the magit-log-mode
buffer.  This shouldn't change the behavior in any other way because
underneath magit-diff-arguments handles finding the revision buffer
(and magit-direct-use-buffer-arguments is let-bound to `selected').

Re: #4382
