### PR TITLE
magit-diff-wash-diff: Fix handling of file names with spaces

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2216,15 +2216,18 @@ section or a child thereof."
       (when file (setq file (magit-decode-git-path file)))
       (magit-diff-insert-file-section
        (or file base) orig status nil nil nil long-status)))
+   ;; The files on this line may be ambigious due to whitespace.
+   ;; That's okay. We can get their names from subsequent headers.
    ((looking-at "^diff --\
-\\(?:\\(?1:git\\) \\(?:\\(?2:.+?\\) \\(?3:.+?\\)\\)?\
-\\|\\(?:cc\\|combined\\) \\(?4:.+\\)\\)\n")
+\\(?:\\(?1:git\\) \\(?:\\(?2:.+?\\) \\2\\)?\
+\\|\\(?:cc\\|combined\\) \\(?3:.+\\)\\)")
     (let ((status (cond ((equal (match-string 1) "git")        "modified")
                         ((derived-mode-p 'magit-revision-mode) "resolved")
                         (t                                     "unmerged")))
-          (orig (match-string 2))
-          (file (or (match-string 3) (match-string 4)))
-          (header (list (match-string 0)))
+          (orig nil)
+          (file (or (match-string 2) (match-string 3)))
+          (header (list (buffer-substring-no-properties
+                         (line-beginning-position) (1+ (line-end-position)))))
           (modes nil)
           (rename nil))
       (magit-delete-line)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2227,12 +2227,6 @@ section or a child thereof."
           (header (list (match-string 0)))
           (modes nil)
           (rename nil))
-      ;; `git-diff' ignores `--no-prefix' for new files and renames at least.
-      (when (and file orig
-                 (string-prefix-p "a/" orig)
-                 (string-prefix-p "b/" file))
-        (setq orig (substring orig 2))
-        (setq file (substring file 2)))
       (magit-delete-line)
       (while (not (or (eobp) (looking-at magit-diff-headline-re)))
         (cond
@@ -2275,9 +2269,14 @@ section or a child thereof."
       (when orig
         (setq orig (magit-decode-git-path orig)))
       (setq file (magit-decode-git-path file))
-      ;; KLUDGE `git-log' ignores `--no-prefix' when `-L' is used.
-      (when (and (derived-mode-p 'magit-log-mode)
-                 (--first (string-match-p "\\`-L" it) magit-buffer-log-args))
+      ;; KLUDGE `git-diff' ignores `--no-prefix' for new files and renames at
+      ;; least.  And `git-log' ignores `--no-prefix' when `-L' is used.
+      (when (or (and file orig
+                     (string-prefix-p "a/" orig)
+                     (string-prefix-p "b/" file))
+                (and (derived-mode-p 'magit-log-mode)
+                     (--first (string-match-p "\\`-L" it)
+                              magit-buffer-log-args)))
         (setq file (substring file 2))
         (when orig
           (setq orig (substring orig 2))))


### PR DESCRIPTION
This is a follow-up to the discussion in <https://github.com/magit/magit/commit/d477163d34a22ff7a30597d0fbc70f62355bceff#commitcomment-53563206>.  The second commit has the main fix.

Below are some cases I considered while working on this.

<details>
<summary>test cases</summary>

Cases tests with master (877f7140) and this PR.

### failures on master

---

```sh
cd $(mktemp --tmpdir -d magit-XXXXX)

fname='foo bar'

git init
echo a >"$fname"
git add "$fname"
```

master: has rename marker with nonsense file name
pr: expected

---

```sh
cd $(mktemp --tmpdir -d magit-XXXXX)

fname='foo bar'

git init
echo a >"$fname"
git add "$fname"
git commit -m'c1'

git rm "$fname"
```


master: has rename marker with nonsense file name
pr: expected

---

```sh
cd $(mktemp --tmpdir -d magit-XXXXX)

fname='foo β'

git init
echo a >"$fname"
git add "$fname"
```

master: errors due to `magit-decode-git-path` parse error
pr: no error

---

### other checks on PR

```sh
cd $(mktemp --tmpdir -d magit-XXXXX)

fname='foo'

git init
echo a >"$fname"
git add "$fname"
git commit -mc1

chmod +x "$fname"
echo a >>"$fname"
git add "$fname"
```

---

```sh
cd $(mktemp --tmpdir -d magit-XXXXX)

fname='foo'

git init
echo a >"$fname"
git add "$fname"
git commit -mc1

echo a >>"$fname"
git add "$fname"
git mv "$fname" bar
```

Can unstage rename and modification separately.

---

```sh
cd $(mktemp --tmpdir -d magit-XXXXX)

fname='foo'

git init
echo a >"$fname"
git add "$fname"
git commit -mc1

chmod +x "$fname"
git add "$fname"
git mv "$fname" bar
```

Both master and pr fail with "git diff header lacks filename information when removing 0 leading pathname components".

---

```sh
cd $(mktemp --tmpdir -d magit-XXXXX)

fname='foo β'

git init
printf '\0' >"$fname"
git add "$fname"
```

</details>
