### PR TITLE
Added goto-address-mode to magit-process-mode

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -286,6 +286,7 @@ Used when `magit-process-display-mode-line-error' is non-nil."
   "Mode for looking at Git process output."
   :group 'magit-process
   (hack-dir-local-variables-non-file-buffer)
+  (goto-address-mode)
   (setq imenu-prev-index-position-function
         'magit-imenu--process-prev-index-position-function)
   (setq imenu-extract-index-name-function


### PR DESCRIPTION
### What ? 
Enable recognition of hyperlinks in magit-process buffers.

### Why ?
This is especially useful after pushing a new branch on the remote server, since `git` logs the URL needed to create the Pull Request. With this minor mode, you can directly click on the PR-creation link, and win some seconds of copy-pasting the URLs returned by git from Emacs to your browser.

### Example
![image](https://user-images.githubusercontent.com/34691216/139142559-4ab7ef72-79a9-403e-a732-ac1b66cf7ce3.png)
