### PR TITLE
Add message to indicate working in progress

### DIFF
--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -129,6 +129,7 @@ repositories are displayed."
   (interactive)
   (if magit-repository-directories
       (with-current-buffer (get-buffer-create "*Magit Repositories*")
+        (message "magit-list-repositories: working...")
         (magit-repolist-mode)
         (magit-repolist-refresh)
         (tabulated-list-print)


### PR DESCRIPTION
+ This is the second of several expected PR's to redo #4399 which
  included several things together.

+ The first time I evaluated function `magit-list-repositories' it took
  so long (> 20 seconds) that I thought it had hung. This commit
  is one step in addressing that in just simply letting the user know
  the operation may take a while.

  + A follow-up could be to set-up a timer to add a period every
    two-seconds until the operation is complete. I didn't include that
    in this commit because in the final product of #4399 the initial
    run of the command is so much speedier, but it could be done
    anyway.

  + A follow-up could be to figure out why the operation is so slow to
    begin with, but that wasn't the direction of #4399.