### PR TITLE
magit-extras: Check that `project-switch-commands' is defined

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -157,6 +157,7 @@ to nil before loading Magit to prevent \"m\" from being bound.")
   ;; `project-switch-commands', though project.el is available in Emacs 25.
   (when (and magit-bind-magit-project-status
              (boundp 'project-prefix-map)
+             (boundp 'project-switch-commands)
              ;; Only modify if it hasn't already been modified.
              (equal project-switch-commands
                     (eval (car (get 'project-switch-commands 'standard-value))


### PR DESCRIPTION
This works around old versions of `project.el`.