### PR TITLE
fix filename converter for tramp in Windows

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1028,9 +1028,9 @@ Sorted from longest to shortest CYGWIN name."
                 (cl-rassoc filename magit-cygwin-mount-points
                            :test (lambda (f win) (string-prefix-p win f))))
           (concat cyg (substring filename (length win)))
-        (expand-file-name
-         (or (file-remote-p filename 'localname)
-             filename)))
+        (let ((expanded (expand-file-name filename)))
+          (or (file-remote-p expanded 'localname)
+              expanded)))
     filename))
 
 (defun magit-decode-git-path (path)


### PR DESCRIPTION
For tramp in Windows, expanding the file name first before to get the local
name. Otherwise "c:" will be added to the filename.

For example, "/plink:user@host:~/R/" should be converted as
"/home/R/" and not "c:/home/R/"

Signed-off-by: Shuguang Sun <shuguang79@qq.com>
