### PR TITLE
Snappy, speedy magit-list-repositories

### DIFF
--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -153,7 +153,7 @@ Each element of the list should be a CAR value of variable
                                    (memq v (mapcar 'car magit-repolist-styles)))))
   :group 'magit-repolist)
 
-(defvar-local magit-repolist-current-style (car magit-repolist-desired-styles))
+(defvar-local magit-repolist-current-style nil)
 
 (defvar magit-repolist-status-flag-alist
   '(("N" . magit-untracked-files)


### PR DESCRIPTION
The first time I evaluated function `magit-list-repositories' it took
so long (> 20 seconds) that I thought it had hung. This commit
addresses that and adds functionalities to the feature.

The code defines a user-configurable set of presentation styles and
defaults to one that has a very short response-time and that gives the
basic information to let the user decide which repository to jump to /
get the status of (the only major-mode-specific keybinding of the
result buffer).

A keybinding 'n' is configured to new function
`magit-list-repositories-next' which cycles through presentation
styles. The default configuration defines styles with 'quick'
response-times first. This new function can be used as a replacement
for `magit-list-repositories'.

A "working..." message is added to let the user know this operation
can take a while.

The default sort column for the result buffer was changed from
being hard-coded to being a defcustom. This was the only change
made to function `magit-repolist-mode'. FWIW, my opinion is that
the default should be "Name", not "Path": 1) Paths can be long, and their
most important (right-most) part is most likely to be truncated by the
buffer window width; 2) Duplicate names become easier to spot.

A new function `magit-repolist-column-flags' offers a column to
present all the flags of variable
`magit-repolist-column-flag-alist' instead of only the first, as
offered by the current function `magit-repolist-column-flag'.

A feature was added to the present style specification to allow the
column width field to be an expression that evaluates to a numeric
column width.

A follow-up commit could supplement function
`magit-repolist-column-flags' to include columns for stashes (heading
'z'), unpulled (heading '↓'), and unpushed (heading '↑'). For each
these, the actual value would be either: blank, for none; an integer
1-9; or '+' for greater than 9. I like this presentation
because it's horizontally compact.