### PR TITLE
magit-version: more flexible for magit.el not exists (magit.el.gz and magit.elc exists)

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -478,8 +478,10 @@ and Emacs to it."
         (toplib (or load-file-name buffer-file-name))
         debug)
     (unless (and toplib
-                 (equal (file-name-nondirectory toplib) "magit.el"))
-      (setq toplib (locate-library "magit.el")))
+                 (equal (file-name-sans-extension
+                         (file-name-nondirectory toplib))
+                        "magit"))
+      (setq toplib (locate-library "magit")))
     (setq toplib (and toplib (magit--straight-chase-links toplib)))
     (push toplib debug)
     (when toplib


### PR DESCRIPTION
Empty result from function `magit-version` when magit is distributed with `*.elc` and `*.el.gz` without `*.el`.

This PR try to make `magit-version` work with this situation.