### PR TITLE
Fix git credential manager core by adding a newline to the chosen option

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -846,9 +846,10 @@ To use this function add it to the appropriate hook
   (and (string-match "^option (enter for default): $" string)
        (progn
          (magit-process-buffer)
-         (process-send-string
-          process
-          (format "%c" (read-char-choice "Option: " '(?\r ?\j ?1 ?2)))))))
+         (let ((option (format "%c\n"
+                               (read-char-choice "Option: " '(?\r ?\j ?1 ?2)))))
+           (insert-before-markers-and-inherit option)
+           (process-send-string process option)))))
 
 (defun magit-process-password-prompt (process string)
   "Find a password based on prompt STRING and send it to git.


### PR DESCRIPTION
fixes #4393

- Add a newline to the option user entered, so that it gets submitted to git prompt.
- Insert the option in the process buffer, so user sees what option was chosen. Also newline puts the next git message on a newline.

I tried using `magit-process-kill-on-abort`, so the git process gets killed when user cancels with `C-g`. But was unsuccessful. Canceling any of `Option` or `Token` prompts, do not kill the git process.