### PR TITLE
magit-repolist-sort-reverse: New option

### DIFF
--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -131,6 +131,12 @@ This has to be the key of an entry in `magit-repolist-columns'."
   :group 'magit-repolist
   :type 'string)
 
+(defcustom magit-repolist-sort-reverse nil
+  "Whether `magit-list-repositories' initially sorts in reverse order."
+  :package-version '(magit . "3.2.0")
+  :group 'magit-repolist
+  :type 'boolean)
+
 ;;; List Repositories
 ;;;; Command
 ;;;###autoload
@@ -183,7 +189,7 @@ repositories are displayed."
         (cons (or (car (assoc magit-repolist-sort-column
                               magit-repolist-columns))
                   (caar magit-repolist-columns))
-              nil))
+              magit-repolist-sort-reverse))
   (setq tabulated-list-format
         (vconcat (mapcar (pcase-lambda (`(,title ,width ,_fn ,props))
                            (nconc (list title width t)


### PR DESCRIPTION
This PR is a complement of the commit 7f666751c0226f37a65f3e9d7dba4c02aa3c252f to be able to reverse the sort order.

For exemple : to have repositories with the most local changes unpushed to upstream at the top of the list, you need to set `magit-repolist-sort-column` to "B>U" and reverse the result. But there is no option to do the reverse.

The implementation is very simple: it just change the cdr of the `tabulated-list-sort-key` variable. According to the documentation of this variable, that's the way to reverse the sort order.