### PR TITLE
magit-wip-commit-worktree: Filter out directories

### DIFF
--- a/lisp/magit-wip.el
+++ b/lisp/magit-wip.el
@@ -287,30 +287,35 @@ commit message."
     (magit-wip-update-wipref ref wipref tree parent files msg "index")))
 
 (defun magit-wip-commit-worktree (ref files msg)
-  (let* ((wipref (magit--wip-wtree-ref ref))
-         (parent (magit-wip-get-parent ref wipref))
-         (tree (magit-with-temp-index parent (list "--reset" "-i")
-                 (if files
-                     ;; Note: `update-index' is used instead of `add'
-                     ;; because `add' will fail if a file is already
-                     ;; deleted in the temporary index.
-                     (magit-call-git
-                      "update-index" "--add" "--remove"
-                      (and (pcase (magit-repository-local-get
-                                   'update-index-has-ignore-sw-p 'unset)
-                             (`unset
-                              (let ((val (version<= "2.25.0"
-                                                    (magit-git-version))))
-                                (magit-repository-local-set
-                                 'update-index-has-ignore-sw-p val)
-                                val))
-                             (val val))
-                           "--ignore-skip-worktree-entries")
-                      "--" files)
-                   (magit-with-toplevel
-                     (magit-call-git "add" "-u" ".")))
-                 (magit-git-string "write-tree"))))
-    (magit-wip-update-wipref ref wipref tree parent files msg "worktree")))
+  (when (or (not files)
+            ;; `update-index' will either ignore (before Git v2.32.0)
+            ;; or fail when passed directories (relevant for the
+            ;; untracked files code paths).
+            (setq files (seq-remove #'file-directory-p files)))
+    (let* ((wipref (magit--wip-wtree-ref ref))
+           (parent (magit-wip-get-parent ref wipref))
+           (tree (magit-with-temp-index parent (list "--reset" "-i")
+                   (if files
+                       ;; Note: `update-index' is used instead of `add'
+                       ;; because `add' will fail if a file is already
+                       ;; deleted in the temporary index.
+                       (magit-call-git
+                        "update-index" "--add" "--remove"
+                        (and (pcase (magit-repository-local-get
+                                     'update-index-has-ignore-sw-p 'unset)
+                               (`unset
+                                (let ((val (version<= "2.25.0"
+                                                      (magit-git-version))))
+                                  (magit-repository-local-set
+                                   'update-index-has-ignore-sw-p val)
+                                  val))
+                               (val val))
+                             "--ignore-skip-worktree-entries")
+                        "--" files)
+                     (magit-with-toplevel
+                       (magit-call-git "add" "-u" ".")))
+                   (magit-git-string "write-tree"))))
+      (magit-wip-update-wipref ref wipref tree parent files msg "worktree"))))
 
 (defun magit-wip-update-wipref (ref wipref tree parent files msg start-msg)
   (cond


### PR DESCRIPTION
```
When magit-wip-commit-worktree receives a non-nil FILES argument, it
feeds the result to update-index.  If triggered by operating on items
in the untracked section, FILES may contain directories.  In this
case, the update-index call ignores directories but succeeds:

  $ git status -s
  ?? d/
  ?? f1
  $ git update-index --add -- f1 d/
  Ignoring path d/
  $ git status -s
  A  f1
  ?? d/

Ignoring directories seems acceptable because 1) when staging with the
composite wip modes, directory files are subsequently captured by the
post-stage magit-wip-commit-index call and 2) the documentation
explicitly says untracked files are not covered by wip modes (which is
particularly relevant when discarding untracked changes).

However, as of Git v2.32.0, specifically 6e773527b6 (sparse-index:
convert from full to sparse, 2021-03-30), update-index errors instead:

  $ git update-index --add -- f1 d/
  error: d/: is a directory - add files inside instead
  fatal: Unable to process path d/
  $ git status -s
  ?? d/
  ?? f1

One solution would be to go back to `git add', but that would bring
back the issue resolved by the switch to update-index in 57f2d0f8
(magit-wip-commit-worktree: Avoid failing git call on file deletion,
2020-02-08).

Instead restore the pre Git v2.32 behavior by removing directories
from FILES.  The only functional difference is that, when the FILES
argument passed to magit-wip-commit-worktree includes both directories
and non-directories, the message created downstream by
magit-wip-update-wipref is now more accurate because its FILES
argument includes only non-directories.
```