### PR TITLE
Fix magit-log-select-quit: actually call quit func

### DIFF
--- a/Documentation/RelNotes/3.1.0.org
+++ b/Documentation/RelNotes/3.1.0.org
@@ -13,3 +13,6 @@
 
 - A regression in v3.0.0 prevented ~magit-bisect-run~ from executing
   ~git bisect run~ unless ~magit-bisect-start~ was called beforehand.
+
+- ~magit-log-select-quit~ failed to call ~magit-log-select-quit-function~.
+  #4423

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1624,11 +1624,12 @@ commit as argument."
     (funcall fun rev)))
 
 (defun magit-log-select-quit ()
-  "Abort selecting a commit, don't act on any commit."
+  "Abort selecting a commit, don't act on any commit.
+Call `magit-log-select-quit-function' if set."
   (interactive)
-  (magit-mode-bury-buffer 'kill)
-  (when magit-log-select-quit-function
-    (funcall magit-log-select-quit-function)))
+  (let ((fun magit-log-select-quit-function))
+    (magit-mode-bury-buffer 'kill)
+    (when fun (funcall fun))))
 
 ;;; Cherry Mode
 


### PR DESCRIPTION
Unless I'm missing something, this is a rather trivial fix.

Since `magit-log-select-quit-function` is a buffer-local variable, killing the buffer then calling the function means that nothing is ever called. The quit function should be temporarily bound so it isn't lost.