### PR TITLE
magit-repolist-mode: configurable sort-column

### DIFF
--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -118,6 +118,13 @@ as the value of `magit-repolist-column-flag'."
   :type '(alist :key-type (function :tag "Predicate Function")
                 :value-type (string :tag "Flag")))
 
+(defcustom magit-repolist-sort-column "Name"
+ "Default sort column for function `magit-list-repositories'.
+This string should be the CAR of an entry in variable
+`magit-repolist-columns'."
+  :type 'string
+  :group 'magit-repolist)
+
 ;;; List Repositories
 ;;;; Command
 ;;;###autoload
@@ -159,9 +166,10 @@ repositories are displayed."
   (setq-local x-stretch-cursor  nil)
   (setq tabulated-list-padding  0)
   (setq tabulated-list-sort-key
-        (cons (or (car (assoc "Path" magit-repolist-columns))
+        (cons (or (car (assoc magit-repolist-sort-column
+                              magit-repolist-columns))
                   (caar magit-repolist-columns))
-              nil))
+                                nil))
   (setq tabulated-list-format
         (vconcat (mapcar (pcase-lambda (`(,title ,width ,_fn ,props))
                            (nconc (list title width t)


### PR DESCRIPTION
+ The default sort column for the result buffer was changed from being
  hard-coded to being a defcustom.

+ The default sor column was changed from "Path" to "Name"

  1) Paths can be long, and their most important (right-most) part is
     most likely to be truncated by the buffer window width;

  2) Duplicate names become easier to spot.

+ This is the first of several expected PR's to redo #4399 which
  included several things together.