### PR TITLE
magit-blame: Add --first-parent

### DIFF
--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -895,6 +895,7 @@ instead of the hash, like `kill-ring-save' would."
   ["Arguments"
    ("-w" "Ignore whitespace" "-w")
    ("-r" "Do not treat root commits as boundaries" "--root")
+   ("-P" "Follow only first parent" "--first-parent")
    (magit-blame:-M)
    (magit-blame:-C)]
   ["Actions"


### PR DESCRIPTION
Passing the --first-parent option to git-blame(1) will make git only
follow the first parent commit upon seeing a merge commit. This option
can be used to determine when a line was introduced to a particular
integration branch, rather than when it was introduced to the history
overall.
