### PR TITLE
magit-push-current-to-{upstream,pushremote}: Escape remote and branch names

### DIFF
--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -90,8 +90,10 @@ argument the push-remote can be changed before pushed to it."
                (magit--select-push-remote "push there")))
     (when changed
       (magit-confirm 'set-and-push
-        (format "Really use \"%s\" as push-remote and push \"%s\" there"
-                remote branch)))
+        (replace-regexp-in-string
+         "%" "%%"
+         (format "Really use \"%s\" as push-remote and push \"%s\" there"
+                 remote branch))))
     (run-hooks 'magit-credential-hook)
     (magit-run-git-async "push" "-v" args remote
                          (format "refs/heads/%s:refs/heads/%s"
@@ -150,8 +152,10 @@ the upstream."
           ;; is what the user wants to happen.
           (setq merge (concat "refs/heads/" merge)))
         (magit-confirm 'set-and-push
-          (format "Really use \"%s\" as upstream and push \"%s\" there"
-                  upstream branch)))
+          (replace-regexp-in-string
+           "%" "%%"
+           (format "Really use \"%s\" as upstream and push \"%s\" there"
+                   upstream branch))))
       (cl-pushnew "--set-upstream" args :test #'equal))
     (run-hooks 'magit-credential-hook)
     (magit-run-git-async "push" "-v" args remote (concat branch ":" merge))))


### PR DESCRIPTION
The branches and remote names are passed unescaped to `magit-confirm` from
`magit-push-current-to-{upstream,pushremote}`.  `magit-confirm` uses its
prompt as a format, which may cause an "Invalid format operation error" when
a branch or remote name contains a "%" character.

--

Magit 3.1.1, Git 2.32.0, Emacs 27.2, darwin

To reproduce on magit-push-current-to-upstream:

1. create branch: `b s` `test%branch`
2. try to push branch, creating upstream one: `P -n u` `origin/test%branch`

Similarly for magit-push-current-to-pushremote:

1. create remote: `M a` `test%remote` `https://localhost/` `n`
2. try to push branch, setting its pushremote: `P -n p` `test%remote`

 
Backtrace (`magit-push-current-to-upstream`):

```
Debugger entered--Lisp error: (error "Invalid format operation %b")
  format("Really use \"origin/test%branch\" as upstream and push \"test%branch\" there? " 0)
  (setq prompt-n (format (concat (or prompt-n prompt) "? ") (length items)))
  (progn (setq prompt-n (format (concat (or prompt-n prompt) "? ") (length items))) (setq prompt (format (concat (or prompt (magit-confirm-make-prompt action)) "? ") (car items))) (or (cond ((and (not (eq action t)) (or (eq magit-no-confirm t) (memq action magit-no-confirm) (cl-member-if #'... magit--no-confirm-alist))) (or (not sitems) items)) ((not sitems) (magit-y-or-n-p prompt action)) ((= (length items) 1) (and (magit-y-or-n-p prompt action) items)) ((> (length items) 1) (and (magit-y-or-n-p (concat (mapconcat ... items "\n") "\n\n" prompt-n) action) items))) (if noabort nil (user-error "Abort"))))
  (progn (if --cl-rest-- (signal 'wrong-number-of-arguments (list 'magit-confirm (+ 5 (length --cl-rest--))))) (progn (setq prompt-n (format (concat (or prompt-n prompt) "? ") (length items))) (setq prompt (format (concat (or prompt (magit-confirm-make-prompt action)) "? ") (car items))) (or (cond ((and (not (eq action t)) (or (eq magit-no-confirm t) (memq action magit-no-confirm) (cl-member-if ... magit--no-confirm-alist))) (or (not sitems) items)) ((not sitems) (magit-y-or-n-p prompt action)) ((= (length items) 1) (and (magit-y-or-n-p prompt action) items)) ((> (length items) 1) (and (magit-y-or-n-p (concat ... "\n\n" prompt-n) action) items))) (if noabort nil (user-error "Abort")))))
  (let* ((sitems (and --cl-rest-- t)) (items (car-safe (prog1 --cl-rest-- (setq --cl-rest-- (cdr --cl-rest--)))))) (progn (if --cl-rest-- (signal 'wrong-number-of-arguments (list 'magit-confirm (+ 5 (length --cl-rest--))))) (progn (setq prompt-n (format (concat (or prompt-n prompt) "? ") (length items))) (setq prompt (format (concat (or prompt (magit-confirm-make-prompt action)) "? ") (car items))) (or (cond ((and (not ...) (or ... ... ...)) (or (not sitems) items)) ((not sitems) (magit-y-or-n-p prompt action)) ((= (length items) 1) (and (magit-y-or-n-p prompt action) items)) ((> (length items) 1) (and (magit-y-or-n-p ... action) items))) (if noabort nil (user-error "Abort"))))))
  magit-confirm(set-and-push "Really use \"origin/test%branch\" as upstream and pu...")
  (let* ((branches (-union (mapcar #'(lambda (it) (ignore it) (concat it "/" branch)) (magit-list-remotes)) (magit-list-remote-branch-names))) (upstream (magit-completing-read (format "Set upstream of %s and push there" branch) branches nil nil nil 'magit-revision-history (or (car (member (magit-remote-branch-at-point) branches)) (car (member "origin/master" branches))))) (upstream* (or (magit-get-tracked upstream) (magit-split-branch-name upstream)))) (setq remote (car upstream*)) (setq merge (cdr upstream*)) (if (string-prefix-p "refs/" merge) nil (setq merge (concat "refs/heads/" merge))) (magit-confirm 'set-and-push (format "Really use \"%s\" as upstream and push \"%s\" there" upstream branch)))
  (progn (let* ((branches (-union (mapcar #'(lambda ... ... ...) (magit-list-remotes)) (magit-list-remote-branch-names))) (upstream (magit-completing-read (format "Set upstream of %s and push there" branch) branches nil nil nil 'magit-revision-history (or (car (member ... branches)) (car (member "origin/master" branches))))) (upstream* (or (magit-get-tracked upstream) (magit-split-branch-name upstream)))) (setq remote (car upstream*)) (setq merge (cdr upstream*)) (if (string-prefix-p "refs/" merge) nil (setq merge (concat "refs/heads/" merge))) (magit-confirm 'set-and-push (format "Really use \"%s\" as upstream and push \"%s\" there" upstream branch))) (setq args (if (member "--set-upstream" args) args (cons "--set-upstream" args))))
  (if (or current-prefix-arg (not (or (magit-get-upstream-branch branch) (magit--unnamed-upstream-p remote merge) (magit--valid-upstream-p remote merge)))) (progn (let* ((branches (-union (mapcar #'... (magit-list-remotes)) (magit-list-remote-branch-names))) (upstream (magit-completing-read (format "Set upstream of %s and push there" branch) branches nil nil nil 'magit-revision-history (or (car ...) (car ...)))) (upstream* (or (magit-get-tracked upstream) (magit-split-branch-name upstream)))) (setq remote (car upstream*)) (setq merge (cdr upstream*)) (if (string-prefix-p "refs/" merge) nil (setq merge (concat "refs/heads/" merge))) (magit-confirm 'set-and-push (format "Really use \"%s\" as upstream and push \"%s\" there" upstream branch))) (setq args (if (member "--set-upstream" args) args (cons "--set-upstream" args)))))
  (let* ((branch (or (magit-get-current-branch) (user-error "No branch is checked out"))) (remote (magit-get "branch" branch "remote")) (merge (magit-get "branch" branch "merge"))) (if (or current-prefix-arg (not (or (magit-get-upstream-branch branch) (magit--unnamed-upstream-p remote merge) (magit--valid-upstream-p remote merge)))) (progn (let* ((branches (-union (mapcar ... ...) (magit-list-remote-branch-names))) (upstream (magit-completing-read (format "Set upstream of %s and push there" branch) branches nil nil nil 'magit-revision-history (or ... ...))) (upstream* (or (magit-get-tracked upstream) (magit-split-branch-name upstream)))) (setq remote (car upstream*)) (setq merge (cdr upstream*)) (if (string-prefix-p "refs/" merge) nil (setq merge (concat "refs/heads/" merge))) (magit-confirm 'set-and-push (format "Really use \"%s\" as upstream and push \"%s\" there" upstream branch))) (setq args (if (member "--set-upstream" args) args (cons "--set-upstream" args))))) (run-hooks 'magit-credential-hook) (magit-run-git-async "push" "-v" args remote (concat branch ":" merge)))
  magit-push-current-to-upstream(nil)
  funcall-interactively(magit-push-current-to-upstream nil)
  call-interactively(magit-push-current-to-upstream nil nil)
  command-execute(magit-push-current-to-upstream)
```