### PR TITLE
Update manual to use updated ox-texinfo

### DIFF
--- a/default.mk
+++ b/default.mk
@@ -218,7 +218,6 @@ endif # ifndef LOAD_PATH
 ifndef ORG_LOAD_PATH
 ORG_LOAD_PATH  = $(LOAD_PATH)
 ORG_LOAD_PATH += -L ../../org/lisp
-ORG_LOAD_PATH += -L ../../ox-texinfo+
 endif
 
 ## Publish ###########################################################

--- a/docs/.orgconfig
+++ b/docs/.orgconfig
@@ -3,8 +3,8 @@
 #+options: H:4 num:3 toc:2
 #+property: header-args :eval never
 
-#+texinfo_deffn: t
+#+macro: kbd (eval (let ((case-fold-search nil) (regexp (regexp-opt '("SPC" "RET" "LFD" "TAB" "BS" "ESC" "DELETE" "SHIFT" "Ctrl" "Meta" "Alt" "Cmd" "Super" "UP" "LEFT" "RIGHT" "DOWN") 'words))) (format "@@texinfo:@kbd{@@%s@@texinfo:}@@" (replace-regexp-in-string regexp "@@texinfo:@key{@@\\&@@texinfo:}@@" $1 t))))
 #+macro: year (eval (format-time-string "%Y"))
-#+macro: version (eval (ox-texinfo+-get-version 'mixed))
+#+macro: version (eval (or (getenv "PACKAGE-VERSION") (ignore-errors (car (process-lines "git" "describe" "--exact"))) (ignore-errors (concat (car (process-lines "git" "describe" (if (getenv "AMEND") "HEAD~" "HEAD"))) "+1"))))
 
 #+language: en

--- a/docs/.orgconfig
+++ b/docs/.orgconfig
@@ -1,0 +1,10 @@
+# -*- mode:org -*-
+
+#+options: H:4 num:3 toc:2
+#+property: header-args :eval never
+
+#+texinfo_deffn: t
+#+macro: year (eval (format-time-string "%Y"))
+#+macro: version (eval (ox-texinfo+-get-version 'mixed))
+
+#+language: en

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -86,9 +86,8 @@ clean-stats:
 
 ## Release management ################################################
 
-ORG_ARGS  = --batch -Q $(ORG_LOAD_PATH) -l ox-texinfo+
+ORG_ARGS  = --batch -Q $(ORG_LOAD_PATH)
 ORG_ARGS += -l magit-utils -l ol-man
-ORG_EVAL  = --eval "(setq org-texinfo+-dissolve-noexport-headlines t)"
 ORG_EVAL += --eval "(setq indent-tabs-mode nil)"
 ORG_EVAL += --eval "(setq org-src-preserve-indentation nil)"
 ORG_EVAL += --funcall org-texinfo-export-to-texinfo

--- a/docs/magit-section.org
+++ b/docs/magit-section.org
@@ -52,7 +52,6 @@ When the documentation leaves something unaddressed, then please
 consider that Magit uses this library extensively and search its
 source for suitable examples before asking me for help.  Thanks!
 
-
 * Creating Sections
 
 - Macro: magit-insert-section [name] (type &optional value hide) &rest body ::

--- a/docs/magit-section.org
+++ b/docs/magit-section.org
@@ -272,7 +272,6 @@ General Public License for more details.
 # Local Variables:
 # eval: (require 'magit-utils nil t)
 # eval: (require 'ol-man      nil t)
-# eval: (require 'ox-texinfo+ nil t)
 # indent-tabs-mode: nil
 # org-src-preserve-indentation: nil
 # End:

--- a/docs/magit-section.org
+++ b/docs/magit-section.org
@@ -3,18 +3,13 @@
 #+author: Jonas Bernoulli
 #+email: jonas@bernoul.li
 #+date: 2015-{{{year}}}
-#+language: en
 
 #+texinfo_dir_category: Emacs
 #+texinfo_dir_title: Magit-Section: (magit-section).
 #+texinfo_dir_desc: Use Magit sections in your own packages.
 #+subtitle: for version {{{version}}}
 
-#+texinfo_deffn: t
-#+options: H:4 num:3 toc:2
-#+property: header-args :eval never
-#+macro: version (eval (ox-texinfo+-get-version 'mixed))
-#+macro: year (eval (format-time-string "%Y"))
+#+setupfile: .orgconfig
 
 This package implements the main user interface of Magit — the
 collapsible sections that make up its buffers.  This package used

--- a/docs/magit-section.org
+++ b/docs/magit-section.org
@@ -55,7 +55,7 @@ source for suitable examples before asking me for help.  Thanks!
 
 * Creating Sections
 
-- Macro: magit-insert-section [name] (type &optional value hide) &rest body
+- Macro: magit-insert-section [name] (type &optional value hide) &rest body ::
 
   Create a section object of type CLASS, storing VALUE in its
   ~value~ slot, and insert the section at point.  CLASS is a
@@ -99,7 +99,7 @@ source for suitable examples before asking me for help.  Thanks!
   a section by washing Git's output and Git didn't actually output
   anything this time around.
 
-- Function: magit-insert-heading &rest args
+- Function: magit-insert-heading &rest args ::
 
   Insert the heading for the section currently being inserted.
 
@@ -128,19 +128,19 @@ source for suitable examples before asking me for help.  Thanks!
   getting it right.  The only exception is that this function does
   insert a newline character if necessary.
 
-- Macro: magit-insert-section-body &rest body
+- Macro: magit-insert-section-body &rest body ::
 
   Use BODY to insert the section body, once the section is expanded.
   If the section is expanded when it is created, then this is
   like ~progn~.  Otherwise BODY isn't evaluated until the section
   is explicitly expanded.
 
-- Function: magit-cancel-section
+- Function: magit-cancel-section ::
 
   Cancel inserting the section that is currently being inserted.
   Remove all traces of that section.
 
-- Function: magit-wash-sequence function
+- Function: magit-wash-sequence function ::
 
   Repeatedly call FUNCTION until it returns ~nil~ or the end of the
   buffer is reached.  FUNCTION has to move point forward or return
@@ -148,16 +148,16 @@ source for suitable examples before asking me for help.  Thanks!
 
 * Core Functions
 
-- Function: magit-current-section
+- Function: magit-current-section ::
 
   Return the section at point.
 
-- Function: magit-section-ident section
+- Function: magit-section-ident section ::
 
   Return an unique identifier for SECTION. The return value has the
   form ~((TYPE . VALUE)...)~.
 
-- Function: magit-section-ident-value value
+- Function: magit-section-ident-value value ::
 
   Return a constant representation of VALUE.
 
@@ -169,21 +169,21 @@ source for suitable examples before asking me for help.  Thanks!
   catch-all method is used, which just returns the argument
   itself.
 
-- Function: magit-get-section ident &optional root
+- Function: magit-get-section ident &optional root ::
 
   Return the section identified by IDENT.
   IDENT has to be a list as returned by ~magit-section-ident~.
   If optional ROOT is non-nil, then search in that section tree
   instead of in the one whose root ~magit-root-section~ is.
 
-- Function: magit-section-lineage section
+- Function: magit-section-lineage section ::
 
   Return the lineage of SECTION.
   The return value has the form ~(TYPE...)~.
 
 * Matching Functions
 
-- Function: magit-section-match condition &optional (section (magit-current-section))
+- Function: magit-section-match condition &optional (section (magit-current-section)) ::
 
   Return t if SECTION matches CONDITION.
 
@@ -217,7 +217,7 @@ source for suitable examples before asking me for help.  Thanks!
   lineage as printed by ~magit-describe-section-briefly~, unless
   of course you want to be that precise.
 
-- Function: magit-section-value-if condition &optional section
+- Function: magit-section-value-if condition &optional section ::
 
   If the section at point matches CONDITION, then return its value.
 
@@ -228,7 +228,7 @@ source for suitable examples before asking me for help.  Thanks!
 
   See ~magit-section-match~ for the forms CONDITION can take.
 
-- Macro: magit-section-case &rest clauses
+- Macro: magit-section-case &rest clauses ::
 
   Choose among clauses on the type of the section at point.
 

--- a/docs/magit-section.org
+++ b/docs/magit-section.org
@@ -1,20 +1,20 @@
-#+TITLE: Magit-Section Developer Manual
+#+title: Magit-Section Developer Manual
 :PREAMBLE:
-#+AUTHOR: Jonas Bernoulli
-#+EMAIL: jonas@bernoul.li
-#+DATE: 2015-{{{year}}}
-#+LANGUAGE: en
+#+author: Jonas Bernoulli
+#+email: jonas@bernoul.li
+#+date: 2015-{{{year}}}
+#+language: en
 
-#+TEXINFO_DIR_CATEGORY: Emacs
-#+TEXINFO_DIR_TITLE: Magit-Section: (magit-section).
-#+TEXINFO_DIR_DESC: Use Magit sections in your own packages.
-#+SUBTITLE: for version {{{version}}}
+#+texinfo_dir_category: Emacs
+#+texinfo_dir_title: Magit-Section: (magit-section).
+#+texinfo_dir_desc: Use Magit sections in your own packages.
+#+subtitle: for version {{{version}}}
 
-#+TEXINFO_DEFFN: t
-#+OPTIONS: H:4 num:3 toc:2
-#+PROPERTY: header-args :eval never
-#+MACRO: version (eval (ox-texinfo+-get-version 'mixed))
-#+MACRO: year (eval (format-time-string "%Y"))
+#+texinfo_deffn: t
+#+options: H:4 num:3 toc:2
+#+property: header-args :eval never
+#+macro: version (eval (ox-texinfo+-get-version 'mixed))
+#+macro: year (eval (format-time-string "%Y"))
 
 This package implements the main user interface of Magit — the
 collapsible sections that make up its buffers.  This package used
@@ -25,10 +25,10 @@ To learn more about the section abstraction and available commands and
 user options see [[info:magit#Sections]].  This manual documents how you
 can use sections in your own packages.
 
-#+TEXINFO: @noindent
+#+texinfo: @noindent
 This manual is for Magit-Section version {{{version}}}.
 
-#+BEGIN_QUOTE
+#+begin_quote
 Copyright (C) 2015-{{{year}}} Jonas Bernoulli <jonas@bernoul.li>
 
 You can redistribute this document and/or modify it under the terms
@@ -40,7 +40,7 @@ This document is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
-#+END_QUOTE
+#+end_quote
 :END:
 * Introduction
 
@@ -254,7 +254,7 @@ source for suitable examples before asking me for help.  Thanks!
 :COPYING:    t
 :END:
 
-#+BEGIN_QUOTE
+#+begin_quote
 Copyright (C) 2015-{{{year}}} Jonas Bernoulli <jonas@bernoul.li>
 
 You can redistribute this document and/or modify it under the terms
@@ -266,7 +266,7 @@ This document is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
-#+END_QUOTE
+#+end_quote
 
 #  LocalWords:  ARGS CONDITIONs EVAL Git Git's IDENT
 #  LocalWords:  LocalWords MERCHANTABILITY Magit Makefile

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -385,7 +385,7 @@ the user invokes Git commands, or creates or visits other buffers.
 In this manual we often speak about "Magit buffers".  By that we mean
 buffers whose major-modes derive from ~magit-mode~.
 
-- Key: M-x magit-toggle-buffer-lock (magit-toggle-buffer-lock) ::
+- Key: M-x magit-toggle-buffer-lock ::
 
   This command locks the current buffer to its value or if the buffer
   is already locked, then it unlocks it.
@@ -1027,16 +1027,16 @@ but all you need to get started are the next two.
   Cycle the visibility of all sections in the current buffer.
 
 - Key: 1 (magit-section-show-level-1) ::
-- Key: 2 (magit-section-show-level-2) ::
-- Key: 3 (magit-section-show-level-3) ::
-- Key: 4 (magit-section-show-level-4) ::
++ Key: 2 (magit-section-show-level-2) ::
++ Key: 3 (magit-section-show-level-3) ::
++ Key: 4 (magit-section-show-level-4) ::
 
   Show sections surrounding the current section up to level N.
 
 - Key: M-1 (magit-section-show-level-1-all) ::
-- Key: M-2 (magit-section-show-level-2-all) ::
-- Key: M-3 (magit-section-show-level-3-all) ::
-- Key: M-4 (magit-section-show-level-4-all) ::
++ Key: M-2 (magit-section-show-level-2-all) ::
++ Key: M-3 (magit-section-show-level-3-all) ::
++ Key: M-4 (magit-section-show-level-4-all) ::
 
   Show all sections up to level N.
 
@@ -1879,7 +1879,7 @@ switch to a shell.
   for the command.  It can be removed to run another command.
 
 - Key: : (magit-git-command) ::
-- Key: ! p (magit-git-command) ::
+- Key: ! p ::
 
   This command reads a command from the user and executes it in
   ~default-directory~.  With a prefix argument the command is executed
@@ -1973,12 +1973,12 @@ can help; though honestly I consider that a kludge too.
 The command ~magit-debug-git-executable~ can be useful to find out where
 Emacs is searching for ~git~.
 
-- Key: M-x magit-debug-git-executable (magit-debug-git-executable) ::
+- Key: M-x magit-debug-git-executable ::
 
   This command displays a buffer with information about
   ~magit-git-executable~ and  ~magit-remote-git-executable~.
 
-- Key: M-x magit-version (magit-version) ::
+- Key: M-x magit-version ::
 
   This command shows the currently used versions of Magit, Git, and
   Emacs in the echo area.  Non-interactively this just returns the
@@ -3626,6 +3626,7 @@ should also change the others to keep things aligned.  The following
 - ~%U~ Upstream of this local branch and additional local vs. upstream
   information.
 
+# new list
 - User Option: magit-refs-filter-alist ::
 
   The purpose of this option is to forgo displaying certain refs
@@ -3911,9 +3912,9 @@ above commands also use another window when invoked with a prefix
 argument.
 
 - Command: magit-diff-visit-file-other-window ::
-- Command: magit-diff-visit-file-other-frame ::
-- Command: magit-diff-visit-worktree-file-other-window ::
-- Command: magit-diff-visit-worktree-file-other-frame ::
++ Command: magit-diff-visit-file-other-frame ::
++ Command: magit-diff-visit-worktree-file-other-window ::
++ Command: magit-diff-visit-worktree-file-other-frame ::
 
 ** Blaming
 
@@ -3941,7 +3942,7 @@ command whose purpose is to turn off that mode would not be of any
 use and therefore isn't available.
 
 - Key: C-c M-g b (magit-blame-addition) ::
-- Key: C-c M-g B b (magit-blame-addition) ::
+- Key: C-c M-g B b ::
 
   This command augments each line or chunk of lines in the current
   file-visiting or blob-visiting buffer with information about what
@@ -3957,7 +3958,7 @@ use and therefore isn't available.
   added the current line or chunk of lines.
 
 - Key: C-c M-g r (magit-blame-removal) ::
-- Key: C-c M-g B r (magit-blame-removal) ::
+- Key: C-c M-g B r ::
 
   This command augments each line or chunk of lines in the current
   blob-visiting buffer with information about the revision that
@@ -3966,7 +3967,7 @@ use and therefore isn't available.
   Like ~magit-blame-addition~, this command can be used recursively.
 
 - Key: C-c M-g f (magit-blame-reverse) ::
-- Key: C-c M-g B f (magit-blame-reverse) ::
+- Key: C-c M-g B f ::
 
   This command augments each line or chunk of lines in the current
   file-visiting or blob-visiting buffer with information about the
@@ -3975,7 +3976,7 @@ use and therefore isn't available.
   Like ~magit-blame-addition~, this command can be used recursively.
 
 - Key: C-c M-g e (magit-blame-echo) ::
-- Key: C-c M-g B e (magit-blame-echo) ::
+- Key: C-c M-g B e ::
 
   This command is like ~magit-blame-addition~ except that it doesn't
   turn on ~read-only-mode~ and that it initially uses the visualization
@@ -4275,7 +4276,7 @@ You can also use Ediff to stage and unstage.  See [[*Ediffing]].
   changes by reversing them in the index but not the working tree.
   The alternative is to raise an error.
 
-- Key: M-x magit-reverse-in-index (magit-reverse-in-index) ::
+- Key: M-x magit-reverse-in-index ::
 
   This command reverses the committed change at point in the index but
   not the working tree.  By default no key is bound directly to this
@@ -4296,7 +4297,7 @@ You can also use Ediff to stage and unstage.  See [[*Ediffing]].
   4. Optionally stage the remaining changes using ~s~ or ~S~ and then
      type ~c c~ to create a new commit.
 
-- Key: M-x magit-reset-index (magit-reset-index) ::
+- Key: M-x magit-reset-index ::
 
   Reset the index to some commit.  The commit is read from the user
   and defaults to the commit at point.  If there is no commit at
@@ -4308,7 +4309,7 @@ Fine-grained un-/staging has to be done from the status or a diff
 buffer, but it's also possible to un-/stage all changes made to the
 file visited in the current buffer right from inside that buffer.
 
-- Key: M-x magit-stage-file (magit-stage-file) ::
+- Key: M-x magit-stage-file ::
 
   When invoked inside a file-visiting buffer, then stage all changes
   to that file.  In a Magit buffer, stage the file at point if any.
@@ -4316,7 +4317,7 @@ file visited in the current buffer right from inside that buffer.
   always prompt the user for a file, even in a file-visiting buffer or
   when there is a file section at point.
 
-- Key: M-x magit-unstage-file (magit-unstage-file) ::
+- Key: M-x magit-unstage-file ::
 
   When invoked inside a file-visiting buffer, then unstage all changes
   to that file.  In a Magit buffer, unstage the file at point if any.
@@ -4883,9 +4884,9 @@ command.
   change branch related variables.
 
 - Key: b C (magit-branch-configure) ::
-- Key: f C (magit-branch-configure) ::
-- Key: F C (magit-branch-configure) ::
-- Key: P C (magit-branch-configure) ::
++ Key: f C ::
++ Key: F C ::
++ Key: P C ::
 
   This transient prefix command binds commands that set the value of
   branch-related variables and displays them in a temporary buffer
@@ -6995,9 +6996,9 @@ Also see [[man:git-bundle]]
 ** Common Commands
 
 - Command: magit-switch-to-repository-buffer ::
-- Command: magit-switch-to-repository-buffer-other-window ::
-- Command: magit-switch-to-repository-buffer-other-frame ::
-- Command: magit-display-repository-buffer ::
++ Command: magit-switch-to-repository-buffer-other-window ::
++ Command: magit-switch-to-repository-buffer-other-frame ::
++ Command: magit-display-repository-buffer ::
 
   These commands read any existing Magit buffer that belongs to the
   current repository from the user and then switch to the selected
@@ -7130,7 +7131,7 @@ When you are unsure whether Magit did commit a change to the wip refs,
 then you can explicitly request that all changes to all tracked files
 are being committed.
 
-- Key: M-x magit-wip-commit (magit-wip-commit) ::
+- Key: M-x magit-wip-commit ::
 
   This command commits all changes to all tracked files to the index
   and working tree work-in-progress refs.  Like the modes described above,
@@ -7501,6 +7502,7 @@ repository:
       . ((eval . (magit-disable-section-inserter 'magit-insert-tags-header)))))
   #+END_SRC
 
+# new list
 - Function: magit-disable-section-inserter fn ::
 
   This function disables the section inserter FN in the current
@@ -8219,7 +8221,7 @@ And now for the asynchronous variants.
 
 *** Matching Sections
 
-- Key: M-x magit-describe-section-briefly (magit-describe-section-briefly) ::
+- Key: M-x magit-describe-section-briefly ::
 
   Show information about the section at point.  This command is
   intended for debugging purposes.
@@ -8901,13 +8903,13 @@ appreciate it very much if you use those tools before reporting an
 issue.  Please include all relevant output when reporting an
 issue.
 
-- Key: M-x magit-version (magit-version) ::
+- Key: M-x magit-version ::
 
   This command shows the currently used versions of Magit, Git, and
   Emacs in the echo area.  Non-interactively this just returns the
   Magit version.
 
-- Key: M-x magit-emacs-Q-command (magit-emacs-Q-command) ::
+- Key: M-x magit-emacs-Q-command ::
 
   This command shows a debugging shell command in the echo area and
   adds it to the kill ring.  Paste that command into a shell and run
@@ -8921,13 +8923,13 @@ issue.
   If you run Magit from its Git repository, then you should be able to
   use ~make emacs-Q~ instead of the output of this command.
 
-- Key: M-x magit-toggle-verbose-refresh (magit-toggle-verbose-refresh) ::
+- Key: M-x magit-toggle-verbose-refresh ::
 
   This command toggles whether Magit refreshes buffers verbosely.
   Enabling this helps figuring out which sections are bottlenecks.
   The additional output can be found in the ~*Messages*~ buffer.
 
-- Key: M-x magit-debug-git-executable (magit-debug-git-executable) ::
+- Key: M-x magit-debug-git-executable ::
 
   This command displays a buffer containing information about the
   available and used ~git~ executable(s), and can be useful when
@@ -8935,7 +8937,7 @@ issue.
 
   Also see [[*Git Executable]].
 
-- Key: M-x with-editor-debug (with-editor-debug) ::
+- Key: M-x with-editor-debug ::
 
   This command displays a buffer containing information about the
   available and used ~emacsclient~ executable(s), and can be useful
@@ -8952,12 +8954,7 @@ Please also see the [[*FAQ]].
 :INDEX:      ky
 :COOKIE_DATA: recursive
 :END:
-* Command Index
-:PROPERTIES:
-:APPENDIX:   t
-:INDEX:      cp
-:END:
-* Function Index
+* Function and Command Index
 :PROPERTIES:
 :APPENDIX:   t
 :INDEX:      fn

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -9011,7 +9011,6 @@ General Public License for more details.
 # Local Variables:
 # eval: (require 'magit-utils nil t)
 # eval: (require 'ol-man      nil t)
-# eval: (require 'ox-texinfo+ nil t)
 # indent-tabs-mode: nil
 # org-src-preserve-indentation: nil
 # End:

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -1,20 +1,20 @@
-#+TITLE: Magit User Manual
+#+title: Magit User Manual
 :PREAMBLE:
-#+AUTHOR: Jonas Bernoulli
-#+EMAIL: jonas@bernoul.li
-#+DATE: 2015-{{{year}}}
-#+LANGUAGE: en
+#+author: Jonas Bernoulli
+#+email: jonas@bernoul.li
+#+date: 2015-{{{year}}}
+#+language: en
 
-#+TEXINFO_DIR_CATEGORY: Emacs
-#+TEXINFO_DIR_TITLE: Magit: (magit).
-#+TEXINFO_DIR_DESC: Using Git from Emacs with Magit.
-#+SUBTITLE: for version {{{version}}}
+#+texinfo_dir_category: Emacs
+#+texinfo_dir_title: Magit: (magit).
+#+texinfo_dir_desc: Using Git from Emacs with Magit.
+#+subtitle: for version {{{version}}}
 
-#+TEXINFO_DEFFN: t
-#+OPTIONS: H:4 num:3 toc:2
-#+PROPERTY: header-args :eval never
-#+MACRO: version (eval (ox-texinfo+-get-version 'mixed))
-#+MACRO: year (eval (format-time-string "%Y"))
+#+texinfo_deffn: t
+#+options: H:4 num:3 toc:2
+#+property: header-args :eval never
+#+macro: version (eval (ox-texinfo+-get-version 'mixed))
+#+macro: year (eval (format-time-string "%Y"))
 
 Magit is an interface to the version control system Git, implemented
 as an Emacs package.  Magit aspires to be a complete Git porcelain.
@@ -24,10 +24,10 @@ Git users to perform almost all of their daily version control tasks
 directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
-#+TEXINFO: @noindent
+#+texinfo: @noindent
 This manual is for Magit version {{{version}}}.
 
-#+BEGIN_QUOTE
+#+begin_quote
 Copyright (C) 2015-{{{year}}} Jonas Bernoulli <jonas@bernoul.li>
 
 You can redistribute this document and/or modify it under the terms
@@ -39,7 +39,7 @@ This document is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
-#+END_QUOTE
+#+end_quote
 :END:
 * Introduction
 
@@ -134,33 +134,33 @@ yourself with it by reading the documentation in the Emacs manual, see
 
 - To use Melpa:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (require 'package)
   (add-to-list 'package-archives
                '("melpa" . "http://melpa.org/packages/") t)
-#+END_SRC
+#+end_src
 
 - To use Melpa-Stable:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (require 'package)
   (add-to-list 'package-archives
                '("melpa-stable" . "http://stable.melpa.org/packages/") t)
-#+END_SRC
+#+end_src
 
 Once you have added your preferred archive, you need to update the
 local package list using:
 
-#+BEGIN_EXAMPLE
+#+begin_example
   M-x package-refresh-contents RET
-#+END_EXAMPLE
+#+end_example
 
 Once you have done that, you can install Magit and its dependencies
 using:
 
-#+BEGIN_EXAMPLE
+#+begin_example
   M-x package-install RET magit RET
-#+END_EXAMPLE
+#+end_example
 
 Now see [[*Post-Installation Tasks]].
 
@@ -173,32 +173,32 @@ them manually from their repository.
 
 Then clone the Magit repository:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   $ git clone https://github.com/magit/magit.git ~/.emacs.d/site-lisp/magit
   $ cd ~/.emacs.d/site-lisp/magit
-#+END_SRC
+#+end_src
 
 Then compile the libraries and generate the info manuals:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   $ make
-#+END_SRC
+#+end_src
 
 If you haven't installed ~dash~, ~transient~ and ~with-editor~ from
 Melpa or at ~/path/to/magit/../<package>~, then you have to tell ~make~
 where to find them.  To do so create the file ~/path/to/magit/config.mk~
 with the following content before running ~make~:
 
-#+BEGIN_SRC makefile
+#+begin_src makefile
   LOAD_PATH  = -L ~/.emacs.d/site-lisp/magit/lisp
   LOAD_PATH += -L ~/.emacs.d/site-lisp/dash
   LOAD_PATH += -L ~/.emacs.d/site-lisp/transient/lisp
   LOAD_PATH += -L ~/.emacs.d/site-lisp/with-editor
-#+END_SRC
+#+end_src
 
 Finally add this to your init file:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (add-to-list 'load-path "~/.emacs.d/site-lisp/magit/lisp")
   (require 'magit)
 
@@ -206,16 +206,16 @@ Finally add this to your init file:
     (info-initialize)
     (add-to-list 'Info-directory-list
                  "~/.emacs.d/site-lisp/magit/Documentation/"))
-#+END_SRC
+#+end_src
 
 Of course if you installed the dependencies manually as well, then
 you have to tell Emacs about them too, by prefixing the above with:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (add-to-list 'load-path "~/.emacs.d/site-lisp/dash")
   (add-to-list 'load-path "~/.emacs.d/site-lisp/transient/lisp")
   (add-to-list 'load-path "~/.emacs.d/site-lisp/with-editor")
-#+END_SRC
+#+end_src
 
 Note that you have to add the ~lisp~ subdirectory to the ~load-path~, not
 the top-level of the repository, and that elements of ~load-path~ should
@@ -224,9 +224,9 @@ not end with a slash, while those of ~Info-directory-list~ should.
 Instead of requiring the feature ~magit~, you could load just the
 autoload definitions, by loading the file ~magit-autoloads.el~.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (load "/path/to/magit/lisp/magit-autoloads")
-#+END_SRC
+#+end_src
 
 Instead of running Magit directly from the repository by adding that
 to the ~load-path~, you might want to instead install it in some other
@@ -234,10 +234,10 @@ directory using ~sudo make install~ and setting ~load-path~ accordingly.
 
 To update Magit use:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   $ git pull
   $ make
-#+END_SRC
+#+end_src
 
 At times it might be necessary to run ~make clean all~ instead.
 
@@ -252,15 +252,15 @@ Magit, Git, and Emacs releases you think you are using.  It's best to
 restart Emacs before doing so, to make sure you are not using an
 outdated value for ~load-path~.
 
-#+BEGIN_EXAMPLE
+#+begin_example
   M-x magit-version RET
-#+END_EXAMPLE
+#+end_example
 
 should display something like
 
-#+BEGIN_EXAMPLE
+#+begin_example
   Magit 2.8.0, Git 2.10.2, Emacs 25.1.1, gnu/linux
-#+END_EXAMPLE
+#+end_example
 
 Then you might also want to read about options that many users likely
 want to customize.  See [[*Essential Settings]].
@@ -642,10 +642,10 @@ buffer are refreshed. The status buffer can be automatically refreshed
 whenever a buffer is saved to a file inside the respective repository
 by adding a hook, like so:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (with-eval-after-load 'magit-mode
     (add-hook 'after-save-hook 'magit-after-save-refresh-status t))
-#+END_SRC
+#+end_src
 
 Automatically refreshing Magit buffers ensures that the displayed
 information is up-to-date most of the time but can lead to a
@@ -923,11 +923,11 @@ You might want to remove some of the functions that Magit adds using
 ~add-hook~.  In doing so you have to make sure you do not attempt to
 remove function that haven't even been added yet, for example:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (with-eval-after-load 'magit-diff
     (remove-hook 'magit-section-movement-hook
                  'magit-hunk-set-window-start))
-#+END_SRC
+#+end_src
 
 - Variable: magit-section-movement-hook
 
@@ -1269,9 +1269,9 @@ Transient is documented in [[info:transient]].
 This command is also, or especially, useful outside Magit buffers, so
 you should setup a global binding:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (global-set-key (kbd "C-x M-g") 'magit-dispatch)
-#+END_SRC
+#+end_src
 
 ** Transient Arguments and Buffer Variables
 
@@ -1352,7 +1352,7 @@ that by default.
   these arguments, which might change the arguments that are used in
   the buffer.
 
-#+TEXINFO: @noindent
+#+texinfo: @noindent
 Valid values for both of the above options are:
 
   - ~always~: Always use the set of arguments that is currently active
@@ -1364,7 +1364,7 @@ Valid values for both of the above options are:
     only if it is the current buffer.
   - ~never~: Never use the set of arguments from the respective buffer.
 
-#+TEXINFO: @noindent
+#+texinfo: @noindent
 I am afraid it gets more complicated still:
 
 - The global diff and log arguments are set for each supported mode
@@ -2038,9 +2038,9 @@ The command ~magit-status~ displays the status buffer belonging to the
 current repository in another window.  This command is used so often
 that it should be bound globally.  We recommend using ~C-x g~:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (global-set-key (kbd "C-x g") 'magit-status)
-#+END_SRC
+#+end_src
 
 - Key: C-x g, magit-status
 
@@ -2759,7 +2759,7 @@ If a local branch and its push-target point at the same commit, then
 their names are combined to preserve space and to make that
 relationship visible.  For example:
 
-#+BEGIN_EXAMPLE
+#+begin_example
   origin/feature
   [green][blue-]
 
@@ -2767,7 +2767,7 @@ relationship visible.  For example:
 
   feature origin/feature
   [blue-] [green-------]
-#+END_EXAMPLE
+#+end_example
 
 Also note that while the transient features the ~--show-signature~
 argument, that won't actually be used when enabled, because Magit
@@ -4709,7 +4709,7 @@ the hook ~git-commit-setup-hook~.
 
   Hook run at the end of ~git-commit-setup~.
 
-#+TEXINFO: @noindent
+#+texinfo: @noindent
 The following functions are suitable for this hook:
 
 - Function: git-commit-save-message
@@ -5267,9 +5267,9 @@ values.  If you want to change the global value, which is used when
 the local value is undefined, then you have to do so on the command
 line, e.g.:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   git config --global remote.autoSetupMerge always
-#+END_SRC
+#+end_src
 
 For more information about these variables you should also see
 man:git-config Also see [[man:git-branch]], [[man:git-checkout]] and [[*Pushing]].
@@ -5421,13 +5421,13 @@ begin with the strings consisting of six times the same character, one
 of ~<~, ~|~, ~=~ and ~>~ and are followed by information about the source of
 the respective versions, e.g.:
 
-#+BEGIN_EXAMPLE
+#+begin_example
   <<<<<<< HEAD
   Take the blue pill.
   =======
   Take the red pill.
   >>>>>>> feature
-#+END_EXAMPLE
+#+end_example
 
 In this case you have chosen to take the red pill on one branch and on
 another you picked the blue pill.  Now that you are merging these two
@@ -5440,22 +5440,22 @@ it in order to bring in the changes from the other side, remove the
 other versions as well as the markers, and then stage the result.  A
 possible resolution might be:
 
-#+BEGIN_EXAMPLE
+#+begin_example
   Take both pills.
-#+END_EXAMPLE
+#+end_example
 
 Often it is useful to see not only the two sides of the conflict but
 also the "original" version from before the same area of the file was
 modified twice on different branches.  Instruct Git to insert that
 version as well by running this command once:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   git config --global merge.conflictStyle diff3
-#+END_SRC
+#+end_src
 
 The above conflict might then have looked like this:
 
-#+BEGIN_EXAMPLE
+#+begin_example
   <<<<<<< HEAD
   Take the blue pill.
   ||||||| merged common ancestors
@@ -5463,7 +5463,7 @@ The above conflict might then have looked like this:
   =======
   Take the red pill.
   >>>>>>> feature
-#+END_EXAMPLE
+#+end_example
 
 If that were the case, then the above conflict resolution would not
 have been correct, which demonstrates why seeing the original version
@@ -7173,11 +7173,11 @@ are being committed.
 
 When ~magit-wip-merge-branch~ is ~t~, then the history looks like this:
 
-#+BEGIN_EXAMPLE
+#+begin_example
   ,*--*--*--*--*--*       refs/wip/index/refs/heads/master
  /     /     /
 A-----B-----C            refs/heads/master
-#+END_EXAMPLE
+#+end_example
 
 When ~magit-wip-merge-branch~ is ~nil~, then creating a commit on the real
 branch and then making a change causes the wip refs to be recreated to
@@ -7189,18 +7189,18 @@ below are such boundary commits).
 
 Starting with
 
-#+BEGIN_EXAMPLE
+#+begin_example
       BI0---BI1    refs/wip/index/refs/heads/master
      /
 A---B              refs/heads/master
      \
       BW0---BW1    refs/wip/wtree/refs/heads/master
-#+END_EXAMPLE
+#+end_example
 
 and committing the staged changes and editing and saving a file would
 result in
 
-#+BEGIN_EXAMPLE
+#+begin_example
       BI0---BI1        refs/wip/index/refs/heads/master
      /
 A---B---C              refs/heads/master
@@ -7208,7 +7208,7 @@ A---B---C              refs/heads/master
       \   CW0---CW1    refs/wip/wtree/refs/heads/master
        \
         BW0---BW1      refs/wip/wtree/refs/heads/master@{2}
-#+END_EXAMPLE
+#+end_example
 
 The fork-point of the index wip ref is not changed until some change
 is being staged.  Likewise just checking out a branch or creating a
@@ -7295,9 +7295,9 @@ and [[info:elisp#Key Binding Conventions]].
 
 If you want a better binding, you have to add it yourself:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (global-set-key (kbd "C-c g") 'magit-file-dispatch)
-#+END_SRC
+#+end_src
 
 The key bindings shown below assume that you have not improved the
 binding for ~magit-file-dispatch~.
@@ -7601,9 +7601,9 @@ Magit buffer, but not the status buffer.  If you do that, then the
 status buffer is only refreshed automatically if it is the
 current buffer.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (setq magit-refresh-status-buffer nil)
-#+END_SRC
+#+end_src
 
 You should also check whether any third-party packages have added
 anything to ~magit-refresh-buffer-hook~, ~magit-status-refresh-hook~,
@@ -7623,10 +7623,10 @@ whether performance is significantly worse, when many buffers exist
 and/or when some buffers visit files using TRAMP.  If so, then this
 should help.
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (setq auto-revert-buffer-list-filter
         'magit-auto-revert-repository-buffer-p)
-#+END_SRC
+#+end_src
 
 For alternative approaches see [[*Automatic Reverting of File-Visiting
 Buffers]].
@@ -7713,9 +7713,9 @@ address that is to display fewer refs, obviously.
 If you are not, or only mildly, interested in seeing the list of tags,
 then start by not displaying them:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (remove-hook 'magit-refs-sections-hook 'magit-insert-tags)
-#+END_SRC
+#+end_src
 
 Then you should also make sure that the listed remote branches
 actually all exist.  You can do so by pruning branches which no longer
@@ -7733,9 +7733,9 @@ committing large amounts of generated data which you don't actually
 intend to inspect before committing.  This behavior can be turned off
 using:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (remove-hook 'server-switch-hook 'magit-commit-diff)
-#+END_SRC
+#+end_src
 
 Then you can type ~C-c C-d~ to show the diff when you actually want to
 see it, but only then.  Alternatively you can leave the hook alone and
@@ -7763,11 +7763,11 @@ Windows-specific issues.
 According to some sources, setting the following Git variables can also
 help.
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   git config --global core.preloadindex true   # default since v2.1
   git config --global core.fscache true        # default since v2.8
   git config --global gc.auto 256
-#+END_SRC
+#+end_src
 
 You should also check whether an anti-virus program is affecting
 performance.
@@ -8621,9 +8621,9 @@ Info manual by instead viewing the respective manpage.  If you prefer
 that approach, then set the value of ~magit-view-git-manual-method~ to
 one of the supported packages ~man~ or ~woman~, e.g.:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (setq magit-view-git-manual-method 'man)
-#+END_SRC
+#+end_src
 
 *** How to show diffs for gpg-encrypted files?
 
@@ -8631,10 +8631,10 @@ Git supports showing diffs for encrypted files, but has to be told to
 do so.  Since Magit just uses Git to get the diffs, configuring Git
 also affects the diffs displayed inside Magit.
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   git config --global diff.gpg.textconv "gpg --no-tty --decrypt"
   echo "*.gpg filter=gpg diff=gpg" > .gitattributes
-#+END_SRC
+#+end_src
 
 *** How does branching and pushing work?
 
@@ -8746,14 +8746,14 @@ So you have to figure out which package is doing.  ~saveplace~,
 ~pointback~, and ~session~ are likely candidates.  These snippets might
 help:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (setq session-name-disable-regexp "\\(?:\\`'\\.git/[A-Z_]+\\'\\)")
 
   (with-eval-after-load 'pointback
     (lambda ()
       (when (or git-commit-mode git-rebase-mode)
 	(pointback-mode -1))))
-#+END_SRC
+#+end_src
 
 *** The mode-line information isn't always up-to-date
 
@@ -8762,9 +8762,9 @@ being displayed in the mode-line and looks something like ~Git-master~.
 The built-in "Version Control" package, also known as "VC", updates
 that information, and can be told to do so more often:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (setq auto-revert-check-vc-info t)
-#+END_SRC
+#+end_src
 
 But doing so isn't good for performance.  For more (overly optimistic)
 information see [[info:emacs#VC Mode Line]].
@@ -8773,10 +8773,10 @@ If you don't really care about seeing this information in the
 mode-line, but just don't want to see /incorrect/ information,
 then consider simply not displaying it in the mode-line:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (setq-default mode-line-format
                 (delete '(vc-mode vc-mode) mode-line-format))
-#+END_SRC
+#+end_src
 
 *** A branch and tag sharing the same name breaks SOMETHING
 
@@ -8811,16 +8811,16 @@ loading ~git-commit~ and starting the server.
 If you want to commit from the command-line, then you have to take
 care of these things yourself. Your ~init.el~ file should contain:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (require 'git-commit)
   (server-mode)
-#+END_SRC
+#+end_src
 
 Instead of `(require 'git-commit)` you may also use:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (load "/path/to/magit-autoloads.el")
-#+END_SRC
+#+end_src
 
 You might want to do that because loading ~git-commit~ causes large
 parts of Magit to be loaded.
@@ -8828,24 +8828,24 @@ parts of Magit to be loaded.
 There are also some variations of ~(server-mode)~ that you might want to
 try. Personally I use:
 
-#+BEGIN_SRC emacs-lisp
+#+begin_src emacs-lisp
   (use-package server
     :config (or (server-running-p) (server-mode)))
-#+END_SRC
+#+end_src
 
 Now you can use:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   $ emacs&
   $ EDITOR=emacsclient git commit
-#+END_SRC
+#+end_src
 
 However you cannot use:
 
-#+BEGIN_SRC shell-script
+#+begin_src shell-script
   $ killall emacs
   $ EDITOR="emacsclient --alternate-editor emacs" git commit
-#+END_SRC
+#+end_src
 
 This will actually end up using ~emacs~, not ~emacsclient~.  If you do
 this, then you can still edit the commit message but ~git-commit-mode~
@@ -8978,7 +8978,7 @@ Please also see the [[*FAQ]].
 :COPYING:    t
 :END:
 
-#+BEGIN_QUOTE
+#+begin_quote
 Copyright (C) 2015-{{{year}}} Jonas Bernoulli <jonas@bernoul.li>
 
 You can redistribute this document and/or modify it under the terms
@@ -8990,7 +8990,7 @@ This document is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
-#+END_QUOTE
+#+end_quote
 
 #  LocalWords:  ARG ARGS CONDITIONs ChangeLog DNS Dired Ediff Ediffing
 #  LocalWords:  Elpa Emacsclient FUNC Flyspell Git Git's Gitk HOOK's

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -385,7 +385,7 @@ the user invokes Git commands, or creates or visits other buffers.
 In this manual we often speak about "Magit buffers".  By that we mean
 buffers whose major-modes derive from ~magit-mode~.
 
-- Key: M-x magit-toggle-buffer-lock, magit-toggle-buffer-lock
+- Key: M-x magit-toggle-buffer-lock (magit-toggle-buffer-lock) ::
 
   This command locks the current buffer to its value or if the buffer
   is already locked, then it unlocks it.
@@ -406,7 +406,7 @@ buffers whose major-modes derive from ~magit-mode~.
 
 *** Switching Buffers
 
-- Function: magit-display-buffer buffer &optional display-function
+- Function: magit-display-buffer buffer &optional display-function ::
 
   This function is a wrapper around ~display-buffer~ and is used to
   display any Magit buffer.  It displays BUFFER in some window and,
@@ -418,7 +418,7 @@ buffers whose major-modes derive from ~magit-mode~.
   display the buffer.  Usually that is ~nil~ and the function specified
   by ~magit-display-buffer-function~ is used.
 
-- Variable: magit-display-buffer-noselect
+- Variable: magit-display-buffer-noselect ::
 
   When this is non-nil, then ~magit-display-buffer~ only displays the
   buffer but forgoes also selecting the window.  This variable should
@@ -427,7 +427,7 @@ buffers whose major-modes derive from ~magit-mode~.
   example when the revision buffer is updated when you move inside the
   log buffer.
 
-- User Option: magit-display-buffer-function
+- User Option: magit-display-buffer-function ::
 
   The function specified here is called by ~magit-display-buffer~ with
   one argument, a buffer, to actually display that buffer.  This
@@ -445,7 +445,7 @@ buffers whose major-modes derive from ~magit-mode~.
 
   To learn about display actions, see [[info:elisp#Choosing Window]].
 
-- Function: magit-display-buffer-traditional buffer
+- Function: magit-display-buffer-traditional buffer ::
 
   This function is the current default value of the option
   ~magit-display-buffer-function~.  Before that option and this function
@@ -453,19 +453,19 @@ buffers whose major-modes derive from ~magit-mode~.
   code base but now all the rules are contained in this one function
   (except for the "noselect" special case mentioned above).
 
-- Function: magit-display-buffer-same-window-except-diff-v1
+- Function: magit-display-buffer-same-window-except-diff-v1 ::
 
   This function displays most buffers in the currently selected
   window.  If a buffer's mode derives from ~magit-diff-mode~ or
   ~magit-process-mode~, it is displayed in another window.
 
-- Function: magit-display-buffer-fullframe-status-v1
+- Function: magit-display-buffer-fullframe-status-v1 ::
 
   This function fills the entire frame when displaying a status
   buffer.  Otherwise, it behaves like
   ~magit-display-buffer-traditional~.
 
-- Function: magit-display-buffer-fullframe-status-topleft-v1
+- Function: magit-display-buffer-fullframe-status-topleft-v1 ::
 
   This function fills the entire frame when displaying a status
   buffer.  It behaves like ~magit-display-buffer-fullframe-status-v1~
@@ -475,7 +475,7 @@ buffers whose major-modes derive from ~magit-mode~.
   to pop up on the same side as they would if
   ~magit-display-buffer-traditional~ were in use.
 
-- Function: magit-display-buffer-fullcolumn-most-v1
+- Function: magit-display-buffer-fullcolumn-most-v1 ::
 
   This function displays most buffers so that they fill the entire
   height of the frame.  However, the buffer is displayed in another
@@ -484,23 +484,23 @@ buffers whose major-modes derive from ~magit-mode~.
   that the mode of the current buffer derives from ~magit-log-mode~ or
   ~magit-cherry-mode~.
 
-- User Option: magit-pre-display-buffer-hook
+- User Option: magit-pre-display-buffer-hook ::
 
   This hook is run by ~magit-display-buffer~ before displaying the
   buffer.
 
-- Function: magit-save-window-configuration
+- Function: magit-save-window-configuration ::
 
   This function saves the current window configuration.  Later when
   the buffer is buried, it may be restored by
   ~magit-restore-window-configuration~.
 
-- User Option: magit-post-display-buffer-hook
+- User Option: magit-post-display-buffer-hook ::
 
   This hook is run by ~magit-display-buffer~ after displaying the
   buffer.
 
-- Function: magit-maybe-set-dedicated
+- Function: magit-maybe-set-dedicated ::
 
   This function remembers if a new window had to be created to display
   the buffer, or whether an existing window was reused.  This
@@ -510,7 +510,7 @@ buffers whose major-modes derive from ~magit-mode~.
 
 *** Naming Buffers
 
-- User Option: magit-generate-buffer-name-function
+- User Option: magit-generate-buffer-name-function ::
 
   The function used to generate the names of Magit buffers.
 
@@ -521,7 +521,7 @@ buffers whose major-modes derive from ~magit-mode~.
   ~magit-buffer-name-format~, then its own doc-string should describe
   the additions.
 
-- Function: magit-generate-buffer-name-default-function mode
+- Function: magit-generate-buffer-name-default-function mode ::
 
   This function returns a buffer name suitable for a buffer whose
   major-mode is MODE and which shows information about the repository
@@ -531,7 +531,7 @@ buffers whose major-modes derive from ~magit-mode~.
   the %-sequences mentioned the documentation of that option.  It also
   respects the option ~magit-uniquify-buffer-names~.
 
-- User Option: magit-buffer-name-format
+- User Option: magit-buffer-name-format ::
 
   The format string used to name Magit buffers.
 
@@ -576,7 +576,7 @@ buffers whose major-modes derive from ~magit-mode~.
   value must end with ~%t~ or ~%t%x~ (or the obsolete ~%T~).  See issue
   #2841.
 
-- User Option: magit-uniquify-buffer-names
+- User Option: magit-uniquify-buffer-names ::
 
   This option controls whether the names of Magit buffers are
   uniquified.  If the names are not being uniquified, then they
@@ -591,7 +591,7 @@ buffers whose major-modes derive from ~magit-mode~.
 
 *** Quitting Windows
 
-- Key: q, magit-mode-bury-buffer
+- Key: q (magit-mode-bury-buffer) ::
 
   This command buries the current Magit buffer.
 
@@ -599,7 +599,7 @@ buffers whose major-modes derive from ~magit-mode~.
   prefix argument, also kills all other Magit buffers associated with
   the current project.
 
-- User Option: magit-bury-buffer-function
+- User Option: magit-bury-buffer-function ::
 
   The function used to actually bury or kill the current buffer.
 
@@ -608,7 +608,7 @@ buffers whose major-modes derive from ~magit-mode~.
   buffer.  Otherwise it has to bury it alive.  The default value
   currently is ~magit-restore-window-configuration~.
 
-- Function: magit-restore-window-configuration kill-buffer
+- Function: magit-restore-window-configuration kill-buffer ::
 
   Bury or kill the current buffer using ~quit-window~, which is called
   with KILL-BUFFER as first and the selected window as second
@@ -619,7 +619,7 @@ buffers whose major-modes derive from ~magit-mode~.
   that also means that point gets adjusted in all the buffers, which
   are being displayed in the selected frame.
 
-- Function: magit-mode-quit-window kill-buffer
+- Function: magit-mode-quit-window kill-buffer ::
 
   Bury or kill the current buffer using ~quit-window~, which is called
   with KILL-BUFFER as first and the selected window as second
@@ -652,7 +652,7 @@ Buffers can also be refreshed explicitly, which is useful in buffers
 that weren't current during the last refresh and after changes were
 made to the repository outside of Magit.
 
-- Key: g, magit-refresh
+- Key: g (magit-refresh) ::
 
   This command refreshes the current buffer if its major mode derives
   from ~magit-mode~ as well as the corresponding status buffer.
@@ -661,7 +661,7 @@ made to the repository outside of Magit.
   reverts all unmodified buffers that visit files being tracked in the
   current repository.
 
-- Key: G, magit-refresh-all
+- Key: G (magit-refresh-all) ::
 
   This command refreshes all Magit buffers belonging to the current
   repository and also reverts all unmodified buffers that visit files
@@ -670,12 +670,12 @@ made to the repository outside of Magit.
   The file-visiting buffers are always reverted, even if
   ~magit-revert-buffers~ is nil.
 
-- User Option: magit-refresh-buffer-hook
+- User Option: magit-refresh-buffer-hook ::
 
   This hook is run in each Magit buffer that was refreshed during the
   current refresh - normally the current buffer and the status buffer.
 
-- User Option: magit-refresh-status-buffer
+- User Option: magit-refresh-status-buffer ::
 
   When this option is non-nil, then the status buffer is automatically
   refreshed after running git for side-effects, in addition to the
@@ -684,7 +684,7 @@ made to the repository outside of Magit.
   Only set this to nil after exhausting all other options to improve
   performance.
 
-- Function: magit-after-save-refresh-status
+- Function: magit-after-save-refresh-status ::
 
   This function is intended to be added to ~after-save-hook~.  After
   doing that the corresponding status buffer is refreshed whenever a
@@ -704,7 +704,7 @@ Magit to interact with Git, one can be fairly confident.  When in
 doubt or after outside changes, type ~g~ (~magit-refresh~) to save and
 refresh explicitly.
 
-- User Option: magit-save-repository-buffers
+- User Option: magit-save-repository-buffers ::
 
   This option controls whether file-visiting buffers are saved before
   certain events.
@@ -728,12 +728,12 @@ file to have "changed on disk".  If Magit did not automatically revert
 the buffer, then you would have to type ~M-x revert-buffer RET RET~ in
 the visiting buffer before you could continue making changes.
 
-- User Option: magit-auto-revert-mode
+- User Option: magit-auto-revert-mode ::
 
   When this mode is enabled, then buffers that visit tracked files
   are automatically reverted after the visited files change on disk.
 
-- User Option: global-auto-revert-mode
+- User Option: global-auto-revert-mode ::
 
   When this mode is enabled, then any file-visiting buffer is
   automatically reverted after the visited file changes on disk.
@@ -743,7 +743,7 @@ the visiting buffer before you could continue making changes.
   just those visiting tracked files.  If that is the case, then enable
   this mode /instead of/ ~magit-auto-revert-mode~.
 
-- User Option: magit-auto-revert-immediately
+- User Option: magit-auto-revert-immediately ::
 
   This option controls whether Magit reverts buffers immediately.
 
@@ -760,20 +760,20 @@ the visiting buffer before you could continue making changes.
   ~nil~, then reverts happen after ~auto-revert-interval~ seconds of user
   inactivity.  That is not desirable.
 
-- User Option: auto-revert-use-notify
+- User Option: auto-revert-use-notify ::
 
   This option controls whether file notification functions should be
   used.  Note that this variable unfortunately defaults to ~t~ even on
   systems on which file notifications cannot be used.
 
-- User Option: magit-auto-revert-tracked-only
+- User Option: magit-auto-revert-tracked-only ::
 
   This option controls whether ~magit-auto-revert-mode~ only reverts
   tracked files or all files that are located inside Git repositories,
   including untracked files and files located inside Git's control
   directory.
 
-- User Option: auto-revert-mode
+- User Option: auto-revert-mode ::
 
   The global mode ~magit-auto-revert-mode~ works by turning on this
   local mode in the appropriate buffers (but ~global-auto-revert-mode~
@@ -781,17 +781,17 @@ the visiting buffer before you could continue making changes.
   manually, which might be necessary if Magit does not notice that a
   previously untracked file now is being tracked or vice-versa.
 
-- User Option: auto-revert-stop-on-user-input
+- User Option: auto-revert-stop-on-user-input ::
 
   This option controls whether the arrival of user input suspends the
   automatic reverts for ~auto-revert-interval~ seconds.
 
-- User Option: auto-revert-interval
+- User Option: auto-revert-interval ::
 
   This option controls how many seconds Emacs waits for before
   resuming suspended reverts.
 
-- User Option: auto-revert-buffer-list-filter
+- User Option: auto-revert-buffer-list-filter ::
 
   This option specifies an additional filter used by
   ~auto-revert-buffers~ to determine whether a buffer should be reverted
@@ -812,7 +812,7 @@ the visiting buffer before you could continue making changes.
   who turn on ~global-auto-revert-mode~, do not have to worry about this
   option, because it is disregarded if the global mode is enabled.
 
-- User Option: auto-revert-verbose
+- User Option: auto-revert-verbose ::
 
   This option controls whether Emacs reports when a buffer has been
   reverted.
@@ -886,28 +886,28 @@ To move within a section use the usual keys (~C-p~, ~C-n~, ~C-b~, ~C-f~ etc),
 whose global bindings are not shadowed.  To move to another section use
 the following commands.
 
-- Key: p, magit-section-backward
+- Key: p (magit-section-backward) ::
 
   When not at the beginning of a section, then move to the beginning
   of the current section.  At the beginning of a section, instead move
   to the beginning of the previous visible section.
 
-- Key: n, magit-section-forward
+- Key: n (magit-section-forward) ::
 
   Move to the beginning of the next visible section.
 
-- Key: M-p, magit-section-backward-siblings
+- Key: M-p (magit-section-backward-siblings) ::
 
   Move to the beginning of the previous sibling section.  If there is
   no previous sibling section, then move to the parent section
   instead.
 
-- Key: M-n, magit-section-forward-siblings
+- Key: M-n (magit-section-forward-siblings) ::
 
   Move to the beginning of the next sibling section.  If there is no
   next sibling section, then move to the parent section instead.
 
-- Key: ^, magit-section-up
+- Key: ^ (magit-section-up) ::
 
   Move to the beginning of the parent of the current section.
 
@@ -924,12 +924,12 @@ remove function that haven't even been added yet, for example:
                  'magit-hunk-set-window-start))
 #+end_src
 
-- Variable: magit-section-movement-hook
+- Variable: magit-section-movement-hook ::
 
   This hook is run by all of the above movement commands, after
   arriving at the destination.
 
-- Function: magit-hunk-set-window-start
+- Function: magit-hunk-set-window-start ::
 
   This hook function ensures that the beginning of the current section
   is visible, provided it is a ~hunk~ section.  Otherwise, it does
@@ -937,14 +937,14 @@ remove function that haven't even been added yet, for example:
 
   Loading ~magit-diff~ adds this function to the hook.
 
-- Function: magit-section-set-window-start
+- Function: magit-section-set-window-start ::
 
   This hook function ensures that the beginning of the current section
   is visible, regardless of the section's type.  If you add this to
   ~magit-section-movement-hook~, then you must remove the hunk-only
   variant in turn.
 
-- Function: magit-log-maybe-show-more-commits
+- Function: magit-log-maybe-show-more-commits ::
 
   This hook function only has an effect in log buffers, and ~point~ is
   on the "show more" section.  If that is the case, then it doubles
@@ -952,7 +952,7 @@ remove function that haven't even been added yet, for example:
 
   Loading ~magit-log~ adds this function to the hook.
 
-- Function: magit-log-maybe-update-revision-buffer
+- Function: magit-log-maybe-update-revision-buffer ::
 
   When moving inside a log buffer, then this function updates the
   revision buffer, provided it is already being displayed in another
@@ -960,37 +960,37 @@ remove function that haven't even been added yet, for example:
 
   Loading ~magit-log~ adds this function to the hook.
 
-- Function: magit-log-maybe-update-blob-buffer
+- Function: magit-log-maybe-update-blob-buffer ::
 
   When moving inside a log buffer and another window of the same frame
   displays a blob buffer, then this function instead displays the blob
   buffer for the commit at point in that window.
 
-- Function: magit-status-maybe-update-revision-buffer
+- Function: magit-status-maybe-update-revision-buffer ::
 
   When moving inside a status buffer, then this function updates the
   revision buffer, provided it is already being displayed in another
   window of the same frame.
 
-- Function: magit-status-maybe-update-stash-buffer
+- Function: magit-status-maybe-update-stash-buffer ::
 
   When moving inside a status buffer, then this function updates the
   stash buffer, provided it is already being displayed in another
   window of the same frame.
 
-- Function: magit-status-maybe-update-blob-buffer
+- Function: magit-status-maybe-update-blob-buffer ::
 
   When moving inside a status buffer and another window of the same
   frame displays a blob buffer, then this function instead displays
   the blob buffer for the commit at point in that window.
 
-- Function: magit-stashes-maybe-update-stash-buffer
+- Function: magit-stashes-maybe-update-stash-buffer ::
 
   When moving inside a buffer listing stashes, then this function
   updates the stash buffer, provided it is already being displayed
   in another window of the same frame.
 
-- User Option: magit-update-other-window-delay
+- User Option: magit-update-other-window-delay ::
 
   Delay before automatically updating the other window.
 
@@ -1010,33 +1010,33 @@ remove function that haven't even been added yet, for example:
 Magit provides many commands for changing the visibility of sections,
 but all you need to get started are the next two.
 
-- Key: TAB, magit-section-toggle
+- Key: TAB (magit-section-toggle) ::
 
   Toggle the visibility of the body of the current section.
 
-- Key: C-<tab>, magit-section-cycle
+- Key: C-<tab> (magit-section-cycle) ::
 
   Cycle the visibility of current section and its children.
 
-- Key: M-<tab>, magit-section-cycle-diffs
+- Key: M-<tab> (magit-section-cycle-diffs) ::
 
   Cycle the visibility of diff-related sections in the current buffer.
 
-- Key: S-<tab>, magit-section-cycle-global
+- Key: S-<tab> (magit-section-cycle-global) ::
 
   Cycle the visibility of all sections in the current buffer.
 
-- Key: 1, magit-section-show-level-1
-- Key: 2, magit-section-show-level-2
-- Key: 3, magit-section-show-level-3
-- Key: 4, magit-section-show-level-4
+- Key: 1 (magit-section-show-level-1) ::
+- Key: 2 (magit-section-show-level-2) ::
+- Key: 3 (magit-section-show-level-3) ::
+- Key: 4 (magit-section-show-level-4) ::
 
   Show sections surrounding the current section up to level N.
 
-- Key: M-1, magit-section-show-level-1-all
-- Key: M-2, magit-section-show-level-2-all
-- Key: M-3, magit-section-show-level-3-all
-- Key: M-4, magit-section-show-level-4-all
+- Key: M-1 (magit-section-show-level-1-all) ::
+- Key: M-2 (magit-section-show-level-2-all) ::
+- Key: M-3 (magit-section-show-level-3-all) ::
+- Key: M-4 (magit-section-show-level-4-all) ::
 
   Show all sections up to level N.
 
@@ -1045,30 +1045,30 @@ also exposed as commands themselves.  By default no keys are bound to
 these commands, as they are generally perceived to be much less
 useful.  But your mileage may vary.
 
-- Command: magit-section-show
+- Command: magit-section-show ::
 
   Show the body of the current section.
 
-- Command: magit-section-hide
+- Command: magit-section-hide ::
 
   Hide the body of the current section.
 
-- Command: magit-section-show-headings
+- Command: magit-section-show-headings ::
 
   Recursively show headings of children of the current section.  Only
   show the headings.  Previously shown text-only bodies are hidden.
 
-- Command: magit-section-show-children
+- Command: magit-section-show-children ::
 
   Recursively show the bodies of children of the current section.
   With a prefix argument show children down to the level of the
   current section, and hide deeper children.
 
-- Command: magit-section-hide-children
+- Command: magit-section-hide-children ::
 
   Recursively hide the bodies of children of the current section.
 
-- Command: magit-section-toggle-children
+- Command: magit-section-toggle-children ::
 
   Toggle visibility of bodies of children of the current section.
 
@@ -1078,7 +1078,7 @@ then the previous visibility is preserved.  The initial visibility of
 certain sections can also be overwritten using the hook
 ~magit-section-set-visibility-hook~.
 
-- User Option: magit-section-initial-visibility-alist
+- User Option: magit-section-initial-visibility-alist ::
 
   This options can be used to override the initial visibility of
   sections.  In the future it will also be used to define the
@@ -1094,7 +1094,7 @@ certain sections can also be overwritten using the hook
   lineage and the type is the first element of that vector.  Wildcards
   can be used, see ~magit-section-match~.
 
-- User Option: magit-section-cache-visibility
+- User Option: magit-section-cache-visibility ::
 
   This option controls for which sections the previous visibility
   state should be restored if a section disappears and later appears
@@ -1105,7 +1105,7 @@ certain sections can also be overwritten using the hook
   This requires that the function ~magit-section-cached-visibility~ is
   a member of ~magit-section-set-visibility-hook~.
 
-- Variable: magit-section-set-visibility-hook
+- Variable: magit-section-set-visibility-hook ::
 
   This hook is run when first creating a buffer and also when
   refreshing an existing buffer, and is used to determine the
@@ -1122,7 +1122,7 @@ certain sections can also be overwritten using the hook
   then the buffer is being refreshed and these functions should
   immediately return ~nil~.
 
-- User Option: magit-section-visibility-indicator
+- User Option: magit-section-visibility-indicator ::
 
   This option controls whether and how to indicate that a section can
   be expanded/collapsed.
@@ -1169,7 +1169,7 @@ Custom interface.
 The various available section hook variables are described later in
 this manual along with the appropriate "section inserter functions".
 
-- Function: magit-add-section-hook hook function &optional at append local
+- Function: magit-add-section-hook hook function &optional at append local ::
 
   Add the function FUNCTION to the value of section hook HOOK.
 
@@ -1207,12 +1207,12 @@ section of type ~file~, for example, is a file name.
 Users usually do not have to worry about a section's type and value,
 but knowing them can be handy at times.
 
-- Key: H, magit-describe-section
+- Key: H (magit-describe-section) ::
 
   This command shows information about the section at point in a
   separate buffer.
 
-- Command: magit-describe-section-briefly
+- Command: magit-describe-section-briefly ::
 
   This command shows information about the section at point in the
   echo area, as ~#<magit-section VALUE [TYPE PARENT-TYPE...]
@@ -1234,7 +1234,7 @@ yourself, and it will automatically be used.
 This section describes options that have an effect on more than just a
 certain type of sections.  As you can see there are not many of those.
 
-- User Option: magit-section-show-child-count
+- User Option: magit-section-show-child-count ::
 
   Whether to append the number of children to section headings.  This
   only affects sections that could benefit from this information.
@@ -1253,7 +1253,7 @@ used the package ~magit-popup~ and even earlier versions library
 
 Transient is documented in [[info:transient]].
 
-- Key: C-c C-c, magit-dispatch
+- Key: C-c C-c (magit-dispatch) ::
 
   This transient prefix command binds most of Magit's other prefix
   commands as suffix commands and displays them in a temporary buffer
@@ -1329,7 +1329,7 @@ press ~RET~ on another commit to show that instead and the diff
 arguments are reset to the default.  Not cool; so Magit does not do
 that by default.
 
-- User Option: magit-prefix-use-buffer-arguments
+- User Option: magit-prefix-use-buffer-arguments ::
 
   This option controls whether the infix arguments initially shown in
   certain transient prefix commands are based on the arguments that
@@ -1338,7 +1338,7 @@ that by default.
   The ~magit-diff~ and ~magit-log~ transient prefix commands are affected
   by this option.
 
-- User Option: magit-direct-use-buffer-arguments
+- User Option: magit-direct-use-buffer-arguments ::
 
   This option controls whether certain commands, when invoked directly
   (i.e. not as the suffix of a transient prefix command), use the
@@ -1411,7 +1411,7 @@ while this option can only be used to disable confirmation for a
 specific set of actions, the next section explains another way of
 telling Magit to ask fewer questions.
 
-- User Option: magit-no-confirm
+- User Option: magit-no-confirm ::
 
   The value of this option is a list of symbols, representing actions
   that do not have to be confirmed by the user before being carried
@@ -1583,7 +1583,7 @@ Also note that Magit asks for confirmation of certain actions that are
 not coupled with completion (or the selection).  Such dialogs are also
 not affected by this option and are described in the previous section.
 
-- User Option: magit-dwim-selection
+- User Option: magit-dwim-selection ::
 
 This option can be used to tell certain commands to use the thing
 at point instead of asking the user to select a candidate to act
@@ -1655,7 +1655,7 @@ selected sections.  The latter would be much more surprising and if
 the current section always is part of the selection, then that cannot
 happen.
 
-- Variable: magit-keep-region-overlay
+- Variable: magit-keep-region-overlay ::
 
   This variable controls whether the region is visualized as usual
   even when a valid Magit selection or a hunk-internal region exists.
@@ -1704,7 +1704,7 @@ However if you want to use Ido, then ~ido-mode~ won't do the trick.  You
 will also have to install the ~ido-completing-read+~ package and use
 ~magit-ido-completing-read~ as ~magit-completing-read-function~.
 
-- User Option: magit-completing-read-function
+- User Option: magit-completing-read-function ::
 
   The value of this variable is the low-level function used to perform
   completion by code that uses ~magit-completing-read~ (as opposed to
@@ -1718,12 +1718,12 @@ will also have to install the ~ido-completing-read+~ package and use
   some additional work, and any function used in its place has to do
   the same.
 
-- Function: magit-builtin-completing-read prompt choices &optional predicate require-match initial-input hist def
+- Function: magit-builtin-completing-read prompt choices &optional predicate require-match initial-input hist def ::
 
   This function performs completion using the built-in ~completing-read~
   and does some additional magit-specific work.
 
-- Function: magit-ido-completing-read prompt choices &optional predicate require-match initial-input hist def
+- Function: magit-ido-completing-read prompt choices &optional predicate require-match initial-input hist def ::
 
   This function performs completion using ~ido-completing-read+~ from the
   package by the same name (which you have to explicitly install) and
@@ -1734,7 +1734,7 @@ will also have to install the ~ido-completing-read+~ package and use
   while intended as a drop-in replacement, cannot serve that purpose
   because it violates too many of the implicit conventions.
 
-- Function: magit-completing-read prompt choices &optional predicate require-match initial-input hist def fallback
+- Function: magit-completing-read prompt choices &optional predicate require-match initial-input hist def fallback ::
 
   This is the function that Magit commands use when they need the user
   to select a single thing to act on.  The arguments have the same
@@ -1775,7 +1775,7 @@ will also have to install the ~ido-completing-read+~ package and use
 
 *** Additional Completion Options
 
-- User Option: magit-list-refs-sortby
+- User Option: magit-list-refs-sortby ::
 
   For many commands that read a ref or refs from the user, the value
   of this option can be used to control the order of the refs.  Valid
@@ -1796,7 +1796,7 @@ per-repository log buffer, which can be consulted using the
 The output/errors for up to `magit-process-log-max' Git commands are
 retained.
 
-- Key: $, magit-process
+- Key: $ (magit-process) ::
 
   This commands displays the process buffer for the current
   repository.
@@ -1804,11 +1804,11 @@ retained.
 Inside that buffer, the usual key bindings for navigating and showing
 sections are available.  There is one additional command.
 
-- Key: k, magit-process-kill
+- Key: k (magit-process-kill) ::
 
   This command kills the process represented by the section at point.
 
-- Variable: magit-git-debug
+- Variable: magit-git-debug ::
 
   This option controls whether additional reporting of git errors is
   enabled.
@@ -1827,7 +1827,7 @@ sections are available.  There is one additional command.
   This is only intended for debugging purposes.  Do not enable this
   permanently, that would negatively affect performance.
 
-- Variable: magit-process-extreme-logging
+- Variable: magit-process-extreme-logging ::
 
   This option controls whether ~magit-process-file~ logs to the
   ~*Messages*~ buffer.
@@ -1865,12 +1865,12 @@ come in handy.  Magit provides some commands for running arbitrary Git
 commands by typing them into the minibuffer, instead of having to
 switch to a shell.
 
-- Key: !, magit-run
+- Key: ! (magit-run) ::
 
   This transient prefix command binds the following suffix commands
   and displays them in a temporary buffer until a suffix is invoked.
 
-- Key: ! !, magit-git-command-topdir
+- Key: ! ! (magit-git-command-topdir) ::
 
   This command reads a command from the user and executes it in the
   top-level directory of the current working tree.
@@ -1878,8 +1878,8 @@ switch to a shell.
   The string "git " is used as initial input when prompting the user
   for the command.  It can be removed to run another command.
 
-- Key: :, magit-git-command
-- Key: ! p, magit-git-command
+- Key: : (magit-git-command) ::
+- Key: ! p (magit-git-command) ::
 
   This command reads a command from the user and executes it in
   ~default-directory~.  With a prefix argument the command is executed
@@ -1888,37 +1888,37 @@ switch to a shell.
   The string "git " is used as initial input when prompting the user
   for the command.  It can be removed to run another command.
 
-- Key: ! s, magit-shell-command-topdir
+- Key: ! s (magit-shell-command-topdir) ::
 
   This command reads a command from the user and executes it in the
   top-level directory of the current working tree.
 
-- Key: ! S, magit-shell-command
+- Key: ! S (magit-shell-command) ::
 
   This command reads a command from the user and executes it in
   ~default-directory~.  With a prefix argument the command is executed
   in the top-level directory of the current working tree instead.
 
-- User Option: magit-shell-command-verbose-prompt
+- User Option: magit-shell-command-verbose-prompt ::
 
   Whether the prompt, used by the above commands when reading a
   shell command, shows the directory in which it will be run.
 
 These suffix commands start external gui tools.
 
-- Key: ! k, magit-run-gitk
+- Key: ! k (magit-run-gitk) ::
 
   This command runs ~gitk~ in the current repository.
 
-- Key: ! a, magit-run-gitk-all
+- Key: ! a (magit-run-gitk-all) ::
 
   This command runs ~gitk --all~ in the current repository.
 
-- Key: ! b, magit-run-gitk-branches
+- Key: ! b (magit-run-gitk-branches) ::
 
   This command runs ~gitk --branches~ in the current repository.
 
-- Key: ! g, magit-run-git-gui
+- Key: ! g (magit-run-git-gui) ::
 
   This command runs ~git gui~ in the current repository.
 
@@ -1944,14 +1944,14 @@ Tramp, would be problematic to use an absolute path that is suitable
 on the local machine, so a separate option is used to control the name
 or path that is used on remote machines.
 
-- User Option: magit-git-executable
+- User Option: magit-git-executable ::
 
   The ~git~ executable used by Magit on the local host.  This should be
   either the absolute path to the executable, or the string "git" to
   let Emacs find the executable itself, using the standard mechanism
   for doing such things.
 
-- User Option: magit-remote-git-executable
+- User Option: magit-remote-git-executable ::
 
   The ~git~ executable used by Magit on remote machines over Tramp.
   Normally this should be just the string "git".  Consider customizing
@@ -1973,12 +1973,12 @@ can help; though honestly I consider that a kludge too.
 The command ~magit-debug-git-executable~ can be useful to find out where
 Emacs is searching for ~git~.
 
-- Key: M-x magit-debug-git-executable, magit-debug-git-executable
+- Key: M-x magit-debug-git-executable (magit-debug-git-executable) ::
 
   This command displays a buffer with information about
   ~magit-git-executable~ and  ~magit-remote-git-executable~.
 
-- Key: M-x magit-version, magit-version
+- Key: M-x magit-version (magit-version) ::
 
   This command shows the currently used versions of Magit, Git, and
   Emacs in the echo area.  Non-interactively this just returns the
@@ -1986,7 +1986,7 @@ Emacs is searching for ~git~.
 
 *** Global Git Arguments
 
-- User Option: magit-git-global-arguments
+- User Option: magit-git-global-arguments ::
 
   The arguments set here are used every time the git executable is run
   as a subprocess.  They are placed right after the executable itself
@@ -2037,7 +2037,7 @@ that it should be bound globally.  We recommend using ~C-x g~:
   (global-set-key (kbd "C-x g") 'magit-status)
 #+end_src
 
-- Key: C-x g, magit-status
+- Key: C-x g (magit-status) ::
 
   When invoked from within an existing Git repository, then this
   command shows the status of that repository in a buffer.
@@ -2072,7 +2072,7 @@ that it should be bound globally.  We recommend using ~C-x g~:
     ~magit-repository-directories~, then the behavior is the same as with
     two prefix arguments.
 
-- User Option: magit-repository-directories
+- User Option: magit-repository-directories ::
 
   List of directories that are Git repositories or contain Git
   repositories.
@@ -2086,7 +2086,7 @@ that it should be bound globally.  We recommend using ~C-x g~:
   ~magit-list-repositories~.  It also affects ~magit-status~ (which see)
   in potentially surprising ways (see above).
 
-- Command: magit-status-quick
+- Command: magit-status-quick ::
 
   This command is an alternative to ~magit-status~ that usually avoids
   refreshing the status buffer.
@@ -2114,7 +2114,7 @@ that it should be bound globally.  We recommend using ~C-x g~:
   It supports displaying any existing Magit buffer that belongs to the
   current repository; not just the status buffer.
 
-- Command: ido-enter-magit-status
+- Command: ido-enter-magit-status ::
 
   From an Ido prompt used to open a file, instead drop into
   ~magit-status~.  This is similar to ~ido-magic-delete-char~, which,
@@ -2144,7 +2144,7 @@ The contents of status buffers is controlled using the hook
 ~magit-status-sections-hook~.  See [[*Section Hooks]] to learn about such
 hooks and how to customize them.
 
-- User Option: magit-status-sections-hook
+- User Option: magit-status-sections-hook ::
 
   Hook run to insert sections into a status buffer.
 
@@ -2152,39 +2152,39 @@ The first function on that hook by default is
 ~magit-insert-status-headers~; it is described in the next section.
 By default the following functions are also members of that hook:
 
-- Function: magit-insert-merge-log
+- Function: magit-insert-merge-log ::
 
   Insert section for the on-going merge.  Display the heads that are
   being merged.  If no merge is in progress, do nothing.
 
-- Function: magit-insert-rebase-sequence
+- Function: magit-insert-rebase-sequence ::
 
   Insert section for the on-going rebase sequence.
   If no such sequence is in progress, do nothing.
 
-- Function: magit-insert-am-sequence
+- Function: magit-insert-am-sequence ::
 
   Insert section for the on-going patch applying sequence.
   If no such sequence is in progress, do nothing.
 
-- Function: magit-insert-sequencer-sequence
+- Function: magit-insert-sequencer-sequence ::
 
   Insert section for the on-going cherry-pick or revert sequence.
   If no such sequence is in progress, do nothing.
 
-- Function: magit-insert-bisect-output
+- Function: magit-insert-bisect-output ::
 
   While bisecting, insert section with output from ~git bisect~.
 
-- Function: magit-insert-bisect-rest
+- Function: magit-insert-bisect-rest ::
 
   While bisecting, insert section visualizing the bisect state.
 
-- Function: magit-insert-bisect-log
+- Function: magit-insert-bisect-log ::
 
   While bisecting, insert section logging bisect progress.
 
-- Function: magit-insert-untracked-files
+- Function: magit-insert-untracked-files ::
 
   Maybe insert a list or tree of untracked files.
 
@@ -2193,48 +2193,48 @@ By default the following functions are also members of that hook:
   directories.  But the directory sections can then be expanded using
   ~TAB~.
 
-- Function: magit-insert-unstaged-changes
+- Function: magit-insert-unstaged-changes ::
 
   Insert section showing unstaged changes.
 
-- Function: magit-insert-staged-changes
+- Function: magit-insert-staged-changes ::
 
   Insert section showing staged changes.
 
-- Function: magit-insert-stashes &optional ref heading
+- Function: magit-insert-stashes &optional ref heading ::
 
   Insert the ~stashes~ section showing reflog for "refs/stash".
   If optional REF is non-nil show reflog for that instead.
   If optional HEADING is non-nil use that as section heading
   instead of "Stashes:".
 
-- Function: magit-insert-unpulled-from-upstream
+- Function: magit-insert-unpulled-from-upstream ::
 
   Insert section showing commits that haven't been pulled from the
   upstream branch yet.
 
-- Function: magit-insert-unpulled-from-pushremote
+- Function: magit-insert-unpulled-from-pushremote ::
 
   Insert section showing commits that haven't been pulled from the
   push-remote branch yet.
 
-- Function: magit-insert-unpushed-to-upstream
+- Function: magit-insert-unpushed-to-upstream ::
 
   Insert section showing commits that haven't been pushed to the
   upstream yet.
 
-- Function: magit-insert-unpushed-to-pushremote
+- Function: magit-insert-unpushed-to-pushremote ::
 
   Insert section showing commits that haven't been pushed to the
   push-remote yet.
 
 The following functions can also be added to the above hook:
 
-- Function: magit-insert-tracked-files
+- Function: magit-insert-tracked-files ::
 
   Insert a tree of tracked files.
 
-- Function: magit-insert-ignored-files
+- Function: magit-insert-ignored-files ::
 
   Insert a tree of ignored files.
   Its possible to limit the logs in the current buffer to a certain
@@ -2245,21 +2245,21 @@ The following functions can also be added to the above hook:
   this function only respects the first of the files and only if it is
   a directory.
 
-- Function: magit-insert-skip-worktree-files
+- Function: magit-insert-skip-worktree-files ::
 
   Insert a tree of skip-worktree files.
   If the first element of ~magit-buffer-diff-files~ is a
   directory, then limit the list to files below that.  The value
   of that variable can be set using ~D -- DIRECTORY RET g~.
 
-- Function: magit-insert-assumed-unchanged-files
+- Function: magit-insert-assumed-unchanged-files ::
 
   Insert a tree of files that are assumed to be unchanged.
   If the first element of ~magit-buffer-diff-files~ is a
   directory, then limit the list to files below that.  The value
   of that variable can be set using ~D -- DIRECTORY RET g~.
 
-- Function: magit-insert-unpulled-or-recent-commits
+- Function: magit-insert-unpulled-or-recent-commits ::
 
   Insert section showing unpulled or recent commits.
   If an upstream is configured for the current branch and it is
@@ -2267,18 +2267,18 @@ The following functions can also be added to the above hook:
   Otherwise, show the last ~magit-log-section-commit-count~
   commits.
 
-- Function: magit-insert-recent-commits
+- Function: magit-insert-recent-commits ::
 
   Insert section showing the last ~magit-log-section-commit-count~
   commits.
 
-- User Option: magit-log-section-commit-count
+- User Option: magit-log-section-commit-count ::
 
   How many recent commits ~magit-insert-recent-commits~ and
   ~magit-insert-unpulled-or-recent-commits~ (provided there are no
   unpulled commits) show.
 
-- Function: magit-insert-unpulled-cherries
+- Function: magit-insert-unpulled-cherries ::
 
   Insert section showing unpulled commits.
   Like ~magit-insert-unpulled-commits~ but prefix each commit
@@ -2286,7 +2286,7 @@ The following functions can also be added to the above hook:
   not shared with any local commit) with "+", and all others
   with "-".
 
-- Function: magit-insert-unpushed-cherries
+- Function: magit-insert-unpushed-cherries ::
 
   Insert section showing unpushed commits.
   Like ~magit-insert-unpushed-commits~ but prefix each commit
@@ -2305,13 +2305,13 @@ The contents of status buffers is controlled using the hook
 By default ~magit-insert-status-headers~ is the first member of that
 hook variable.
 
-- Function: magit-insert-status-headers
+- Function: magit-insert-status-headers ::
 
   Insert headers sections appropriate for ~magit-status-mode~ buffers.
   The sections are inserted by running the functions on the hook
   ~magit-status-headers-hook~.
 
-- User Option: magit-status-headers-hook
+- User Option: magit-status-headers-hook ::
 
   Hook run to insert headers sections into the status buffer.
 
@@ -2320,7 +2320,7 @@ hook variable.
 
 By default the following functions are members of the above hook:
 
-- Function: magit-insert-error-header
+- Function: magit-insert-error-header ::
 
   Insert a header line showing the message about the Git error that
   just occurred.
@@ -2330,36 +2330,36 @@ By default the following functions are members of the above hook:
   generating a diff, then that error won't be inserted.  Refreshing
   the status buffer causes this section to disappear again.
 
-- Function: magit-insert-diff-filter-header
+- Function: magit-insert-diff-filter-header ::
 
   Insert a header line showing the effective diff filters.
 
-- Function: magit-insert-head-branch-header
+- Function: magit-insert-head-branch-header ::
 
   Insert a header line about the current branch or detached ~HEAD~.
 
-- Function: magit-insert-upstream-branch-header
+- Function: magit-insert-upstream-branch-header ::
 
   Insert a header line about the branch that is usually pulled into
   the current branch.
 
-- Function: magit-insert-push-branch-header
+- Function: magit-insert-push-branch-header ::
 
   Insert a header line about the branch that the current branch is
   usually pushed to.
 
-- Function: magit-insert-tags-header
+- Function: magit-insert-tags-header ::
 
   Insert a header line about the current and/or next tag, along with
   the number of commits between the tag and ~HEAD~.
 
 The following functions can also be added to the above hook:
 
-- Function: magit-insert-repo-header
+- Function: magit-insert-repo-header ::
 
   Insert a header line showing the path to the repository top-level.
 
-- Function: magit-insert-remote-header
+- Function: magit-insert-remote-header ::
 
   Insert a header line about the remote of the current branch.
 
@@ -2367,7 +2367,7 @@ The following functions can also be added to the above hook:
   showing the "origin" remote, or if that does not exist the first
   remote in alphabetic order.
 
-- Function: magit-insert-user-header
+- Function: magit-insert-user-header ::
 
   Insert a header line about the current user.
 
@@ -2379,7 +2379,7 @@ The contents of status buffers is controlled using the hook
 By default ~magit-insert-modules~ is /not/ a member of that hook
 variable.
 
-- Function: magit-insert-modules
+- Function: magit-insert-modules ::
 
   Insert submodule sections.
 
@@ -2387,11 +2387,11 @@ variable.
   inserted, and option ~magit-module-sections-nested~ controls whether
   they are wrapped in an additional section.
 
-- User Option: magit-module-sections-hook
+- User Option: magit-module-sections-hook ::
 
   Hook run by ~magit-insert-modules~.
 
-- User Option: magit-module-sections-nested
+- User Option: magit-module-sections-nested ::
 
   This option controls whether ~magit-insert-modules~ wraps inserted
   sections in an additional section.
@@ -2400,7 +2400,7 @@ variable.
   If it is nil, then all sections listed in ~magit-module-sections-hook~
   become top-level sections.
 
-- Function: magit-insert-modules-overview
+- Function: magit-insert-modules-overview ::
 
   Insert sections for all submodules.  For each section insert the
   path, the branch, and the output of ~git describe --tags~,
@@ -2411,24 +2411,24 @@ variable.
   in a separate buffer.  This shows additional information not
   displayed in the super-repository's status buffer.
 
-- Function: magit-insert-modules-unpulled-from-upstream
+- Function: magit-insert-modules-unpulled-from-upstream ::
 
   Insert sections for modules that haven't been pulled from the
   upstream yet.  These sections can be expanded to show the respective
   commits.
 
-- Function: magit-insert-modules-unpulled-from-pushremote
+- Function: magit-insert-modules-unpulled-from-pushremote ::
 
   Insert sections for modules that haven't been pulled from the
   push-remote yet.  These sections can be expanded to show the
   respective commits.
 
-- Function: magit-insert-modules-unpushed-to-upstream
+- Function: magit-insert-modules-unpushed-to-upstream ::
 
   Insert sections for modules that haven't been pushed to the upstream
   yet.  These sections can be expanded to show the respective commits.
 
-- Function: magit-insert-modules-unpushed-to-pushremote
+- Function: magit-insert-modules-unpushed-to-pushremote ::
 
   Insert sections for modules that haven't been pushed to the
   push-remote yet.  These sections can be expanded to show the
@@ -2436,11 +2436,11 @@ variable.
 
 *** Status Options
 
-- User Option: magit-status-refresh-hook
+- User Option: magit-status-refresh-hook ::
 
   Hook run after a status buffer has been refreshed.
 
-- User Option: magit-status-margin
+- User Option: magit-status-margin ::
 
   This option specifies whether the margin is initially shown in
   Magit-Status mode buffers and how it is formatted.
@@ -2466,7 +2466,7 @@ buffers.
 
 ** Repository List
 
-- Command: magit-list-repositories
+- Command: magit-list-repositories ::
 
   This command displays a list of repositories in a separate buffer.
 
@@ -2474,7 +2474,7 @@ buffers.
   ~magit-repository-directories-depth~ control which repositories are
   displayed.
 
-- User Option: magit-repolist-columns
+- User Option: magit-repolist-columns ::
 
   This option controls what columns are displayed by the command
   ~magit-list-repositories~ and how they are displayed.
@@ -2496,37 +2496,37 @@ buffers.
 
 The following functions can be added to the above option:
 
-- Function: magit-repolist-column-ident
+- Function: magit-repolist-column-ident ::
 
   This function inserts the identification of the repository.  Usually
   this is just its basename.
 
-- Function: magit-repolist-column-path
+- Function: magit-repolist-column-path ::
 
   This function inserts the absolute path of the repository.
 
-- Function: magit-repolist-column-version
+- Function: magit-repolist-column-version ::
 
   This function inserts a description of the repository's ~HEAD~ revision.
 
-- Function: magit-repolist-column-branch
+- Function: magit-repolist-column-branch ::
 
   This function inserts the name of the current branch.
 
-- Function: magit-repolist-column-upstream
+- Function: magit-repolist-column-upstream ::
 
   This function inserts the name of the upstream branch of the current
   branch.
 
-- Function: magit-repolist-column-branches
+- Function: magit-repolist-column-branches ::
 
   This function inserts the number of branches.
 
-- Function: magit-repolist-column-stashes
+- Function: magit-repolist-column-stashes ::
 
   This function inserts the number of stashes.
 
-- Function: magit-repolist-column-flag
+- Function: magit-repolist-column-flag ::
 
   This function inserts a flag as specified by
   ~magit-repolist-column-flag-alist~.
@@ -2539,22 +2539,22 @@ The following functions can be added to the above option:
 
   Only the first one of these that applies is shown.
 
-- Function: magit-repolist-column-unpulled-from-upstream
+- Function: magit-repolist-column-unpulled-from-upstream ::
 
   This function inserts the number of upstream commits not in the
   current branch.
 
-- Function: magit-repolist-column-unpulled-from-pushremote
+- Function: magit-repolist-column-unpulled-from-pushremote ::
 
   This function inserts the number of commits in the push branch but
   not the current branch.
 
-- Function: magit-repolist-column-unpushed-to-upstream
+- Function: magit-repolist-column-unpushed-to-upstream ::
 
   This function inserts the number of commits in the current branch
   but not its upstream.
 
-- Function: magit-repolist-column-unpushed-to-pushremote
+- Function: magit-repolist-column-unpushed-to-pushremote ::
 
   This function inserts the number of commits in the current branch
   but not its push branch.
@@ -2579,38 +2579,38 @@ The switch ~++order=VALUE~ is converted to one of ~--author-date-order~,
 
 The log transient also features several reflog commands.  See [[*Reflog]].
 
-- Key: l, magit-log
+- Key: l (magit-log) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: l l, magit-log-current
+- Key: l l (magit-log-current) ::
 
   Show log for the current branch.  When ~HEAD~ is detached or with a
   prefix argument, show log for one or more revs read from the
   minibuffer.
 
-- Key: l o, magit-log-other
+- Key: l o (magit-log-other) ::
 
   Show log for one or more revs read from the minibuffer.  The user
   can input any revision or revisions separated by a space, or even
   ranges, but only branches, tags, and a representation of the
   commit at point are available as completion candidates.
 
-- Key: l h, magit-log-head
+- Key: l h (magit-log-head) ::
 
   Show log for ~HEAD~.
 
-- Key: l L, magit-log-branches
+- Key: l L (magit-log-branches) ::
 
   Show log for all local branches and ~HEAD~.
 
-- Key: l b, magit-log-all-branches
+- Key: l b (magit-log-all-branches) ::
 
   Show log for all local and remote branches and ~HEAD~.
 
-- Key: l a, magit-log-all
+- Key: l a (magit-log-all) ::
 
   Show log for all references and ~HEAD~.
 
@@ -2626,38 +2626,38 @@ change the log arguments used in the current buffer, without changing
 which log is shown.  This works in dedicated log buffers, but also in
 the status buffer.
 
-- Key: L, magit-log-refresh
+- Key: L (magit-log-refresh) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: L g, magit-log-refresh
+- Key: L g (magit-log-refresh) ::
 
   This suffix command sets the local log arguments for the current
   buffer.
 
-- Key: L s, magit-log-set-default-arguments
+- Key: L s (magit-log-set-default-arguments) ::
 
   This suffix command sets the default log arguments for buffers of
   the same type as that of the current buffer.  Other existing buffers
   of the same type are not affected because their local values have
   already been initialized.
 
-- Key: L w, magit-log-save-default-arguments
+- Key: L w (magit-log-save-default-arguments) ::
 
   This suffix command sets the default log arguments for buffers of
   the same type as that of the current buffer, and saves the value for
   future sessions.  Other existing buffers of the same type are not
   affected because their local values have already been initialized.
 
-- Key: L t, magit-toggle-margin
+- Key: L t (magit-toggle-margin) ::
 
   Show or hide the margin.
 
 *** Log Buffer
 
-- Key: L, magit-log-refresh
+- Key: L (magit-log-refresh) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -2665,28 +2665,28 @@ the status buffer.
 
   See [[*Refreshing Logs]].
 
-- Key: q, magit-log-bury-buffer
+- Key: q (magit-log-bury-buffer) ::
 
   Bury the current buffer or the revision buffer in the same frame.
   Like ~magit-mode-bury-buffer~ (which see) but with a negative prefix
   argument instead bury the revision buffer, provided it is displayed
   in the current frame.
 
-- Key: C-c C-b, magit-go-backward
+- Key: C-c C-b (magit-go-backward) ::
 
   Move backward in current buffer's history.
 
-- Key: C-c C-f, magit-go-forward
+- Key: C-c C-f (magit-go-forward) ::
 
   Move forward in current buffer's history.
 
-- Key: C-c C-n, magit-log-move-to-parent
+- Key: C-c C-n (magit-log-move-to-parent) ::
 
   Move to a parent of the current commit.  By default, this is the
   first parent, but a numeric prefix can be used to specify another
   parent.
 
-- Key: j, magit-log-move-to-revision
+- Key: j (magit-log-move-to-revision) ::
 
   Read a revision and move to it in current log buffer.
 
@@ -2697,7 +2697,7 @@ the status buffer.
   If invoked outside any log buffer, then display the log buffer
   of the current repository first; creating it if necessary.
 
-- Key: SPC, magit-diff-show-or-scroll-up
+- Key: SPC (magit-diff-show-or-scroll-up) ::
 
   Update the commit or diff buffer for the thing at point.
 
@@ -2707,7 +2707,7 @@ the status buffer.
   scroll the buffer up.  If there is no commit or stash at point, then
   prompt for a commit.
 
-- Key: DEL, magit-diff-show-or-scroll-down
+- Key: DEL (magit-diff-show-or-scroll-down) ::
 
   Update the commit or diff buffer for the thing at point.
 
@@ -2717,27 +2717,27 @@ the status buffer.
   scroll the buffer down.  If there is no commit or stash at point,
   then prompt for a commit.
 
-- Key: =, magit-log-toggle-commit-limit
+- Key: = (magit-log-toggle-commit-limit) ::
 
   Toggle the number of commits the current log buffer is limited to.
   If the number of commits is currently limited, then remove that
   limit.  Otherwise set it to 256.
 
-- Key: +, magit-log-double-commit-limit
+- Key: + (magit-log-double-commit-limit) ::
 
   Double the number of commits the current log buffer is limited to.
 
-- Key: -, magit-log-half-commit-limit
+- Key: - (magit-log-half-commit-limit) ::
 
   Half the number of commits the current log buffer is limited to.
 
-- User Option: magit-log-auto-more
+- User Option: magit-log-auto-more ::
 
   Insert more log entries automatically when moving past the last
   entry.  Only considered when moving past the last entry with
   ~magit-goto-*-section~ commands.
 
-- User Option: magit-log-show-refname-after-summary
+- User Option: magit-log-show-refname-after-summary ::
 
   Whether to show the refnames after the commit summaries.  This is
   useful if you use really long branch names.
@@ -2780,7 +2780,7 @@ used to configure the margin are named ~magit-INFIX-margin~, where INFIX
 is the same as in the respective major-mode ~magit-INFIX-mode~.  In
 regular log buffers that would be ~magit-log-margin~.
 
-- User Option: magit-log-margin
+- User Option: magit-log-margin ::
 
   This option specifies whether the margin is initially shown in
   Magit-Log mode buffers and how it is formatted.
@@ -2810,7 +2810,7 @@ in the default of all other options.  But setting it to ~t~, i.e.
 re-enforcing the default for that option, does not carry to other
 options.
 
-- User Option: magit-log-margin-show-committer-date
+- User Option: magit-log-margin-show-committer-date ::
 
   This option specifies whether to show the committer date in the
   margin.  This option only controls whether the committer date is
@@ -2818,7 +2818,7 @@ options.
   displayed in the margin and whether the margin is displayed at all
   is controlled by other options.
 
-- Key: L, magit-margin-settings
+- Key: L (magit-margin-settings) ::
 
   This transient prefix command binds the following suffix commands,
   each of which changes the appearance of the margin in some way.
@@ -2827,15 +2827,15 @@ In some buffers that support the margin, ~L~ is instead bound to
 ~magit-log-refresh~, but that transient features the same commands, and
 then some other unrelated commands.
 
-- Key: L L, magit-toggle-margin
+- Key: L L (magit-toggle-margin) ::
 
   This command shows or hides the margin.
 
-- Key: L l, magit-cycle-margin-style
+- Key: L l (magit-cycle-margin-style) ::
 
   This command cycles the style used for the margin.
 
-- Key: L d, magit-toggle-margin-details
+- Key: L d (magit-toggle-margin-details) ::
 
   This command shows or hides details in the margin.
 
@@ -2855,17 +2855,17 @@ In addition to the key bindings available in all log buffers, the
 following additional key bindings are available in selection log
 buffers:
 
-- Key: C-c C-c, magit-log-select-pick
+- Key: C-c C-c (magit-log-select-pick) ::
 
   Select the commit at point and act on it.  Call
   ~magit-log-select-pick-function~ with the selected commit as
   argument.
 
-- Key: C-c C-k, magit-log-select-quit
+- Key: C-c C-k (magit-log-select-quit) ::
 
   Abort selecting a commit, don't act on any commit.
 
-- User Option: magit-log-select-margin
+- User Option: magit-log-select-margin ::
 
   This option specifies whether the margin is initially shown in
   Magit-Log-Select mode buffers and how it is formatted.
@@ -2893,19 +2893,19 @@ Also see [[man:git-reflog]]
 These reflog commands are available from the log transient.  See
 [[*Logging]].
 
-- Key: l r, magit-reflog-current
+- Key: l r (magit-reflog-current) ::
 
   Display the reflog of the current branch.
 
-- Key: l O, magit-reflog-other
+- Key: l O (magit-reflog-other) ::
 
   Display the reflog of a branch or another ref.
 
-- Key: l H, magit-reflog-head
+- Key: l H (magit-reflog-head) ::
 
   Display the ~HEAD~ reflog.
 
-- User Option: magit-reflog-margin
+- User Option: magit-reflog-margin ::
 
   This option specifies whether the margin is initially shown in
   Magit-Reflog mode buffers and how it is formatted.
@@ -2939,12 +2939,12 @@ multiple "upstreams" at once.
 
 Also see [[man:git-reflog]]
 
-- Key: Y, magit-cherry
+- Key: Y (magit-cherry) ::
 
   Show commits that are in a certain branch but that have not been
   merged in the upstream branch.
 
-- User Option: magit-cherry-margin
+- User Option: magit-cherry-margin ::
 
   This option specifies whether the margin is initially shown in
   Magit-Cherry mode buffers and how it is formatted.
@@ -2981,17 +2981,17 @@ buffer, depending on the value of ~magit-prefix-use-buffer-arguments~
 
 Also see [[man:git-diff]]
 
-- Key: d, magit-diff
+- Key: d (magit-diff) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: d d, magit-diff-dwim
+- Key: d d (magit-diff-dwim) ::
 
   Show changes for the thing at point.
 
-- Key: d r, magit-diff-range
+- Key: d r (magit-diff-range) ::
 
   Show differences between two commits.
 
@@ -3005,23 +3005,23 @@ Also see [[man:git-diff]]
   revisions, choose a revision to view changes along, starting at the
   common ancestor of both revisions (i.e., use a "..."  range).
 
-- Key: d w, magit-diff-working-tree
+- Key: d w (magit-diff-working-tree) ::
 
   Show changes between the current working tree and the ~HEAD~ commit.
   With a prefix argument show changes between the working tree and a
   commit read from the minibuffer.
 
-- Key: d s, magit-diff-staged
+- Key: d s (magit-diff-staged) ::
 
   Show changes between the index and the ~HEAD~ commit.  With a prefix
   argument show changes between the index and a commit read from the
   minibuffer.
 
-- Key: d u, magit-diff-unstaged
+- Key: d u (magit-diff-unstaged) ::
 
   Show changes between the working tree and the index.
 
-- Key: d p, magit-diff-paths
+- Key: d p (magit-diff-paths) ::
 
   Show changes between any two files on disk.
 
@@ -3029,12 +3029,12 @@ All of the above suffix commands update the repository's diff buffer.
 The diff transient also features two commands which show differences
 in another buffer:
 
-- Key: d c, magit-show-commit
+- Key: d c (magit-show-commit) ::
 
   Show the commit at point.  If there is no commit at point or with a
   prefix argument, prompt for a commit.
 
-- Key: d t, magit-stash-show
+- Key: d t (magit-stash-show) ::
 
   Show all diffs of a stash in a buffer.
 
@@ -3049,46 +3049,46 @@ change the diff arguments used in the current buffer, without changing
 which diff is shown.  This works in dedicated diff buffers, but also
 in the status buffer.
 
-- Key: D, magit-diff-refresh
+- Key: D (magit-diff-refresh) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: D g, magit-diff-refresh
+- Key: D g (magit-diff-refresh) ::
 
   This suffix command sets the local diff arguments for the current
   buffer.
 
-- Key: D s, magit-diff-set-default-arguments
+- Key: D s (magit-diff-set-default-arguments) ::
 
   This suffix command sets the default diff arguments for buffers of
   the same type as that of the current buffer.  Other existing buffers
   of the same type are not affected because their local values have
   already been initialized.
 
-- Key: D w, magit-diff-save-default-arguments
+- Key: D w (magit-diff-save-default-arguments) ::
 
   This suffix command sets the default diff arguments for buffers of
   the same type as that of the current buffer, and saves the value for
   future sessions.  Other existing buffers of the same type are not
   affected because their local values have already been initialized.
 
-- Key: D t, magit-diff-toggle-refine-hunk
+- Key: D t (magit-diff-toggle-refine-hunk) ::
 
   This command toggles hunk refinement on or off.
 
-- Key: D r, magit-diff-switch-range-type
+- Key: D r (magit-diff-switch-range-type) ::
 
   This command converts the diff range type from "revA..revB" to
   "revB...revA", or vice versa.
 
-- Key: D f, magit-diff-flip-revs
+- Key: D f (magit-diff-flip-revs) ::
 
   This command swaps revisions in the diff range from "revA..revB"
   to "revB..revA", or vice versa.
 
-- Key: D F, magit-diff-toggle-file-filter
+- Key: D F (magit-diff-toggle-file-filter) ::
 
   This command toggles the file restriction of the diffs in the
   current buffer, allowing you to quickly switch between viewing all
@@ -3102,22 +3102,22 @@ In addition to the above transient, which allows changing any of the
 supported arguments, there also exist some commands that change only
 a particular argument.
 
-- Key: -, magit-diff-less-context
+- Key: - (magit-diff-less-context) ::
 
   This command decreases the context for diff hunks by COUNT lines.
 
-- Key: +, magit-diff-more-context
+- Key: + (magit-diff-more-context) ::
 
   This command increases the context for diff hunks by COUNT lines.
 
-- Key: 0, magit-diff-default-context
+- Key: 0 (magit-diff-default-context) ::
 
   This command resets the context for diff hunks to the default height.
 
 The following commands quickly change what diff is being displayed
 without having to using one of the diff transient.
 
-- Key: C-c C-d, magit-diff-while-committing
+- Key: C-c C-d (magit-diff-while-committing) ::
 
   While committing, this command shows the changes that are about to
   be committed.  While amending, invoking the command again toggles
@@ -3127,11 +3127,11 @@ without having to using one of the diff transient.
   This binding is available in the diff buffer as well as the commit
   message buffer.
 
-- Key: C-c C-b, magit-go-backward
+- Key: C-c C-b (magit-go-backward) ::
 
   This command moves backward in current buffer's history.
 
-- Key: C-c C-f, magit-go-forward
+- Key: C-c C-f (magit-go-forward) ::
 
   This command moves forward in current buffer's history.
 
@@ -3145,18 +3145,18 @@ version of the file that the diff at point is about.  Likewise
 version of the file that the diff at point is about.  See [[*Visiting
 Files and Blobs from a Diff]] for more information and the key bindings.
 
-- Key: C-c C-t, magit-diff-trace-definition
+- Key: C-c C-t (magit-diff-trace-definition) ::
 
   This command shows a log for the definition at point.
 
-- User Option: magit-log-trace-definition-function
+- User Option: magit-log-trace-definition-function ::
 
   The function specified by this option is used by
   ~magit-log-trace-definition~ to determine the function at point.  For
   major-modes that have special needs, you could set the local value
   using the mode's hook.
 
-- Key: C-c C-e, magit-diff-edit-hunk-commit
+- Key: C-c C-e (magit-diff-edit-hunk-commit) ::
 
   From a hunk, this command edits the respective commit and visits
   the file.
@@ -3176,7 +3176,7 @@ Files and Blobs from a Diff]] for more information and the key bindings.
   the rebase.  If that is undesirable, then it might be better to
   use ~magit-rebase-edit-command~ instead of this command.
 
-- Key: j, magit-jump-to-diffstat-or-diff
+- Key: j (magit-jump-to-diffstat-or-diff) ::
 
   This command jumps to the diffstat or diff.  When point is on a file
   inside the diffstat section, then jump to the respective diff
@@ -3187,17 +3187,17 @@ The next two commands are not specific to Magit-Diff mode (or and
 Magit buffer for that matter), but it might be worth pointing out
 that they are available here too.
 
-- Key: SPC, scroll-up
+- Key: SPC (scroll-up) ::
 
   This command scrolls text upward.
 
-- Key: DEL, scroll-down
+- Key: DEL (scroll-down) ::
 
   This command scrolls text downward.
 
 *** Diff Options
 
-- User Option: magit-diff-refine-hunk
+- User Option: magit-diff-refine-hunk ::
 
   Whether to show word-granularity differences within diff hunks.
 
@@ -3205,12 +3205,12 @@ that they are available here too.
   - ~t~ Show fine differences for the current diff hunk only.
   - ~all~ Show fine differences for all displayed diff hunks.
 
-- User Option: magit-diff-refine-ignore-whitespace
+- User Option: magit-diff-refine-ignore-whitespace ::
 
   Whether to ignore whitespace changes in word-granularity
   differences.
 
-- User Option: magit-diff-adjust-tab-width
+- User Option: magit-diff-adjust-tab-width ::
 
   Whether to adjust the width of tabs in diffs.
 
@@ -3232,7 +3232,7 @@ that they are available here too.
   - NUMBER Like ~always~, but don't visit files larger than NUMBER
     bytes.
 
-- User Option: magit-diff-paint-whitespace
+- User Option: magit-diff-paint-whitespace ::
 
   Specify where to highlight whitespace errors.
 
@@ -3247,7 +3247,7 @@ that they are available here too.
     uncommitted changes.  For backward compatibility ~status~ is treated
     as a synonym.
 
-- User Option: magit-diff-paint-whitespace-lines
+- User Option: magit-diff-paint-whitespace-lines ::
 
   Specify in what kind of lines to highlight whitespace errors.
 
@@ -3255,12 +3255,12 @@ that they are available here too.
   - ~both~ Highlight in added and removed lines.
   - ~all~ Highlight in added, removed and context lines.
 
-- User Option: magit-diff-highlight-trailing
+- User Option: magit-diff-highlight-trailing ::
 
   Whether to highlight whitespace at the end of a line in diffs.  Used
   only when ~magit-diff-paint-whitespace~ is non-nil.
 
-- User Option: magit-diff-highlight-indentation
+- User Option: magit-diff-highlight-indentation ::
 
   This option controls whether to highlight the indentation in case it
   used the "wrong" indentation style.  Indentation is only highlighted
@@ -3275,11 +3275,11 @@ that they are available here too.
   INDENT is an integer, highlight indentation with at least that many
   spaces.  Otherwise, highlight neither.
 
-- User Option: magit-diff-hide-trailing-cr-characters
+- User Option: magit-diff-hide-trailing-cr-characters ::
 
   Whether to hide ^M characters at the end of a line in diffs.
 
-- User Option: magit-diff-highlight-hunk-region-functions
+- User Option: magit-diff-highlight-hunk-region-functions ::
 
   This option specifies the functions used to highlight the
   hunk-internal region.
@@ -3304,14 +3304,14 @@ that they are available here too.
   and underline variants normally do, so there they fall back to
   calling the face function instead.
 
-- User Option: magit-diff-unmarked-lines-keep-foreground
+- User Option: magit-diff-unmarked-lines-keep-foreground ::
 
   This option controls whether added and removed lines outside the
   hunk-internal region only lose their distinct background color or
   also the foreground color.  Whether the outside of the region is
   dimmed at all depends on ~magit-diff-highlight-hunk-region-functions~.
 
-- User Option: magit-diff-extra-stat-arguments
+- User Option: magit-diff-extra-stat-arguments ::
 
   This option specifies additional arguments to be used alongside
   ~--stat~.
@@ -3323,7 +3323,7 @@ that they are available here too.
 
 *** Revision Buffer
 
-- User Option: magit-revision-insert-related-refs
+- User Option: magit-revision-insert-related-refs ::
 
   Whether to show related branches in revision buffers.
 
@@ -3332,7 +3332,7 @@ that they are available here too.
   - ~all~ Show related local and remote branches.
   - ~mixed~ Show all containing branches and local merged branches.
 
-- User Option: magit-revision-show-gravatars
+- User Option: magit-revision-show-gravatars ::
 
   Whether to show gravatar images in revision buffers.
 
@@ -3349,7 +3349,7 @@ that they are available here too.
   same column.  The cdr specifies where to insert the committer's
   image, accordingly.  Either the car or the cdr may be nil."
 
-- User Option: magit-revision-use-hash-sections
+- User Option: magit-revision-use-hash-sections ::
 
   Whether to turn hashes inside the commit message into sections.
 
@@ -3373,7 +3373,7 @@ from a log buffer, the revision buffer will share the same file
 restriction as that log buffer (also see the command
 ~magit-diff-toggle-file-filter~).
 
-- User Option: magit-revision-filter-files-on-follow
+- User Option: magit-revision-filter-files-on-follow ::
 
   Whether showing a commit from a log buffer honors the log's file
   filter when the log arguments include ~--follow~.
@@ -3396,7 +3396,7 @@ Buffer Variables]]).
 This section describes how to enter Ediff from Magit buffers.  For
 information on how to use Ediff itself, see info:ediff.
 
-- Key: e, magit-ediff-dwim
+- Key: e (magit-ediff-dwim) ::
 
   Compare, stage, or resolve using Ediff.
 
@@ -3408,12 +3408,12 @@ information on how to use Ediff itself, see info:ediff.
   explicitly.  If it cannot read the user's mind at all, then it asks
   the user for a command to run.
 
-- Key: E, magit-ediff
+- Key: E (magit-ediff) ::
 
   This transient prefix command binds the following suffix commands
   and displays them in a temporary buffer until a suffix is invoked.
 
-- Key: E r, magit-ediff-compare
+- Key: E r (magit-ediff-compare) ::
 
   Compare two revisions of a file using Ediff.
 
@@ -3422,7 +3422,7 @@ information on how to use Ediff itself, see info:ediff.
   revisions, choose a revision to view changes along, starting at the
   common ancestor of both revisions (i.e., use a "..."  range).
 
-- Key: E m, magit-ediff-resolve
+- Key: E m (magit-ediff-resolve) ::
 
   Resolve outstanding conflicts in a file using Ediff, defaulting to
   the file at point.
@@ -3435,32 +3435,32 @@ information on how to use Ediff itself, see info:ediff.
   including those already resolved by Git, use
   ~ediff-merge-revisions-with-ancestor~.
 
-- Key: E s, magit-ediff-stage
+- Key: E s (magit-ediff-stage) ::
 
   Stage and unstage changes to a file using Ediff, defaulting to the
   file at point.
 
-- Key: E u, magit-ediff-show-unstaged
+- Key: E u (magit-ediff-show-unstaged) ::
 
   Show unstaged changes to a file using Ediff.
 
-- Key: E i, magit-ediff-show-staged
+- Key: E i (magit-ediff-show-staged) ::
 
   Show staged changes to a file using Ediff.
 
-- Key: E w, magit-ediff-show-working-tree
+- Key: E w (magit-ediff-show-working-tree) ::
 
   Show changes in a file between ~HEAD~ and working tree using Ediff.
 
-- Key: E c, magit-ediff-show-commit
+- Key: E c (magit-ediff-show-commit) ::
 
   Show changes to a file introduced by a commit using Ediff.
 
-- Key: E z, magit-ediff-show-stash
+- Key: E z (magit-ediff-show-stash) ::
 
   Show changes to a file introduced by a stash using Ediff.
 
-- User Option: magit-ediff-dwim-show-on-hunks
+- User Option: magit-ediff-dwim-show-on-hunks ::
 
   This option controls what command ~magit-ediff-dwim~ calls when
   point is on uncommitted hunks.  When nil, always run
@@ -3468,14 +3468,14 @@ information on how to use Ediff itself, see info:ediff.
   ~magit-ediff-show-unstaged~ to show staged and unstaged changes,
   respectively.
 
-- User Option: magit-ediff-show-stash-with-index
+- User Option: magit-ediff-show-stash-with-index ::
 
   This option controls whether ~magit-ediff-show-stash~ includes a
   buffer containing the file's state in the index at the time the
   stash was created.  This makes it possible to tell which changes in
   the stash were staged.
 
-- User Option: magit-ediff-quit-hook
+- User Option: magit-ediff-quit-hook ::
 
   This hook is run after quitting an Ediff session that was created
   using a Magit command.  The hook functions are run inside the Ediff
@@ -3487,7 +3487,7 @@ information on how to use Ediff itself, see info:ediff.
 
 ** References Buffer
 
-- Key: y, magit-show-refs
+- Key: y (magit-show-refs) ::
 
   This command lists branches and tags in a dedicated buffer.
 
@@ -3502,27 +3502,27 @@ enabled by changing the value of ~magit-refs-show-commit-count~ (see
 below).  These commands specify a different branch or commit against
 which all the other references are compared.
 
-- Key: y y, magit-show-refs-head
+- Key: y y (magit-show-refs-head) ::
 
   This command lists branches and tags in a dedicated buffer.  Each
   reference is being compared with ~HEAD~.
 
-- Key: y c, magit-show-refs-current
+- Key: y c (magit-show-refs-current) ::
 
   This command lists branches and tags in a dedicated buffer.  Each
   reference is being compared with the current branch or ~HEAD~ if it
   is detached.
 
-- Key: y o, magit-show-refs-other
+- Key: y o (magit-show-refs-other) ::
 
   This command lists branches and tags in a dedicated buffer.  Each
   reference is being compared with a branch read from the user.
 
-- Key: y r, magit-refs-set-show-commit-count
+- Key: y r (magit-refs-set-show-commit-count) ::
 
   This command changes for which refs the commit count is shown.
 
-- User Option: magit-refs-show-commit-count
+- User Option: magit-refs-show-commit-count ::
 
   Whether to show commit counts in Magit-Refs mode buffers.
 
@@ -3532,7 +3532,7 @@ which all the other references are compared.
 
   The default is ~nil~ because anything else can be very expensive.
 
-- User Option: magit-refs-pad-commit-counts
+- User Option: magit-refs-pad-commit-counts ::
 
   Whether to pad all commit counts on all sides in Magit-Refs mode
   buffers.
@@ -3545,14 +3545,14 @@ which all the other references are compared.
   If this is non-nil, then spaces are placed on both sides of all
   commit counts.
 
-- User Option: magit-refs-show-remote-prefix
+- User Option: magit-refs-show-remote-prefix ::
 
   Whether to show the remote prefix in lists of remote branches.
 
   Showing the prefix is redundant because the name of the remote is
   already shown in the heading preceding the list of its branches.
 
-- User Option: magit-refs-primary-column-width
+- User Option: magit-refs-primary-column-width ::
 
   Width of the primary column in `magit-refs-mode' buffers.  The
   primary column is the column that contains the name of the branch
@@ -3565,7 +3565,7 @@ which all the other references are compared.
   the shown local branches.  (Remote branches and tags are not taken
   into account when calculating to optimal width.)
 
-- User Option: magit-refs-focus-column-width
+- User Option: magit-refs-focus-column-width ::
 
   Width of the focus column in `magit-refs-mode' buffers.
 
@@ -3580,7 +3580,7 @@ which all the other references are compared.
   which case this option is ignored.  Use ~L v~ to change the verbosity
   of this column.
 
-- User Option: magit-refs-margin
+- User Option: magit-refs-margin ::
 
   This option specifies whether the margin is initially shown in
   Magit-Refs mode buffers and how it is formatted.
@@ -3601,7 +3601,7 @@ which all the other references are compared.
   - AUTHOR-WIDTH has to be an integer.  When the name of the author
     is shown, then this specifies how much space is used to do so.
 
-- User Option: magit-refs-margin-for-tags
+- User Option: magit-refs-margin-for-tags ::
 
   This option specifies whether to show information about tags in the
   margin.  This is disabled by default because it is slow if there are
@@ -3626,7 +3626,7 @@ should also change the others to keep things aligned.  The following
 - ~%U~ Upstream of this local branch and additional local vs. upstream
   information.
 
-- User Option: magit-refs-filter-alist
+- User Option: magit-refs-filter-alist ::
 
   The purpose of this option is to forgo displaying certain refs
   based on their name.  If you want to not display any refs of a
@@ -3648,7 +3648,7 @@ should also change the others to keep things aligned.  The following
   displayed as just "master", however for this comparison the
   former is used.
 
-- Key: RET, magit-visit-ref
+- Key: RET (magit-visit-ref) ::
 
   This command visits the reference or revision at point in another
   buffer.  If there is no revision at point or with a prefix argument
@@ -3659,7 +3659,7 @@ should also change the others to keep things aligned.  The following
   which case the behavior may be different, but only if you have
   customized the option ~magit-visit-ref-behavior~.
 
-- User Option: magit-visit-ref-behavior
+- User Option: magit-visit-ref-behavior ::
 
   This option controls how ~magit-visit-ref~ behaves in ~magit-refs-mode~
   buffers.
@@ -3729,19 +3729,19 @@ the default value.  Note that it makes much less sense to customize
 this hook than it does for the respective hook used for the status
 buffer.
 
-- User Option: magit-refs-sections-hook
+- User Option: magit-refs-sections-hook ::
 
   Hook run to insert sections into a references buffer.
 
-- Function: magit-insert-local-branches
+- Function: magit-insert-local-branches ::
 
   Insert sections showing all local branches.
 
-- Function: magit-insert-remote-branches
+- Function: magit-insert-remote-branches ::
 
   Insert sections showing all remote-tracking branches.
 
-- Function: magit-insert-tags
+- Function: magit-insert-tags ::
 
   Insert sections showing all tags.
 
@@ -3749,7 +3749,7 @@ buffer.
 
 Also see [[man:git-bisect]]
 
-- Key: B, magit-bisect
+- Key: B (magit-bisect) ::
 
   This transient prefix command binds the following suffix commands
   and displays them in a temporary buffer until a suffix is invoked.
@@ -3757,7 +3757,7 @@ Also see [[man:git-bisect]]
 When bisecting is not in progress, then the transient features the
 following suffix commands.
 
-- Key: B B, magit-bisect-start
+- Key: B B (magit-bisect-start) ::
 
   Start a bisect session.
 
@@ -3768,37 +3768,37 @@ following suffix commands.
   conceptually more fitting than "bad" and "good", but the infix
   arguments to do so are disabled by default.
 
-- Key: B s, magit-bisect-run
+- Key: B s (magit-bisect-run) ::
 
   Bisect automatically by running commands after each step.
 
 When bisecting in progress, then the transient instead features the
 following suffix commands.
 
-- Key: B b, magit-bisect-bad
+- Key: B b (magit-bisect-bad) ::
 
   Mark the current commit as bad.  Use this after you have asserted
   that the commit does contain the bug in question.
 
-- Key: B g, magit-bisect-good
+- Key: B g (magit-bisect-good) ::
 
   Mark the current commit as good.  Use this after you have asserted
   that the commit does not contain the bug in question.
 
-- Key: B m, magit-bisect-mark
+- Key: B m (magit-bisect-mark) ::
 
   Mark the current commit with one of the bisect terms.  This command
   provides an alternative to ~magit-bisect-bad~ and
   ~magit-bisect-good~ and is useful when using terms other than "bad"
   and "good".  This suffix is disabled by default.
 
-- Key: B k, magit-bisect-skip
+- Key: B k (magit-bisect-skip) ::
 
   Skip the current commit.  Use this if for some reason the current
   commit is not a good one to test.  This command lets Git choose a
   different one.
 
-- Key: B r, magit-bisect-reset
+- Key: B r (magit-bisect-reset) ::
 
   After bisecting, cleanup bisection state and return to original
   ~HEAD~.
@@ -3806,7 +3806,7 @@ following suffix commands.
 By default the status buffer shows information about the ongoing
 bisect session.
 
-- User Option: magit-bisect-show-graph
+- User Option: magit-bisect-show-graph ::
 
   This option controls whether a graph is displayed for the log of
   commits that still have to be bisected.
@@ -3824,19 +3824,19 @@ These commands can be used anywhere to open any blob.  Currently no
 keys are bound to these commands by default, but that is likely to
 change.
 
-- Command: magit-find-file
+- Command: magit-find-file ::
 
   This command reads a filename and revision from the user and visits
   the respective blob in a buffer.  The buffer is displayed in the
   selected window.
 
-- Command: magit-find-file-other-window
+- Command: magit-find-file-other-window ::
 
   This command reads a filename and revision from the user and visits
   the respective blob in a buffer.  The buffer is displayed in another
   window.
 
-- Command: magit-find-file-other-frame
+- Command: magit-find-file-other-frame ::
 
   This command reads a filename and revision from the user and visits
   the respective blob in a buffer.  The buffer is displayed in another
@@ -3846,7 +3846,7 @@ change.
 
 These commands can only be used when point is inside a diff.
 
-- Key: RET, magit-diff-visit-file
+- Key: RET (magit-diff-visit-file) ::
 
   This command visits the appropriate version of the file that the
   diff at point is about.
@@ -3877,7 +3877,7 @@ These commands can only be used when point is inside a diff.
   The buffer is displayed in the selected window.  With a prefix
   argument the buffer is displayed in another window instead.
 
-- User Option: magit-diff-visit-previous-blob
+- User Option: magit-diff-visit-previous-blob ::
 
   This option controls whether ~magit-diff-visit-file~ may visit the
   previous blob.  When this is ~t~ (the default) and point is on a
@@ -3889,7 +3889,7 @@ These commands can only be used when point is inside a diff.
   and unstaged changes ~magit-diff-visit-file~ always visits the file in
   the working tree.
 
-- Key: C-<return>, magit-diff-visit-file-worktree
+- Key: C-<return> (magit-diff-visit-file-worktree) ::
 
   This command visits the worktree version of the appropriate file.
   The location of point inside the diff determines which file is being
@@ -3910,10 +3910,10 @@ then you may want to change the above key bindings, but note that the
 above commands also use another window when invoked with a prefix
 argument.
 
-- Command: magit-diff-visit-file-other-window
-- Command: magit-diff-visit-file-other-frame
-- Command: magit-diff-visit-worktree-file-other-window
-- Command: magit-diff-visit-worktree-file-other-frame
+- Command: magit-diff-visit-file-other-window ::
+- Command: magit-diff-visit-file-other-frame ::
+- Command: magit-diff-visit-worktree-file-other-window ::
+- Command: magit-diff-visit-worktree-file-other-frame ::
 
 ** Blaming
 
@@ -3929,7 +3929,7 @@ have to enter the blaming sub-transient first.
 The key bindings shown below assume that you enter the dispatch
 transient using the default binding.
 
-- Key: C-c M-g B, magit-blame
+- Key: C-c M-g B (magit-blame) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -3940,8 +3940,8 @@ times.  For example if ~magit-blame-mode~ is not enabled, then the
 command whose purpose is to turn off that mode would not be of any
 use and therefore isn't available.
 
-- Key: C-c M-g b, magit-blame-addition
-- Key: C-c M-g B b, magit-blame-addition
+- Key: C-c M-g b (magit-blame-addition) ::
+- Key: C-c M-g B b (magit-blame-addition) ::
 
   This command augments each line or chunk of lines in the current
   file-visiting or blob-visiting buffer with information about what
@@ -3956,8 +3956,8 @@ use and therefore isn't available.
   ~magit-find-file~), where REVISION is a parent of the revision that
   added the current line or chunk of lines.
 
-- Key: C-c M-g r, magit-blame-removal
-- Key: C-c M-g B r, magit-blame-removal
+- Key: C-c M-g r (magit-blame-removal) ::
+- Key: C-c M-g B r (magit-blame-removal) ::
 
   This command augments each line or chunk of lines in the current
   blob-visiting buffer with information about the revision that
@@ -3965,8 +3965,8 @@ use and therefore isn't available.
 
   Like ~magit-blame-addition~, this command can be used recursively.
 
-- Key: C-c M-g f, magit-blame-reverse
-- Key: C-c M-g B f, magit-blame-reverse
+- Key: C-c M-g f (magit-blame-reverse) ::
+- Key: C-c M-g B f (magit-blame-reverse) ::
 
   This command augments each line or chunk of lines in the current
   file-visiting or blob-visiting buffer with information about the
@@ -3974,8 +3974,8 @@ use and therefore isn't available.
 
   Like ~magit-blame-addition~, this command can be used recursively.
 
-- Key: C-c M-g e, magit-blame-echo
-- Key: C-c M-g B e, magit-blame-echo
+- Key: C-c M-g e (magit-blame-echo) ::
+- Key: C-c M-g B e (magit-blame-echo) ::
 
   This command is like ~magit-blame-addition~ except that it doesn't
   turn on ~read-only-mode~ and that it initially uses the visualization
@@ -3986,11 +3986,11 @@ enabled and Read-Only mode is not enabled.  These commands are also
 available in other buffers; here only the behavior is described that
 is relevant in file-visiting buffers that are being blamed.
 
-- Key: RET, magit-show-commit
+- Key: RET (magit-show-commit) ::
 
   This command shows the commit that last touched the line at point.
 
-- Key: SPC, magit-diff-show-or-scroll-up
+- Key: SPC (magit-diff-show-or-scroll-up) ::
 
   This command updates the commit buffer.
 
@@ -3999,7 +3999,7 @@ is relevant in file-visiting buffers that are being blamed.
   in the current frame and if that buffer contains information about
   that commit, then the buffer is scrolled up instead.
 
-- Key: DEL, magit-diff-show-or-scroll-down
+- Key: DEL (magit-diff-show-or-scroll-down) ::
 
   This command updates the commit buffer.
 
@@ -4011,32 +4011,32 @@ is relevant in file-visiting buffers that are being blamed.
 The following key bindings are available when both Magit-Blame mode
 and Read-Only mode are enabled.
 
-- Key: b, magit-blame
+- Key: b (magit-blame) ::
 
   See above.
 
-- Key: n, magit-blame-next-chunk
+- Key: n (magit-blame-next-chunk) ::
 
   This command moves to the next chunk.
 
-- Key: N, magit-blame-next-chunk-same-commit
+- Key: N (magit-blame-next-chunk-same-commit) ::
 
   This command moves to the next chunk from the same commit.
 
-- Key: p, magit-blame-previous-chunk
+- Key: p (magit-blame-previous-chunk) ::
 
   This command moves to the previous chunk.
 
-- Key: P, magit-blame-previous-chunk-same-commit
+- Key: P (magit-blame-previous-chunk-same-commit) ::
 
   This command moves to the previous chunk from the same commit.
 
-- Key: q, magit-blame-quit
+- Key: q (magit-blame-quit) ::
 
   This command turns off Magit-Blame mode.  If the buffer was created
   during a recursive blame, then it also kills the buffer.
 
-- Key: M-w, magit-blame-copy-hash
+- Key: M-w (magit-blame-copy-hash) ::
 
   This command saves the hash of the current chunk's commit to the
   kill ring.
@@ -4044,7 +4044,7 @@ and Read-Only mode are enabled.
   When the region is active, the command saves the region's content
   instead of the hash, like ~kill-ring-save~ would.
 
-- Key: c, magit-blame-cycle-style
+- Key: c (magit-blame-cycle-style) ::
 
   This command changes how blame information is visualized in the
   current buffer by cycling through the styles specified using the
@@ -4052,41 +4052,41 @@ and Read-Only mode are enabled.
 
 Blaming is also controlled using the following options.
 
-- User Option: magit-blame-styles
+- User Option: magit-blame-styles ::
 
   This option defines a list of styles used to visualize blame
   information.  For now see its doc-string to learn more.
 
-- User Option: magit-blame-echo-style
+- User Option: magit-blame-echo-style ::
 
   This option specifies the blame visualization style used by the
   command ~magit-blame-echo~.  This must be a symbol that is used as the
   identifier for one of the styles defined in ~magit-blame-styles~.
 
-- User Option: magit-blame-time-format
+- User Option: magit-blame-time-format ::
 
   This option specifies the format string used to display times when
   showing blame information.
 
-- User Option: magit-blame-read-only
+- User Option: magit-blame-read-only ::
 
   This option controls whether blaming a buffer also makes temporarily
   read-only.
 
-- User Option: magit-blame-disable-modes
+- User Option: magit-blame-disable-modes ::
 
   This option lists incompatible minor-modes that should be disabled
   temporarily when a buffer contains blame information.  They are
   enabled again when the buffer no longer shows blame information.
 
-- User Option: magit-blame-goto-chunk-hook
+- User Option: magit-blame-goto-chunk-hook ::
 
   This hook is run when moving between chunks.
 
 * Manipulating
 ** Creating Repository
 
-- Key: I, magit-init
+- Key: I (magit-init) ::
 
   This command initializes a repository and then shows the status
   buffer for the new repository.
@@ -4104,7 +4104,7 @@ command, which binds several infix arguments and suffix commands, or
 it can invoke ~git clone~ directly, depending on whether a prefix
 argument is used and on the value of ~magit-clone-always-transient~.
 
-- User Option: magit-clone-always-transient
+- User Option: magit-clone-always-transient ::
 
   This option controls whether the command ~magit-clone~ always acts as
   a transient prefix command, regardless of whether a prefix argument
@@ -4112,7 +4112,7 @@ argument is used and on the value of ~magit-clone-always-transient~.
   prefix.  If ~nil~, then a prefix argument has to be used for it to act
   as a transient.
 
-- Key: C, magit-clone
+- Key: C (magit-clone) ::
 
   This command either acts as a transient prefix command as described
   above or does the same thing as ~transient-clone-regular~ as described
@@ -4121,24 +4121,24 @@ argument is used and on the value of ~magit-clone-always-transient~.
   If it acts as a transient prefix, then it binds the following suffix
   commands and several infix arguments.
 
-- Key: C C, magit-clone-regular
+- Key: C C (magit-clone-regular) ::
 
   This command creates a regular clone of an existing repository.
   The repository and the target directory are read from the user.
 
-- Key: C s, magit-clone-shallow
+- Key: C s (magit-clone-shallow) ::
 
   This command creates a shallow clone of an existing repository.
   The repository and the target directory are read from the user.
   By default the depth of the cloned history is a single commit,
   but with a prefix argument the depth is read from the user.
 
-- Key: C b, magit-clone-bare
+- Key: C b (magit-clone-bare) ::
 
   This command creates a bare clone of an existing repository.
   The repository and the target directory are read from the user.
 
-- Key: C m, magit-clone-mirror
+- Key: C m (magit-clone-mirror) ::
 
   This command creates a mirror of an existing repository.
   The repository and the target directory are read from the user.
@@ -4146,21 +4146,21 @@ argument is used and on the value of ~magit-clone-always-transient~.
 The following suffixes are disabled by default. See
 [[info:transient#Enabling and Disabling Suffixes]] for how to enable them.
 
-- Key: C d, magit-clone-shallow-since
+- Key: C d (magit-clone-shallow-since) ::
 
   This command creates a shallow clone of an existing repository.
   Only commits that were committed after a date are cloned, which
   is read from the user.  The repository and the target directory
   are also read from the user.
 
-- Key: C e, magit-clone-shallow-exclude
+- Key: C e (magit-clone-shallow-exclude) ::
 
   This command creates a shallow clone of an existing repository.
   This reads a branch or tag from the user.  Commits that are
   reachable from that are not cloned.  The repository and the target
   directory are also read from the user.
 
-- User Option: magit-clone-set-remote-head
+- User Option: magit-clone-set-remote-head ::
 
   This option controls whether cloning causes the reference
   ~refs/remotes/<remote>/HEAD~ to be created in the clone.  The default
@@ -4170,7 +4170,7 @@ The following suffixes are disabled by default. See
   of the remote changes.  Setting this option to ~t~ preserves Git's
   default behavior of creating the reference.
 
-- User Option: magit-clone-set-remote.pushDefault
+- User Option: magit-clone-set-remote.pushDefault ::
 
   This option controls whether the value of the Git variable
   ~remote.pushDefault~ is set after cloning.
@@ -4180,7 +4180,7 @@ The following suffixes are disabled by default. See
     repository.
   - If ~nil~, then it is never set.
 
-- User Option: magit-clone-default-directory
+- User Option: magit-clone-default-directory ::
 
   This option control the default directory name used when reading the
   destination for a cloning operation.
@@ -4190,7 +4190,7 @@ The following suffixes are disabled by default. See
   - If a function, then that is called with the remote url as the only
     argument and the returned value is used.
 
-- User Option: magit-clone-name-alist
+- User Option: magit-clone-name-alist ::
 
   This option maps regular expressions, which match repository names,
   to repository urls, making it possible for users to enter short
@@ -4211,7 +4211,7 @@ The following suffixes are disabled by default. See
   value of that is used as the username.  Otherwise it is used as the
   username itself.
 
-- User Option: magit-clone-url-format
+- User Option: magit-clone-url-format ::
 
   The format specified by this option is used when turning repository
   names into urls. ~%h~ is the hostname and ~%n~ is the repository name,
@@ -4241,7 +4241,7 @@ apply variants are described in the next section.
 
 You can also use Ediff to stage and unstage.  See [[*Ediffing]].
 
-- Key: s, magit-stage
+- Key: s (magit-stage) ::
 
   Add the change at point to the staging area.
 
@@ -4249,14 +4249,14 @@ You can also use Ediff to stage and unstage.  See [[*Ediffing]].
   stage the file but not its content.  This makes it possible to stage
   only a subset of the new file's changes.
 
-- Key: S, magit-stage-modified
+- Key: S (magit-stage-modified) ::
 
   Stage all changes to files modified in the worktree.  Stage all new
   content of tracked files and remove tracked files that no longer
   exist in the working tree from the index also.  With a prefix
   argument also stage previously untracked (but not ignored) files.
 
-- Key: u, magit-unstage
+- Key: u (magit-unstage) ::
 
   Remove the change at point from the staging area.
 
@@ -4265,17 +4265,17 @@ You can also use Ediff to stage and unstage.  See [[*Ediffing]].
   called on a committed change: it reverses the change in the index
   but not in the working tree.
 
-- Key: U, magit-unstage-all
+- Key: U (magit-unstage-all) ::
 
   Remove all changes from the staging area.
 
-- User Option: magit-unstage-committed
+- User Option: magit-unstage-committed ::
 
   This option controls whether ~magit-unstage~ "unstages" committed
   changes by reversing them in the index but not the working tree.
   The alternative is to raise an error.
 
-- Key: M-x magit-reverse-in-index, magit-reverse-in-index
+- Key: M-x magit-reverse-in-index (magit-reverse-in-index) ::
 
   This command reverses the committed change at point in the index but
   not the working tree.  By default no key is bound directly to this
@@ -4296,7 +4296,7 @@ You can also use Ediff to stage and unstage.  See [[*Ediffing]].
   4. Optionally stage the remaining changes using ~s~ or ~S~ and then
      type ~c c~ to create a new commit.
 
-- Key: M-x magit-reset-index, magit-reset-index
+- Key: M-x magit-reset-index (magit-reset-index) ::
 
   Reset the index to some commit.  The commit is read from the user
   and defaults to the commit at point.  If there is no commit at
@@ -4308,7 +4308,7 @@ Fine-grained un-/staging has to be done from the status or a diff
 buffer, but it's also possible to un-/stage all changes made to the
 file visited in the current buffer right from inside that buffer.
 
-- Key: M-x magit-stage-file, magit-stage-file
+- Key: M-x magit-stage-file (magit-stage-file) ::
 
   When invoked inside a file-visiting buffer, then stage all changes
   to that file.  In a Magit buffer, stage the file at point if any.
@@ -4316,7 +4316,7 @@ file visited in the current buffer right from inside that buffer.
   always prompt the user for a file, even in a file-visiting buffer or
   when there is a file section at point.
 
-- Key: M-x magit-unstage-file, magit-unstage-file
+- Key: M-x magit-unstage-file (magit-unstage-file) ::
 
   When invoked inside a file-visiting buffer, then unstage all changes
   to that file.  In a Magit buffer, unstage the file at point if any.
@@ -4352,14 +4352,14 @@ The previous section described the staging and unstaging commands.
 What follows are the commands which implement the remaining apply
 variants.
 
-- Key: a, magit-apply
+- Key: a (magit-apply) ::
 
   Apply the change at point to the working tree.
 
   With a prefix argument fallback to a 3-way merge.  Doing so causes
   the change to be applied to the index as well.
 
-- Key: k, magit-discard
+- Key: k (magit-discard) ::
 
   Remove the change at point from the working tree.
 
@@ -4367,7 +4367,7 @@ variants.
   keep (while discarding the other).  If point is within the text
   of a side, then keep that side without prompting.
 
-- Key: v, magit-reverse
+- Key: v (magit-reverse) ::
 
   Reverse the change at point in the working tree.
 
@@ -4390,22 +4390,22 @@ commit using the file's content as message.
 
 Also see [[man:git-commit]]
 
-- Key: c, magit-commit
+- Key: c (magit-commit) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: c c, magit-commit-create
+- Key: c c (magit-commit-create) ::
 
   Create a new commit on ~HEAD~.  With a prefix argument amend to the
   commit at ~HEAD~ instead.
 
-- Key: c a, magit-commit-amend
+- Key: c a (magit-commit-amend) ::
 
   Amend the last commit.
 
-- Key: c e, magit-commit-extend
+- Key: c e (magit-commit-extend) ::
 
   Amend the last commit, without editing the message.  With a prefix
   argument keep the committer date, otherwise change it.  The option
@@ -4415,7 +4415,7 @@ Also see [[man:git-commit]]
   Non-interactively respect the optional OVERRIDE-DATE argument and
   ignore the option.
 
-- Key: c w, magit-commit-reword
+- Key: c w (magit-commit-reword) ::
 
   Reword the last commit, ignoring staged changes.  With a prefix
   argument keep the committer date, otherwise change it.  The option
@@ -4425,7 +4425,7 @@ Also see [[man:git-commit]]
   Non-interactively respect the optional OVERRIDE-DATE argument and
   ignore the option.
 
-- Key: c f, magit-commit-fixup
+- Key: c f (magit-commit-fixup) ::
 
   Create a fixup commit.
 
@@ -4433,11 +4433,11 @@ Also see [[man:git-commit]]
   Otherwise the commit at point may be used without confirmation
   depending on the value of option ~magit-commit-squash-confirm~.
 
-- Key: c F, magit-commit-instant-fixup
+- Key: c F (magit-commit-instant-fixup) ::
 
   Create a fixup commit and instantly rebase.
 
-- Key: c s, magit-commit-squash
+- Key: c s (magit-commit-squash) ::
 
   Create a squash commit, without editing the squash message.
 
@@ -4445,11 +4445,11 @@ Also see [[man:git-commit]]
   Otherwise the commit at point may be used without confirmation
   depending on the value of option ~magit-commit-squash-confirm~.
 
-- Key: c S, magit-commit-instant-squash
+- Key: c S (magit-commit-instant-squash) ::
 
   Create a squash commit and instantly rebase.
 
-- Key: c A, magit-commit-augment
+- Key: c A (magit-commit-augment) ::
 
   Create a squash commit, editing the squash message.
 
@@ -4457,24 +4457,24 @@ Also see [[man:git-commit]]
   Otherwise the commit at point may be used without confirmation
   depending on the value of option ~magit-commit-squash-confirm~.
 
-- User Option: magit-commit-ask-to-stage
+- User Option: magit-commit-ask-to-stage ::
 
   Whether to ask to stage all unstaged changes when committing and nothing is
   staged.
 
-- User Option: magit-commit-show-diff
+- User Option: magit-commit-show-diff ::
 
   Whether the relevant diff is automatically shown when committing.
 
-- User Option: magit-commit-extend-override-date
+- User Option: magit-commit-extend-override-date ::
 
   Whether using ~magit-commit-extend~ changes the committer date.
 
-- User Option: magit-commit-reword-override-date
+- User Option: magit-commit-reword-override-date ::
 
   Whether using ~magit-commit-reword~ changes the committer date.
 
-- User Option: magit-commit-squash-confirm
+- User Option: magit-commit-squash-confirm ::
 
   Whether the commit targeted by squash and fixup has to be confirmed.
   When non-nil then the commit at point (if any) is used as default
@@ -4483,7 +4483,7 @@ Also see [[man:git-commit]]
   always require confirmation because making an error while using
   those is harder to recover from.
 
-- User Option: magit-post-commit-hook
+- User Option: magit-post-commit-hook ::
 
   Hook run after creating a commit without the user editing a message.
 
@@ -4494,7 +4494,7 @@ Also see [[man:git-commit]]
 
   Also see ~git-commit-post-finish-hook~.
 
-- User Option: magit-commit-diff-inhibit-same-window
+- User Option: magit-commit-diff-inhibit-same-window ::
 
   Whether to inhibit use of same window when showing diff while
   committing.
@@ -4534,12 +4534,12 @@ If the editor returns with a non-zero exit status then ~git~ does not
 create the commit.  So the most important commands are those for
 finishing and aborting the commit.
 
-- Key: C-c C-c, with-editor-finish
+- Key: C-c C-c (with-editor-finish) ::
 
   Finish the current editing session by returning with exit code 0.
   Git then creates the commit using the message it finds in the file.
 
-- Key: C-c C-k, with-editor-cancel
+- Key: C-c C-k (with-editor-cancel) ::
 
   Cancel the current editing session by returning with exit code 1.
   Git then cancels the commit, but leaves the file untouched.
@@ -4550,17 +4550,17 @@ is stored at the beginning and the end of an edit session (regardless
 of whether the session is finished successfully or was canceled).  It
 is sometimes useful to bring back messages from that ring.
 
-- Key: C-c M-s, git-commit-save-message
+- Key: C-c M-s (git-commit-save-message) ::
 
   Save the current buffer content to the commit message ring.
 
-- Key: M-p, git-commit-prev-message
+- Key: M-p (git-commit-prev-message) ::
 
   Cycle backward through the commit message ring, after saving the
   current message to the ring.  With a numeric prefix ARG, go back
   ARG comments.
 
-- Key: M-n, git-commit-next-message
+- Key: M-n (git-commit-next-message) ::
 
   Cycle forward through the commit message ring, after saving the
   current message to the ring.  With a numeric prefix ARG, go back
@@ -4574,7 +4574,7 @@ When amending to an existing commit it may be useful to show either
 the changes that are about to be added to that commit or to show those
 changes alongside those that have already been committed.
 
-- Key: C-c C-d, magit-diff-while-committing
+- Key: C-c C-d (magit-diff-while-committing) ::
 
   While committing, show the changes that are about to be committed.
   While amending, invoking the command again toggles between showing
@@ -4582,7 +4582,7 @@ changes alongside those that have already been committed.
 
 **** Using the Revision Stack
 
-- Key: C-c C-w, magit-pop-revision-stack
+- Key: C-c C-w (magit-pop-revision-stack) ::
 
   This command inserts a representation of a revision into the current
   buffer.  It can be used inside buffers used to write commit messages
@@ -4611,7 +4611,7 @@ changes alongside those that have already been committed.
   stack, or with two prefix arguments, then read the repository in
   the minibuffer too.
 
-- User Option: magit-pop-revision-stack-format
+- User Option: magit-pop-revision-stack-format ::
 
   This option controls how the command ~magit-pop-revision-stack~
   inserts a revision into the current buffer.
@@ -4644,40 +4644,40 @@ changes alongside those that have already been committed.
 Some projects use pseudo headers in commit messages.  Magit colorizes
 such headers and provides some commands to insert such headers.
 
-- User Option: git-commit-known-pseudo-headers
+- User Option: git-commit-known-pseudo-headers ::
 
   A list of Git pseudo headers to be highlighted.
 
-- Key: C-c C-i, git-commit-insert-pseudo-header
+- Key: C-c C-i (git-commit-insert-pseudo-header) ::
 
   Insert a commit message pseudo header.
 
-- Key: C-c C-a, git-commit-ack
+- Key: C-c C-a (git-commit-ack) ::
 
   Insert a header acknowledging that you have looked at the commit.
 
-- Key: C-c C-r, git-commit-review
+- Key: C-c C-r (git-commit-review) ::
 
   Insert a header acknowledging that you have reviewed the commit.
 
-- Key: C-c C-s, git-commit-signoff
+- Key: C-c C-s (git-commit-signoff) ::
 
   Insert a header to sign off the commit.
 
-- Key: C-c C-t, git-commit-test
+- Key: C-c C-t (git-commit-test) ::
 
   Insert a header acknowledging that you have tested the commit.
 
-- Key: C-c C-o, git-commit-cc
+- Key: C-c C-o (git-commit-cc) ::
 
   Insert a header mentioning someone who might be interested.
 
-- Key: C-c C-p, git-commit-reported
+- Key: C-c C-p (git-commit-reported) ::
 
   Insert a header mentioning the person who reported the issue being
   fixed by the commit.
 
-- Key: C-c M-i, git-commit-suggested
+- Key: C-c M-i (git-commit-suggested) ::
 
   Insert a header mentioning the person who suggested the change.
 
@@ -4689,7 +4689,7 @@ in buffers used to edit commit messages.  It is even possible to use
 different major modes in different repositories, which is useful when
 different projects impose different commit message conventions.
 
-- User Option: git-commit-major-mode
+- User Option: git-commit-major-mode ::
 
   The value of this option is the major mode used to edit Git commit
   messages.
@@ -4700,33 +4700,33 @@ happens in the function ~git-commit-setup~, which among other things runs
 the hook ~git-commit-setup-hook~.
 
 
-- User Option: git-commit-setup-hook
+- User Option: git-commit-setup-hook ::
 
   Hook run at the end of ~git-commit-setup~.
 
 #+texinfo: @noindent
 The following functions are suitable for this hook:
 
-- Function: git-commit-save-message
+- Function: git-commit-save-message ::
 
   Save the current buffer content to the commit message ring.
 
-- Function: git-commit-setup-changelog-support
+- Function: git-commit-setup-changelog-support ::
 
   After this function is called, ChangeLog entries are treated as
   paragraphs.
 
-- Function: git-commit-turn-on-auto-fill
+- Function: git-commit-turn-on-auto-fill ::
 
   Turn on ~auto-fill-mode~ and set ~fill-column~ to the value of
   ~git-commit-fill-column~.
 
-- Function: git-commit-turn-on-flyspell
+- Function: git-commit-turn-on-flyspell ::
 
   Turn on Flyspell mode.  Also prevent comments from being checked and
   finally check current non-comment text.
 
-- Function: git-commit-propertize-diff
+- Function: git-commit-propertize-diff ::
 
   Propertize the diff shown inside the commit message buffer.  Git
   inserts such diffs into the commit message template when the
@@ -4735,15 +4735,15 @@ The following functions are suitable for this hook:
   more useful.  But some users disagree, which is why this function
   exists.
 
-- Function: bug-reference-mode
+- Function: bug-reference-mode ::
 
   Hyperlink bug references in the buffer.
 
-- Function: with-editor-usage-message
+- Function: with-editor-usage-message ::
 
   Show usage information in the echo area.
 
-- User Option: git-commit-setup-hook
+- User Option: git-commit-setup-hook ::
 
   Hook run after the user finished writing a commit message.
 
@@ -4769,18 +4769,18 @@ course be turned off, but the result of doing that usually is that
 instead of some code it's now the human who is reviewing your commits
 who has to waste some time telling you to fix your commits.
 
-- User Option: git-commit-summary-max-length
+- User Option: git-commit-summary-max-length ::
 
   The intended maximal length of the summary line of commit messages.
   Characters beyond this column are colorized to indicate that this
   preference has been violated.
 
-- User Option: git-commit-fill-column
+- User Option: git-commit-fill-column ::
 
   Column beyond which automatic line-wrapping should happen in commit
   message buffers.
 
-- User Option: git-commit-finish-query-functions
+- User Option: git-commit-finish-query-functions ::
 
   List of functions called to query before performing commit.
 
@@ -4796,13 +4796,13 @@ who has to waste some time telling you to fix your commits.
 
   By default the only member is ~git-commit-check-style-conventions~.
 
-- Function: git-commit-check-style-conventions
+- Function: git-commit-check-style-conventions ::
 
   This function checks for violations of certain basic style
   conventions.  For each violation it asks users if they want to
   proceed anyway.
 
-- User Option: git-commit-style-convention-checks
+- User Option: git-commit-style-convention-checks ::
 
   This option controls what conventions the function by the same name
   tries to enforce.  The value is a list of self-explanatory symbols
@@ -4865,7 +4865,7 @@ command deals with branches themselves, not with the commits reachable
 from them.  Those features are available from separate transient
 command.
 
-- Key: b, magit-branch
+- Key: b (magit-branch) ::
 
   This transient prefix command binds the following suffix commands
   and displays them in a temporary buffer until a suffix is invoked.
@@ -4873,7 +4873,7 @@ command.
   By default it also binds and displays the values of some
   branch-related Git variables and allows changing their values.
 
-- User Option: magit-branch-direct-configure
+- User Option: magit-branch-direct-configure ::
 
   This option controls whether the transient command ~magit-branch~ can
   be used to directly change the values of Git variables.  This defaults
@@ -4882,10 +4882,10 @@ command.
   command ~magit-branch-configure~ has to be used instead to view and
   change branch related variables.
 
-- Key: b C, magit-branch-configure
-- Key: f C, magit-branch-configure
-- Key: F C, magit-branch-configure
-- Key: P C, magit-branch-configure
+- Key: b C (magit-branch-configure) ::
+- Key: f C (magit-branch-configure) ::
+- Key: F C (magit-branch-configure) ::
+- Key: P C (magit-branch-configure) ::
 
   This transient prefix command binds commands that set the value of
   branch-related variables and displays them in a temporary buffer
@@ -4902,7 +4902,7 @@ command.
 
 The variables are described in [[*Branch Git Variables]].
 
-- Key: b b, magit-checkout
+- Key: b b (magit-checkout) ::
 
   Checkout a revision read in the minibuffer and defaulting to the
   branch or arbitrary revision at point.  If the revision is a local
@@ -4910,7 +4910,7 @@ The variables are described in [[*Branch Git Variables]].
   else then ~HEAD~ becomes detached.  Checkout fails if the working tree
   or the staging area contain changes.
 
-- Key: b n, magit-branch-create
+- Key: b n (magit-branch-create) ::
 
   Create a new branch.  The user is asked for a branch or arbitrary
   revision to use as the starting point of the new branch.  When a
@@ -4920,14 +4920,14 @@ The variables are described in [[*Branch Git Variables]].
 
   Also see option ~magit-branch-prefer-remote-upstream~.
 
-- Key: b c, magit-branch-and-checkout
+- Key: b c (magit-branch-and-checkout) ::
 
   This command creates a new branch like ~magit-branch-create~, but then
   also checks it out.
 
   Also see option ~magit-branch-prefer-remote-upstream~.
 
-- Key: b l, magit-branch-checkout
+- Key: b l (magit-branch-checkout) ::
 
   This command checks out an existing or new local branch.  It reads a
   branch name from the user offering all local branches and a subset
@@ -4949,7 +4949,7 @@ The variables are described in [[*Branch Git Variables]].
   to the chosen starting point or something else depends on the value
   of ~magit-branch-adjust-remote-upstream-alist~.
 
-- Key: b s, magit-branch-spinoff
+- Key: b s (magit-branch-spinoff) ::
 
   This command creates and checks out a new branch starting at and
   tracking the current branch.  That branch in turn is reset to the
@@ -4978,13 +4978,13 @@ The variables are described in [[*Branch Git Variables]].
   branch.  If FROM is not reachable from ~HEAD~ or is reachable from the
   source branch's upstream, then an error is raised.
 
-- Key: b S, magit-branch-spinout
+- Key: b S (magit-branch-spinout) ::
 
   This command behaves like ~magit-branch-spinoff~, except that it does
   not change the current branch.  If there are any uncommitted changes,
   then it behaves exactly like ~magit-branch-spinoff~.
 
-- Key: b x, magit-branch-reset
+- Key: b x (magit-branch-reset) ::
 
   This command resets a branch, defaulting to the branch at point, to
   the tip of another branch or any other commit.
@@ -5000,25 +5000,25 @@ The variables are described in [[*Branch Git Variables]].
   the target branch is set as the upstream of the branch that is being
   reset.
 
-- Key: b k, magit-branch-delete
+- Key: b k (magit-branch-delete) ::
 
   Delete one or multiple branches.  If the region marks multiple
   branches, then offer to delete those.  Otherwise, prompt for a single
   branch to be deleted, defaulting to the branch at point.
 
-- Key: b r, magit-branch-rename
+- Key: b r (magit-branch-rename) ::
 
   Rename a branch.  The branch and the new name are read in the
   minibuffer.  With prefix argument the branch is renamed even if that
   name conflicts with an existing branch.
 
-- User Option: magit-branch-read-upstream-first
+- User Option: magit-branch-read-upstream-first ::
 
   When creating a branch, whether to read the upstream branch before
   the name of the branch that is to be created.  The default is ~t~,
   and I recommend you leave it at that.
 
-- User Option: magit-branch-prefer-remote-upstream
+- User Option: magit-branch-prefer-remote-upstream ::
 
   This option specifies whether remote upstreams are favored over
   local upstreams when creating new branches.
@@ -5067,7 +5067,7 @@ The variables are described in [[*Branch Git Variables]].
   prefer the former, then you should add branches such as ~master~,
   ~next~, and ~maint~ to the value of this options.
 
-- User Option: magit-branch-adjust-remote-upstream-alist
+- User Option: magit-branch-adjust-remote-upstream-alist ::
 
   The value of this option is an alist of branches to be used as
   the upstream when branching a remote branch.
@@ -5129,12 +5129,12 @@ you should also account for other common names:
      ("master" . ("main" "master" "next" "maint")))
   #+END_SRC
 
-- Command: magit-branch-orphan
+- Command: magit-branch-orphan ::
 
   This command creates and checks out a new orphan branch with
   contents from a given revision.
 
-- Command: magit-branch-or-checkout
+- Command: magit-branch-or-checkout ::
 
   This command is a hybrid between ~magit-checkout~ and
   ~magit-branch-and-checkout~ and is intended as a replacement for the
@@ -5162,19 +5162,19 @@ These variables can be set from the transient prefix command
 ~magit-branch-configure~.  By default they can also be set from
 ~magit-branch~.  See [[*Branch Commands]].
 
-- Variable: branch.NAME.merge
+- Variable: branch.NAME.merge ::
 
   Together with ~branch.NAME.remote~ this variable defines the upstream
   branch of the local branch named NAME.  The value of this variable
   is the full reference of the upstream /branch/.
 
-- Variable: branch.NAME.remote
+- Variable: branch.NAME.remote ::
 
   Together with ~branch.NAME.merge~ this variable defines the upstream
   branch of the local branch named NAME.  The value of this variable
   is the name of the upstream /remote/.
 
-- Variable: branch.NAME.rebase
+- Variable: branch.NAME.rebase ::
 
   This variable controls whether pulling into the branch named NAME is
   done by rebasing or by merging the fetched branch.
@@ -5184,7 +5184,7 @@ These variables can be set from the transient prefix command
   - When undefined then the value of ~pull.rebase~ is used.  The default
     of that variable is ~false~.
 
-- Variable: branch.NAME.pushRemote
+- Variable: branch.NAME.pushRemote ::
 
   This variable specifies the remote that the branch named NAME is
   usually pushed to.  The value has to be the name of an existing
@@ -5198,7 +5198,7 @@ These variables can be set from the transient prefix command
   then the value of the latter is used.  By default ~remote.pushDefault~
   is undefined.
 
-- Variable: branch.NAME.description
+- Variable: branch.NAME.description ::
 
   This variable can be used to describe the branch named NAME.  That
   description is used e.g. when turning the branch into a series of
@@ -5207,7 +5207,7 @@ These variables can be set from the transient prefix command
 The following variables specify defaults which are used if the above
 branch-specific variables are not set.
 
-- Variable: pull.rebase
+- Variable: pull.rebase ::
 
   This variable specifies whether pulling is done by rebasing or by
   merging.  It can be overwritten using ~branch.NAME.rebase~.
@@ -5220,7 +5220,7 @@ branch-specific variables are not set.
   should consider setting this to ~true~, and ~branch.master.rebase~ to
   ~false~.
 
-- Variable: remote.pushDefault
+- Variable: remote.pushDefault ::
 
   This variable specifies what remote the local branches are usually
   pushed to.  This can be overwritten per branch using
@@ -5230,7 +5230,7 @@ The following variables are used during the creation of a branch and
 control whether the various branch-specific variables are
 automatically set at this time.
 
-- Variable: branch.autoSetupMerge
+- Variable: branch.autoSetupMerge ::
 
   This variable specifies under what circumstances creating a branch
   NAME should result in the variables ~branch.NAME.merge~ and
@@ -5244,7 +5244,7 @@ automatically set at this time.
     point is a remote branch, but not when it is a local branch.
   - When ~false~ then the variables are never set.
 
-- Variable: branch.autoSetupRebase
+- Variable: branch.autoSetupRebase ::
 
   This variable specifies whether creating a branch NAME should result
   in the variable ~branch.NAME.rebase~ being set to ~true~.
@@ -5269,7 +5269,7 @@ line, e.g.:
 For more information about these variables you should also see
 man:git-config Also see [[man:git-branch]], [[man:git-checkout]] and [[*Pushing]].
 
-- User Option: magit-prefer-remote-upstream
+- User Option: magit-prefer-remote-upstream ::
 
   This option controls whether commands that read a branch from the
   user and then set it as the upstream branch, offer a local or a
@@ -5285,7 +5285,7 @@ man:git-config Also see [[man:git-branch]], [[man:git-checkout]] and [[*Pushing]
 These commands are not available from the transient ~magit-branch~ by
 default.
 
-- Command: magit-branch-shelve
+- Command: magit-branch-shelve ::
 
   This command shelves a branch.  This is done by deleting the branch,
   and creating a new reference "refs/shelved/BRANCH-NAME" pointing at
@@ -5295,7 +5295,7 @@ default.
   This is useful if you want to move a branch out of sight, but are
   not ready to completely discard it yet.
 
-- Command: magit-branch-unshelve
+- Command: magit-branch-unshelve ::
 
   This command unshelves a branch that was previously shelved using
   ~magit-branch-shelve~.  This is done by deleting the reference
@@ -5309,7 +5309,7 @@ default.
 Also see [[man:git-merge]]  For information on how to resolve
 merge conflicts see the next section.
 
-- Key: m, magit-merge
+- Key: m (magit-merge) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -5318,7 +5318,7 @@ merge conflicts see the next section.
 When no merge is in progress, then the transient features the
 following suffix commands.
 
-- Key: m m, magit-merge-plain
+- Key: m m (magit-merge-plain) ::
 
   This command merges another branch or an arbitrary revision into the
   current branch.  The branch or revision to be merged is read in the
@@ -5331,21 +5331,21 @@ following suffix commands.
   merge commit, which makes it possible to inspect how conflicts were
   resolved and to adjust the commit message.
 
-- Key: m e, magit-merge-editmsg
+- Key: m e (magit-merge-editmsg) ::
 
   This command merges another branch or an arbitrary revision into the
   current branch and opens a commit message buffer, so that the user
   can make adjustments.  The commit is not actually created until the
   user finishes with ~C-c C-c~.
 
-- Key: m n, magit-merge-nocommit
+- Key: m n (magit-merge-nocommit) ::
 
   This command merges another branch or an arbitrary revision into the
   current branch, but does not actually create the merge commit.  The
   user can then further adjust the merge, even when automatic conflict
   resolution succeeded and/or adjust the commit message.
 
-- Key: m a, magit-merge-absorb
+- Key: m a (magit-merge-absorb) ::
 
   This command merges another local branch into the current branch and
   then removes the former.
@@ -5357,7 +5357,7 @@ following suffix commands.
   Finally, if ~magit-branch-pull-request~ was used to create the merged
   branch, then the respective remote branch is also removed.
 
-- Key: m i, magit-merge-into
+- Key: m i (magit-merge-into) ::
 
   This command merges the current branch into another local branch and
   then removes the former.  The latter becomes the new current branch.
@@ -5369,7 +5369,7 @@ following suffix commands.
   Finally, if ~magit-branch-pull-request~ was used to create the merged
   branch, then the respective remote branch is also removed.
 
-- Key: m s, magit-merge-squash
+- Key: m s (magit-merge-squash) ::
 
   This command squashes the changes introduced by another branch or an
   arbitrary revision into the current branch.  This only applies the
@@ -5377,7 +5377,7 @@ following suffix commands.
   that would allow creating an actual merge commit.  Instead of this
   command you should probably use a command from the apply transient.
 
-- Key: m p, magit-merge-preview
+- Key: m p (magit-merge-preview) ::
 
   This command shows a preview of merging another branch or an
   arbitrary revision into the current branch.
@@ -5385,12 +5385,12 @@ following suffix commands.
 When a merge is in progress, then the transient instead features the
 following suffix commands.
 
-- Key: m m, magit-merge
+- Key: m m (magit-merge) ::
 
   After the user resolved conflicts, this command proceeds with the
   merge.  If some conflicts weren't resolved, then this command fails.
 
-- Key: m a, magit-merge-abort
+- Key: m a (magit-merge-abort) ::
 
   This command aborts the current merge operation.
 
@@ -5519,7 +5519,7 @@ truly complex conflicts, the latter is usually overkill.
 Also see [[man:git-rebase]]  For information on how to resolve
 conflicts that occur during rebases see the preceding section.
 
-- Key: r, magit-rebase
+- Key: r (magit-rebase) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -5538,7 +5538,7 @@ See [[*Information About In-Progress Rebase]].
 For information about the upstream and the push-remote, see [[*The Two
 Remotes]].
 
-- Key: r p, magit-rebase-onto-pushremote
+- Key: r p (magit-rebase-onto-pushremote) ::
 
   This command rebases the current branch onto its push-remote.
 
@@ -5546,7 +5546,7 @@ Remotes]].
   configured or unusable, then let the user first configure the
   push-remote.
 
-- Key: r u, magit-rebase-onto-upstream
+- Key: r u (magit-rebase-onto-upstream) ::
 
   This command rebases the current branch onto its upstream branch.
 
@@ -5554,13 +5554,13 @@ Remotes]].
   configured or unusable, then let the user first configure
   the upstream.
 
-- Key: r e, magit-rebase-branch
+- Key: r e (magit-rebase-branch) ::
 
   This command rebases the current branch onto a branch read in the
   minibuffer.  All commits that are reachable from head but not from
   the selected branch TARGET are being rebased.
 
-- Key: r s, magit-rebase-subset
+- Key: r s (magit-rebase-subset) ::
 
   This command starts a non-interactive rebase sequence to transfer
   commits from START to ~HEAD~ onto NEWBASE.  START has to be selected
@@ -5590,127 +5590,127 @@ Explicitly enabling ~--interactive~ won't have an effect on the
 following commands as they always use that argument anyway, even if it
 is not enabled in the transient.
 
-- Key: r i, magit-rebase-interactive
+- Key: r i (magit-rebase-interactive) ::
 
   This command starts an interactive rebase sequence.
 
-- Key: r f, magit-rebase-autosquash
+- Key: r f (magit-rebase-autosquash) ::
 
   This command combines squash and fixup commits with their intended
   targets.
 
-- Key: r m, magit-rebase-edit-commit
+- Key: r m (magit-rebase-edit-commit) ::
 
   This command starts an interactive rebase sequence that lets the
   user edit a single older commit.
 
-- Key: r w, magit-rebase-reword-commit
+- Key: r w (magit-rebase-reword-commit) ::
 
   This command starts an interactive rebase sequence that lets the
   user reword a single older commit.
 
-- Key: r k, magit-rebase-remove-commit
+- Key: r k (magit-rebase-remove-commit) ::
 
   This command removes a single older commit using rebase.
 
 When a rebase is in progress, then the transient instead features
 the following suffix commands.
 
-- Key: r r, magit-rebase-continue
+- Key: r r (magit-rebase-continue) ::
 
   This command restart the current rebasing operation.
 
   In some cases this pops up a commit message buffer for you do edit.
   With a prefix argument the old message is reused as-is.
 
-- Key: r s, magit-rebase-skip
+- Key: r s (magit-rebase-skip) ::
 
   This command skips the current commit and restarts the current
   rebase operation.
 
-- Key: r e, magit-rebase-edit
+- Key: r e (magit-rebase-edit) ::
 
   This command lets the user edit the todo list of the current rebase
   operation.
 
-- Key: r a, magit-rebase-abort
+- Key: r a (magit-rebase-abort) ::
 
   This command aborts the current rebase operation, restoring the
   original branch.
 
 *** Editing Rebase Sequences
 
-- Key: C-c C-c, with-editor-finish
+- Key: C-c C-c (with-editor-finish) ::
 
   Finish the current editing session by returning with exit code 0.
   Git then uses the rebase instructions it finds in the file.
 
-- Key: C-c C-k, with-editor-cancel
+- Key: C-c C-k (with-editor-cancel) ::
 
   Cancel the current editing session by returning with exit code 1.
   Git then forgoes starting the rebase sequence.
 
-- Key: RET, git-rebase-show-commit
+- Key: RET (git-rebase-show-commit) ::
 
   Show the commit on the current line in another buffer and select
   that buffer.
 
-- Key: SPC, git-rebase-show-or-scroll-up
+- Key: SPC (git-rebase-show-or-scroll-up) ::
 
   Show the commit on the current line in another buffer without
   selecting that buffer.  If the revision buffer is already visible in
   another window of the current frame, then instead scroll that window
   up.
 
-- Key: DEL, git-rebase-show-or-scroll-down
+- Key: DEL (git-rebase-show-or-scroll-down) ::
 
   Show the commit on the current line in another buffer without
   selecting that buffer.  If the revision buffer is already visible in
   another window of the current frame, then instead scroll that window
   down.
 
-- Key: p, git-rebase-backward-line
+- Key: p (git-rebase-backward-line) ::
 
   Move to previous line.
 
-- Key: n, forward-line
+- Key: n (forward-line) ::
 
   Move to next line.
 
-- Key: M-p, git-rebase-move-line-up
+- Key: M-p (git-rebase-move-line-up) ::
 
   Move the current commit (or command) up.
 
-- Key: M-n, git-rebase-move-line-down
+- Key: M-n (git-rebase-move-line-down) ::
 
   Move the current commit (or command) down.
 
-- Key: r, git-rebase-reword
+- Key: r (git-rebase-reword) ::
 
   Edit message of commit on current line.
 
-- Key: e, git-rebase-edit
+- Key: e (git-rebase-edit) ::
 
   Stop at the commit on the current line.
 
-- Key: s, git-rebase-squash
+- Key: s (git-rebase-squash) ::
 
   Meld commit on current line into previous commit, and edit message.
 
-- Key: f, git-rebase-fixup
+- Key: f (git-rebase-fixup) ::
 
   Meld commit on current line into previous commit, discarding the
   current commit's message.
 
-- Key: k, git-rebase-kill-line
+- Key: k (git-rebase-kill-line) ::
 
   Kill the current action line.
 
-- Key: c, git-rebase-pick
+- Key: c (git-rebase-pick) ::
 
   Use commit on current line.
 
-- Key: x, git-rebase-exec
+- Key: x (git-rebase-exec) ::
 
   Insert a shell command to be run after the proceeding commit.
 
@@ -5719,29 +5719,29 @@ the following suffix commands.
   there already is one on the current line.  With empty input remove
   the command on the current line, if any.
 
-- Key: b, git-rebase-break
+- Key: b (git-rebase-break) ::
 
   Insert a break action before the current line, instructing Git to
   return control to the user.
 
-- Key: y, git-rebase-insert
+- Key: y (git-rebase-insert) ::
 
   Read an arbitrary commit and insert it below current line.
 
-- Key: C-x u, git-rebase-undo
+- Key: C-x u (git-rebase-undo) ::
 
   Undo some previous changes.  Like ~undo~ but works in read-only
   buffers.
 
-- User Option: git-rebase-auto-advance
+- User Option: git-rebase-auto-advance ::
 
   Whether to move to next line after changing a line.
 
-- User Option: git-rebase-show-instructions
+- User Option: git-rebase-show-instructions ::
 
   Whether to show usage instructions inside the rebase buffer.
 
-- User Option: git-rebase-confirm-cancel
+- User Option: git-rebase-confirm-cancel ::
 
   Whether confirmation is required to cancel.
 
@@ -5749,24 +5749,24 @@ When a rebase is performed with the ~--rebase-merges~ option, the
 sequence will include a few other types of actions and the following
 commands become relevant.
 
-- Key: l, git-rebase-label
+- Key: l (git-rebase-label) ::
 
   This commands inserts a label action or edits the one at point.
 
-- Key: t, git-rebase-reset
+- Key: t (git-rebase-reset) ::
 
   This command inserts a reset action or edits the one at point.  The
   prompt will offer the labels that are currently present in the
   buffer.
 
-- Key: MM, git-rebase-merge
+- Key: MM (git-rebase-merge) ::
 
   The command inserts a merge action or edits the one at point.  The
   prompt will offer the labels that are currently present in the
   buffer.  Specifying a message to reuse via ~-c~ or ~-C~ is not
   supported; an editor will always be invoked for the merge.
 
-- Key: Mt, git-rebase-merge-toggle-editmsg
+- Key: Mt (git-rebase-merge-toggle-editmsg) ::
 
   This command toggles between the ~-C~ and ~-c~ options of the merge
   action at point.  These options both specify a commit whose message
@@ -5947,7 +5947,7 @@ answer the question "Do these commits make the same change?".
 
 Also see [[man:git-cherry-pick]]
 
-- Key: A, magit-cherry-pick
+- Key: A (magit-cherry-pick) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -5956,14 +5956,14 @@ Also see [[man:git-cherry-pick]]
 When no cherry-pick or revert is in progress, then the transient
 features the following suffix commands.
 
-- Key: A A, magit-cherry-copy
+- Key: A A (magit-cherry-copy) ::
 
   This command copies COMMITS from another branch onto the current
   branch.  If the region selects multiple commits, then those are
   copied, without prompting.  Otherwise the user is prompted for a
   commit or range, defaulting to the commit at point.
 
-- Key: A a, magit-cherry-apply
+- Key: A a (magit-cherry-apply) ::
 
   This command applies the changes in COMMITS from another branch onto
   the current branch.  If the region selects multiple commits, then
@@ -5981,7 +5981,7 @@ conflicts.  If that happens, then these commands abort and you not
 only have to resolve the conflicts but also finish the process the
 same way you would have to if these commands didn't exist at all.
 
-- Key: A h, magit-cherry-harvest
+- Key: A h (magit-cherry-harvest) ::
 
   This command moves the selected COMMITS that must be located on
   another BRANCH onto the current branch instead, removing them from
@@ -5993,7 +5993,7 @@ same way you would have to if these commands didn't exist at all.
   command stops and you have to resolve the conflicts and then finish
   the process manually.
 
-- Key: A d, magit-cherry-donate
+- Key: A d (magit-cherry-donate) ::
 
   This command moves the selected COMMITS from the current branch onto
   another existing BRANCH, removing them from the former.  When this
@@ -6005,7 +6005,7 @@ same way you would have to if these commands didn't exist at all.
   command stops and you have to resolve the conflicts and then finish
   the process manually.
 
-- Key: A n, magit-cherry-spinout
+- Key: A n (magit-cherry-spinout) ::
 
   This command moves the selected COMMITS from the current branch onto
   a new branch BRANCH, removing them from the former.  When this
@@ -6016,7 +6016,7 @@ same way you would have to if these commands didn't exist at all.
   command stops and you have to resolve the conflicts and then finish
   the process manually.
 
-- Key: A s, magit-cherry-spinoff
+- Key: A s (magit-cherry-spinoff) ::
 
   This command moves the selected COMMITS from the current branch onto
   a new branch BRANCH, removing them from the former.  When this
@@ -6030,22 +6030,22 @@ same way you would have to if these commands didn't exist at all.
 When a cherry-pick or revert is in progress, then the transient
 instead features the following suffix commands.
 
-- Key: A A, magit-sequence-continue
+- Key: A A (magit-sequence-continue) ::
 
   Resume the current cherry-pick or revert sequence.
 
-- Key: A s, magit-sequence-skip
+- Key: A s (magit-sequence-skip) ::
 
   Skip the stopped at commit during a cherry-pick or revert sequence.
 
-- Key: A a, magit-sequence-abort
+- Key: A a (magit-sequence-abort) ::
 
   Abort the current cherry-pick or revert sequence.  This discards all
   changes made since the sequence started.
 
 *** Reverting
 
-- Key: V, magit-revert
+- Key: V (magit-revert) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -6054,13 +6054,13 @@ instead features the following suffix commands.
 When no cherry-pick or revert is in progress, then the transient
 features the following suffix commands.
 
-- Key: V V, magit-revert-and-commit
+- Key: V V (magit-revert-and-commit) ::
 
   Revert a commit by creating a new commit.  Prompt for a commit,
   defaulting to the commit at point.  If the region selects multiple
   commits, then revert all of them, without prompting.
 
-- Key: V v, magit-revert-no-commit
+- Key: V v (magit-revert-no-commit) ::
 
   Revert a commit by applying it in reverse to the working tree.
   Prompt for a commit, defaulting to the commit at point.  If the
@@ -6070,15 +6070,15 @@ features the following suffix commands.
 When a cherry-pick or revert is in progress, then the transient
 instead features the following suffix commands.
 
-- Key: V A, magit-sequence-continue
+- Key: V A (magit-sequence-continue) ::
 
   Resume the current cherry-pick or revert sequence.
 
-- Key: V s, magit-sequence-skip
+- Key: V s (magit-sequence-skip) ::
 
   Skip the stopped at commit during a cherry-pick or revert sequence.
 
-- Key: V a, magit-sequence-abort
+- Key: V a (magit-sequence-abort) ::
 
   Abort the current cherry-pick or revert sequence.  This discards all
   changes made since the sequence started.
@@ -6087,48 +6087,48 @@ instead features the following suffix commands.
 
 Also see [[man:git-reset]]
 
-- Key: x, magit-reset-quickly
+- Key: x (magit-reset-quickly) ::
 
   Reset the ~HEAD~ and index to some commit read from the user and
   defaulting to the commit at point, and possibly also reset the
   working tree.  With a prefix argument reset the working tree
   otherwise don't.
 
-- Key: X m, magit-reset-mixed
+- Key: X m (magit-reset-mixed) ::
 
   Reset the ~HEAD~ and index to some commit read from the user and
   defaulting to the commit at point.  The working tree is kept as-is.
 
-- Key: X s, magit-reset-soft
+- Key: X s (magit-reset-soft) ::
 
   Reset the ~HEAD~ to some commit read from the user and defaulting
   to the commit at point.  The index and the working tree are kept
   as-is.
 
-- Key: X h, magit-reset-hard
+- Key: X h (magit-reset-hard) ::
 
   Reset the ~HEAD~, index, and working tree to some commit read from the
   user and defaulting to the commit at point.
 
-- Key: X k, magit-reset-keep
+- Key: X k (magit-reset-keep) ::
 
   Reset the ~HEAD~, index, and working tree to some commit read from the
   user and defaulting to the commit at point.  Uncommitted changes are
   kept as-is.
 
-- Key: X i, magit-reset-index
+- Key: X i (magit-reset-index) ::
 
   Reset the index to some commit read from the user and defaulting to
   the commit at point.  Keep the ~HEAD~ and working tree as-is, so if
   the commit refers to the ~HEAD~, then this effectively unstages all
   changes.
 
-- Key: X w, magit-reset-worktree
+- Key: X w (magit-reset-worktree) ::
 
   Reset the working tree to some commit read from the user and
   defaulting to the commit at point.  Keep the ~HEAD~ and index as-is.
 
-- Key: X f, magit-file-checkout
+- Key: X f (magit-file-checkout) ::
 
   Update file in the working tree and index to the contents from a
   revision.  Both the revision and file are read from the user.
@@ -6137,103 +6137,103 @@ Also see [[man:git-reset]]
 
 Also see [[man:git-stash]]
 
-- Key: z, magit-stash
+- Key: z (magit-stash) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: z z, magit-stash-both
+- Key: z z (magit-stash-both) ::
 
   Create a stash of the index and working tree.  Untracked files are
   included according to infix arguments.  One prefix argument is
   equivalent to ~--include-untracked~ while two prefix arguments are
   equivalent to ~--all~.
 
-- Key: z i, magit-stash-index
+- Key: z i (magit-stash-index) ::
 
   Create a stash of the index only.  Unstaged and untracked changes
   are not stashed.
 
-- Key: z w, magit-stash-worktree
+- Key: z w (magit-stash-worktree) ::
 
   Create a stash of unstaged changes in the working tree.  Untracked
   files are included according to infix arguments.  One prefix
   argument is equivalent to ~--include-untracked~ while two prefix
   arguments are equivalent to ~--all~.
 
-- Key: z x, magit-stash-keep-index
+- Key: z x (magit-stash-keep-index) ::
 
   Create a stash of the index and working tree, keeping index intact.
   Untracked files are included according to infix arguments.  One
   prefix argument is equivalent to ~--include-untracked~ while two
   prefix arguments are equivalent to ~--all~.
 
-- Key: z Z, magit-snapshot-both
+- Key: z Z (magit-snapshot-both) ::
 
   Create a snapshot of the index and working tree.  Untracked files
   are included according to infix arguments.  One prefix argument is
   equivalent to ~--include-untracked~ while two prefix arguments are
   equivalent to ~--all~.
 
-- Key: z I, magit-snapshot-index
+- Key: z I (magit-snapshot-index) ::
 
   Create a snapshot of the index only.  Unstaged and untracked changes
   are not stashed.
 
-- Key: z W, magit-snapshot-worktree
+- Key: z W (magit-snapshot-worktree) ::
 
   Create a snapshot of unstaged changes in the working tree.
   Untracked files are included according to infix arguments.  One
   prefix argument is equivalent to ~--include-untracked~ while two
   prefix arguments are equivalent to ~--all~-.
 
-- Key: z a, magit-stash-apply
+- Key: z a (magit-stash-apply) ::
 
   Apply a stash to the working tree.  Try to preserve the stash index.
   If that fails because there are staged changes, apply without
   preserving the stash index.
 
-- Key: z p, magit-stash-pop
+- Key: z p (magit-stash-pop) ::
 
   Apply a stash to the working tree and remove it from stash list.
   Try to preserve the stash index.  If that fails because there are
   staged changes, apply without preserving the stash index and forgo
   removing the stash.
 
-- Key: z k, magit-stash-drop
+- Key: z k (magit-stash-drop) ::
 
   Remove a stash from the stash list.  When the region is active, offer
   to drop all contained stashes.
 
-- Key: z v, magit-stash-show
+- Key: z v (magit-stash-show) ::
 
   Show all diffs of a stash in a buffer.
 
-- Key: z b, magit-stash-branch
+- Key: z b (magit-stash-branch) ::
 
   Create and checkout a new BRANCH from STASH.  The branch starts at
   the commit that was current when the stash was created.
 
-- Key: z B, magit-stash-branch-here
+- Key: z B (magit-stash-branch-here) ::
 
   Create and checkout a new BRANCH using ~magit-branch~ with the current
   branch or ~HEAD~ as the starting-point.  Then apply STASH, dropping it
   if it applies cleanly.
 
-- Key: z f, magit-stash-format-patch
+- Key: z f (magit-stash-format-patch) ::
 
   Create a patch from STASH.
 
-- Key: k, magit-stash-clear
+- Key: k (magit-stash-clear) ::
 
   Remove all stashes saved in REF's reflog by deleting REF.
 
-- Key: z l, magit-stash-list
+- Key: z l (magit-stash-list) ::
 
   List all stashes in a buffer.
 
-- User Option: magit-stashes-margin
+- User Option: magit-stashes-margin ::
 
   This option specifies whether the margin is initially shown in
   stashes buffers and how it is formatted.
@@ -6265,7 +6265,7 @@ Those features are available from separate transient commands.
 
 Also see [[man:git-remote]]
 
-- Key: M, magit-remote
+- Key: M (magit-remote) ::
 
   This transient prefix command binds the following suffix commands
   and displays them in a temporary buffer until a suffix is invoked.
@@ -6273,7 +6273,7 @@ Also see [[man:git-remote]]
   By default it also binds and displays the values of some
   remote-related Git variables and allows changing their values.
 
-- User Option: magit-remote-direct-configure
+- User Option: magit-remote-direct-configure ::
 
   This option controls whether remote-related Git variables are
   accessible directly from the transient ~magit-remote~.
@@ -6284,7 +6284,7 @@ Also see [[man:git-remote]]
 
   If ~nil~, then ~magit-remote-configure~ has to be used to do so.
 
-- Key: M C, magit-remote-configure
+- Key: M C (magit-remote-configure) ::
 
   This transient prefix command binds commands that set the value of
   remote-related variables and displays them in a temporary buffer
@@ -6301,31 +6301,31 @@ Also see [[man:git-remote]]
 
 The variables are described in [[*Remote Git Variables]].
 
-- Key: M a, magit-remote-add
+- Key: M a (magit-remote-add) ::
 
   This command add a remote and fetches it.  The remote name and url
   are read in the minibuffer.
 
-- Key: M r, magit-remote-rename
+- Key: M r (magit-remote-rename) ::
 
   This command renames a remote.  Both the old and the new names are
   read in the minibuffer.
 
-- Key: M u, magit-remote-set-url
+- Key: M u (magit-remote-set-url) ::
 
   This command changes the url of a remote.  Both the remote and the
   new url are read in the minibuffer.
 
-- Key: M k, magit-remote-remove
+- Key: M k (magit-remote-remove) ::
 
   This command deletes a remote, read in the minibuffer.
 
-- Key: M p, magit-remote-prune
+- Key: M p (magit-remote-prune) ::
 
   This command removes stale remote-tracking branches for a remote
   read in the minibuffer.
 
-- Key: M P, magit-remote-prune-refspecs
+- Key: M P (magit-remote-prune-refspecs) ::
 
   This command removes stale refspecs for a remote read in the
   minibuffer.
@@ -6343,7 +6343,7 @@ The variables are described in [[*Remote Git Variables]].
   created due to the now stale refspecs.  Other stale branches are
   not removed.
 
-- User Option: magit-remote-add-set-remote.pushDefault
+- User Option: magit-remote-add-set-remote.pushDefault ::
 
   This option controls whether the user is asked whether they want to
   set ~remote.pushDefault~ after adding a remote.
@@ -6361,28 +6361,28 @@ These variables can be set from the transient prefix command
 ~magit-remote-configure~.  By default they can also be set from
 ~magit-remote~.  See [[*Remote Commands]].
 
-- Variable: remote.NAME.url
+- Variable: remote.NAME.url ::
 
   This variable specifies the url of the remote named NAME.  It can
   have multiple values.
 
-- Variable: remote.NAME.fetch
+- Variable: remote.NAME.fetch ::
 
   The refspec used when fetching from the remote named NAME.  It can
   have multiple values.
 
-- Variable: remote.NAME.pushurl
+- Variable: remote.NAME.pushurl ::
 
   This variable specifies the url used for fetching from the remote
   named NAME.  If it is not specified, then ~remote.NAME.url~ is used
   instead.  It can have multiple values.
 
-- Variable: remote.NAME.push
+- Variable: remote.NAME.push ::
 
   The refspec used when pushing to the remote named NAME.  It can
   have multiple values.
 
-- Variable: remote.NAME.tagOpts
+- Variable: remote.NAME.tagOpts ::
 
   This variable specifies what tags are fetched by default.  If the
   value is ~--no-tags~ then no tags are fetched.  If the value is
@@ -6394,13 +6394,13 @@ These variables can be set from the transient prefix command
 Also see [[man:git-fetch]] For information about the upstream and the
 push-remote, see [[*The Two Remotes]].
 
-- Key: f, magit-fetch
+- Key: f (magit-fetch) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: f p, magit-fetch-from-pushremote
+- Key: f p (magit-fetch-from-pushremote) ::
 
   This command fetches from the current push-remote.
 
@@ -6408,7 +6408,7 @@ push-remote, see [[*The Two Remotes]].
   configured or unusable, then let the user first configure the
   push-remote.
 
-- Key: f u, magit-fetch-from-upstream
+- Key: f u (magit-fetch-from-upstream) ::
 
   This command fetch from the upstream of the current branch.
 
@@ -6421,30 +6421,30 @@ push-remote, see [[*The Two Remotes]].
   from the ~magit-fetch~ transient prefix and invoking it directly
   results in an error.
 
-- Key: f e, magit-fetch-other
+- Key: f e (magit-fetch-other) ::
 
   This command fetch from a repository read from the minibuffer.
 
-- Key: f o, magit-fetch-branch
+- Key: f o (magit-fetch-branch) ::
 
   This command fetches a branch from a remote, both of which are read
   from the minibuffer.
 
-- Key: f r, magit-fetch-refspec
+- Key: f r (magit-fetch-refspec) ::
 
   This command fetches from a remote using an explicit refspec, both
   of which are read from the minibuffer.
 
-- Key: f a, magit-fetch-all
+- Key: f a (magit-fetch-all) ::
 
   This command fetches from all remotes.
 
-- Key: f m, magit-submodule-fetch
+- Key: f m (magit-submodule-fetch) ::
 
   This command fetches all submodules.  With a prefix argument it
   fetches all remotes of all submodules.
 
-- User Option: magit-pull-or-fetch
+- User Option: magit-pull-or-fetch ::
 
   By default fetch and pull commands are available from separate
   transient prefix command.  Setting this to ~t~ adds some (but not all)
@@ -6464,12 +6464,12 @@ push-remote, see [[*The Two Remotes]].
 Also see [[man:git-pull]] For information about the upstream and the
 push-remote, see [[*The Two Remotes]].
 
-- Key: F, magit-pull
+- Key: F (magit-pull) ::
 
   This transient prefix command binds the following suffix commands
   and displays them in a temporary buffer until a suffix is invoked.
 
-- Key: F p, magit-pull-from-pushremote
+- Key: F p (magit-pull-from-pushremote) ::
 
   This command pulls from the push-remote of the current branch.
 
@@ -6477,7 +6477,7 @@ push-remote, see [[*The Two Remotes]].
   configured or unusable, then let the user first configure the
   push-remote.
 
-- Key: F u, magit-pull-from-upstream
+- Key: F u (magit-pull-from-upstream) ::
 
   This command pulls from the upstream of the current branch.
 
@@ -6485,7 +6485,7 @@ push-remote, see [[*The Two Remotes]].
   configured or unusable, then let the user first configure
   the upstream.
 
-- Key: F e, magit-pull-branch
+- Key: F e (magit-pull-branch) ::
 
   This command pulls from a branch read in the minibuffer.
 
@@ -6494,13 +6494,13 @@ push-remote, see [[*The Two Remotes]].
 Also see [[man:git-push]] For information about the upstream and the
 push-remote, see [[*The Two Remotes]].
 
-- Key: P, magit-push
+- Key: P (magit-push) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: P p, magit-push-current-to-pushremote
+- Key: P p (magit-push-current-to-pushremote) ::
 
   This command pushes the current branch to its push-remote.
 
@@ -6508,7 +6508,7 @@ push-remote, see [[*The Two Remotes]].
   configured or unusable, then let the user first configure the
   push-remote.
 
-- Key: P u, magit-push-current-to-upstream
+- Key: P u (magit-push-current-to-upstream) ::
 
   This command pushes the current branch to its upstream branch.
 
@@ -6516,17 +6516,17 @@ push-remote, see [[*The Two Remotes]].
   configured or unusable, then let the user first configure
   the upstream.
 
-- Key: P e, magit-push-current
+- Key: P e (magit-push-current) ::
 
   This command pushes the current branch to a branch read in the
   minibuffer.
 
-- Key: P o, magit-push-other
+- Key: P o (magit-push-other) ::
 
   This command pushes an arbitrary branch or commit somewhere.  Both
   the source and the target are read in the minibuffer.
 
-- Key: P r, magit-push-refspecs
+- Key: P r (magit-push-refspecs) ::
 
   This command pushes one or multiple refspecs to a remote, both of
   which are read in the minibuffer.
@@ -6535,7 +6535,7 @@ push-remote, see [[*The Two Remotes]].
   only available for the part before the colon, or when no colon is
   used.
 
-- Key: P m, magit-push-matching
+- Key: P m (magit-push-matching) ::
 
   This command pushes all matching branches to another repository.
 
@@ -6543,7 +6543,7 @@ push-remote, see [[*The Two Remotes]].
   a remote, offering the remote configured for the current branch as
   default.
 
-- Key: P t, magit-push-tags
+- Key: P t (magit-push-tags) ::
 
   This command pushes all tags to another repository.
 
@@ -6551,7 +6551,7 @@ push-remote, see [[*The Two Remotes]].
   a remote, offering the remote configured for the current branch as
   default.
 
-- Key: P T, magit-push-tag
+- Key: P T (magit-push-tag) ::
 
   This command pushes a tag to another repository.
 
@@ -6569,7 +6569,7 @@ Two more push commands exist, which by default are not available from
 the push transient.  See their doc-strings for instructions on how to
 add them to the transient.
 
-- Command: magit-push-implicitly args
+- Command: magit-push-implicitly args ::
 
   This command pushes somewhere without using an explicit refspec.
 
@@ -6589,7 +6589,7 @@ add them to the transient.
       '(\"i\" magit-push-implicitly))"
   #+END_SRC
 
-- Command: magit-push-to-remote remote args
+- Command: magit-push-to-remote remote args ::
 
   This command pushes to the remote REMOTE without using an explicit
   refspec.  The remote is read in the minibuffer.
@@ -6603,13 +6603,13 @@ add them to the transient.
 
 ** Plain Patches
 
-- Key: W, magit-patch
+- Key: W (magit-patch) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: W c, magit-patch-create
+- Key: W c (magit-patch-create) ::
 
   This command creates patches for a set commits.  If the region marks
   several commits, then it creates patches for all of them.  Otherwise
@@ -6618,14 +6618,14 @@ add them to the transient.
   command is invoked as a suffix of itself, then it creates a patch
   using the specified infix arguments.
 
-- Key: w a, magit-patch-apply
+- Key: w a (magit-patch-apply) ::
 
   This command applies a patch.  This is a transient prefix command,
   which features several infix arguments and binds itself as a suffix
   command.  When this command is invoked as a suffix of itself, then
   it applies a patch using the specified infix arguments.
 
-- Key: W s, magit-patch-save
+- Key: W s (magit-patch-save) ::
 
   This command creates a patch from the current diff.
 
@@ -6639,24 +6639,24 @@ a ~magit-diff-mode~ or ~magit-revision-mode~ buffer.
 
 Also see [[man:git-am]] and [[man:git-apply]]
 
-- Key: w, magit-am
+- Key: w (magit-am) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: w w, magit-am-apply-patches
+- Key: w w (magit-am-apply-patches) ::
 
   This command applies one or more patches.  If the region marks
   files, then those are applied as patches.  Otherwise this command
   reads a file-name in the minibuffer, defaulting to the file at
   point.
 
-- Key: w m, magit-am-apply-maildir
+- Key: w m (magit-am-apply-maildir) ::
 
   This command applies patches from a maildir.
 
-- Key: w a, magit-patch-apply
+- Key: w a (magit-patch-apply) ::
 
   This command applies a plain patch.  For a longer description see
   [[*Plain Patches]].  This command is only available from the ~magit-am~
@@ -6665,16 +6665,16 @@ Also see [[man:git-am]] and [[man:git-apply]]
 When an "am" operation is in progress, then the transient instead
 features the following suffix commands.
 
-- Key: w w, magit-am-continue
+- Key: w w (magit-am-continue) ::
 
   This command resumes the current patch applying sequence.
 
-- Key: w s, magit-am-skip
+- Key: w s (magit-am-skip) ::
 
   This command skips the stopped at patch during a patch applying
   sequence.
 
-- Key: w a, magit-am-abort
+- Key: w a (magit-am-abort) ::
 
   This command aborts the current patch applying sequence.  This
   discards all changes made since the sequence started.
@@ -6684,18 +6684,18 @@ features the following suffix commands.
 
 Also see [[man:git-tag]]
 
-- Key: t, magit-tag
+- Key: t (magit-tag) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: t t, magit-tag-create
+- Key: t t (magit-tag-create) ::
 
   This command creates a new tag with the given NAME at REV.  With a
   prefix argument it creates an annotated tag.
 
-- Key: t r, magit-tag-release
+- Key: t r (magit-tag-release) ::
 
   This commands creates a release tag.  It assumes that release tags
   match ~magit-release-tag-regexp~.
@@ -6715,14 +6715,14 @@ Also see [[man:git-tag]]
   TAG "v1.2.3" and a repository located at something like
   "/path/to/foo-bar".
 
-- Key: t k, magit-tag-delete
+- Key: t k (magit-tag-delete) ::
 
   This command deletes one or more tags.  If the region marks multiple
   tags (and nothing else), then it offers to delete those.  Otherwise,
   it prompts for a single tag to be deleted, defaulting to the tag at
   point.
 
-- Key: t p, magit-tag-prune
+- Key: t p (magit-tag-prune) ::
 
   This command offers to delete tags missing locally from REMOTE, and
   vice versa.
@@ -6731,13 +6731,13 @@ Also see [[man:git-tag]]
 
 Also see [[man:git-notes]]
 
-- Key: T, magit-notes
+- Key: T (magit-notes) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.
 
-- Key: T T, magit-notes-edit
+- Key: T T (magit-notes-edit) ::
 
   Edit the note attached to a commit, defaulting to the commit at
   point.
@@ -6745,7 +6745,7 @@ Also see [[man:git-notes]]
   By default use the value of Git variable ~core.notesRef~ or
   "refs/notes/commits" if that is undefined.
 
-- Key: T r, magit-notes-remove
+- Key: T r (magit-notes-remove) ::
 
   Remove the note attached to a commit, defaulting to the commit at
   point.
@@ -6753,7 +6753,7 @@ Also see [[man:git-notes]]
   By default use the value of Git variable ~core.notesRef~ or
   "refs/notes/commits" if that is undefined.
 
-- Key: T p, magit-notes-prune
+- Key: T p (magit-notes-prune) ::
 
   Remove notes about unreachable commits.
 
@@ -6761,7 +6761,7 @@ It is possible to merge one note ref into another.  That may result in
 conflicts which have to resolved in the temporary worktree
 ".git/NOTES_MERGE_WORKTREE".
 
-- Key: T m, magit-notes-merge
+- Key: T m (magit-notes-merge) ::
 
   Merge the notes of a ref read from the user into the current notes
   ref.  The current notes ref is the value of Git variable
@@ -6770,12 +6770,12 @@ conflicts which have to resolved in the temporary worktree
 When a notes merge is in progress then the transient features the
 following suffix commands, instead of those listed above.
 
-- Key: T c, magit-notes-merge-commit
+- Key: T c (magit-notes-merge-commit) ::
 
   Commit the current notes ref merge, after manually resolving
   conflicts.
 
-- Key: T a, magit-notes-merge-abort
+- Key: T a (magit-notes-merge-abort) ::
 
   Abort the current notes ref merge.
 
@@ -6783,12 +6783,12 @@ The following variables control what notes reference ~magit-notes-*~,
 ~git notes~ and ~git show~ act on and display.  Both the local and global
 values are displayed and can be modified.
 
-- Variable: core.notesRef
+- Variable: core.notesRef ::
 
   This variable specifies the notes ref that is displayed by default
   and which commands act on by default.
 
-- Variable: notes.displayRef
+- Variable: notes.displayRef ::
 
   This variable specifies additional notes ref to be displayed in
   addition to the ref specified by ~core.notesRef~.  It can have
@@ -6807,14 +6807,14 @@ display information about submodules directly in the status buffer of
 the super-repository by adding ~magit-insert-modules~ to the hook
 ~magit-status-sections-hook~ as described in [[*Status Module Sections]].
 
-- Command: magit-list-submodules
+- Command: magit-list-submodules ::
 
   This command displays a list of the current repository's submodules
   in a separate buffer.
 
   It can be invoked by pressing ~RET~ on the section titled "Modules".
 
-- User Option: magit-submodule-list-columns
+- User Option: magit-submodule-list-columns ::
 
   This option controls what columns are displayed by the command
   ~magit-list-submodules~ and how they are displayed.
@@ -6830,7 +6830,7 @@ the super-repository by adding ~magit-insert-modules~ to the hook
 
 *** Submodule Transient
 
-- Key: o, magit-submodule
+- Key: o (magit-submodule) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -6844,44 +6844,44 @@ read a single module to act on.  With a prefix argument these commands
 ignore the selection and the current module and instead act on all
 suitable modules.
 
-- Key: o a, magit-submodule-add
+- Key: o a (magit-submodule-add) ::
 
   This commands adds the repository at URL as a module.  Optional PATH
   is the path to the module relative to the root of the super-project.
   If it is nil then the path is determined based on URL.
 
-- Key: o r, magit-submodule-register
+- Key: o r (magit-submodule-register) ::
 
   This command registers the selected modules by copying their urls
   from ".gitmodules" to "$GIT_DIR/config".  These values can then be
   edited before running ~magit-submodule-populate~.  If you don't need
   to edit any urls, then use the latter directly.
 
-- Key: o p, magit-submodule-populate
+- Key: o p (magit-submodule-populate) ::
 
   This command creates the working directory or directories of the
   selected modules, checking out the recorded commits.
 
-- Key: o u, magit-submodule-update
+- Key: o u (magit-submodule-update) ::
 
   This command updates the selected modules checking out the recorded
   commits.
 
-- Key: o s, magit-submodule-synchronize
+- Key: o s (magit-submodule-synchronize) ::
 
   This command synchronizes the urls of the selected modules, copying
   the values from ".gitmodules" to the ".git/config" of the
   super-project as well those of the modules.
 
-- Key: o d, magit-submodule-unpopulate
+- Key: o d (magit-submodule-unpopulate) ::
 
   This command removes the working directory of the selected modules.
 
-- Key: o l, magit-list-submodules
+- Key: o l (magit-list-submodules) ::
 
   This command displays a list of the current repository's modules.
 
-- Key: o f, magit-fetch-modules
+- Key: o f (magit-fetch-modules) ::
 
   This command fetches all modules.
 
@@ -6894,12 +6894,12 @@ suitable modules.
 
 Also see [[man:git-subtree]]
 
-- Key: O, magit-subtree
+- Key: O (magit-subtree) ::
 
   This transient prefix command binds the two sub-transients; one for
   importing a subtree and one for exporting a subtree.
 
-- Key: O i, magit-subtree-import
+- Key: O i (magit-subtree-import) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -6911,23 +6911,23 @@ Also see [[man:git-subtree]]
   prefix without prompting the user.  If it is unset, then they read
   the prefix in the minibuffer.
 
-- Key: O i a, magit-subtree-add
+- Key: O i a (magit-subtree-add) ::
 
   This command adds COMMIT from REPOSITORY as a new subtree at PREFIX.
 
-- Key: O i c, magit-subtree-add-commit
+- Key: O i c (magit-subtree-add-commit) ::
 
   This command add COMMIT as a new subtree at PREFIX.
 
-- Key: O i m, magit-subtree-merge
+- Key: O i m (magit-subtree-merge) ::
 
   This command merges COMMIT into the PREFIX subtree.
 
-- Key: O i f, magit-subtree-pull
+- Key: O i f (magit-subtree-pull) ::
 
   This command pulls COMMIT from REPOSITORY into the PREFIX subtree.
 
-- Key: O e, magit-subtree-export
+- Key: O e (magit-subtree-export) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -6939,12 +6939,12 @@ Also see [[man:git-subtree]]
   prefix without prompting the user.  If it is unset, then they read
   the prefix in the minibuffer.
 
-- Key: O e p, magit-subtree-push
+- Key: O e p (magit-subtree-push) ::
 
   This command extract the history of the subtree PREFIX and pushes it
   to REF on REPOSITORY.
 
-- Key: O e s, magit-subtree-split
+- Key: O e s (magit-subtree-split) ::
 
   This command extracts the history of the subtree PREFIX.
 
@@ -6952,29 +6952,29 @@ Also see [[man:git-subtree]]
 
 Also see [[man:git-worktree]]
 
-- Key: Z, magit-worktree
+- Key: Z (magit-worktree) ::
 
   This transient prefix command binds the following suffix commands
   and displays them in a temporary buffer until a suffix is invoked.
 
-- Key: Z b, magit-worktree-checkout
+- Key: Z b (magit-worktree-checkout) ::
 
   Checkout BRANCH in a new worktree at PATH.
 
-- Key: Z c, magit-worktree-branch
+- Key: Z c (magit-worktree-branch) ::
 
   Create a new BRANCH and check it out in a new worktree at PATH.
 
-- Key: Z m, magit-worktree-move
+- Key: Z m (magit-worktree-move) ::
 
   Move an existing worktree to a new PATH.
 
-- Key: Z k, magit-worktree-delete
+- Key: Z k (magit-worktree-delete) ::
 
   Delete a worktree, defaulting to the worktree at point.
   The primary worktree cannot be deleted.
 
-- Key: Z g, magit-worktree-status
+- Key: Z g (magit-worktree-status) ::
 
   Show the status for the worktree at point.
 
@@ -6986,7 +6986,7 @@ Also see [[man:git-worktree]]
 
 Also see [[man:git-bundle]]
 
-- Command: magit-bundle
+- Command: magit-bundle ::
 
   This transient prefix command binds several suffix commands for
   running ~git bundle~ subcommands and displays them in a temporary
@@ -6994,10 +6994,10 @@ Also see [[man:git-bundle]]
 
 ** Common Commands
 
-- Command: magit-switch-to-repository-buffer
-- Command: magit-switch-to-repository-buffer-other-window
-- Command: magit-switch-to-repository-buffer-other-frame
-- Command: magit-display-repository-buffer
+- Command: magit-switch-to-repository-buffer ::
+- Command: magit-switch-to-repository-buffer-other-window ::
+- Command: magit-switch-to-repository-buffer-other-frame ::
+- Command: magit-display-repository-buffer ::
 
   These commands read any existing Magit buffer that belongs to the
   current repository from the user and then switch to the selected
@@ -7010,7 +7010,7 @@ These are some of the commands that can be used in all buffers whose
 major-modes derive from ~magit-mode~.  There are other common commands
 beside the ones below, but these didn't fit well anywhere else.
 
-- Key: C-w, magit-copy-section-value
+- Key: C-w (magit-copy-section-value) ::
 
   This command saves the value of the current section to the
   ~kill-ring~, and, provided that the current section is a commit,
@@ -7028,7 +7028,7 @@ beside the ones below, but these didn't fit well anywhere else.
   only either the added or removed lines, depending on the sign of
   the prefix argument.
 
-- Key: M-w, magit-copy-buffer-revision
+- Key: M-w (magit-copy-buffer-revision) ::
 
   This command saves the revision being displayed in the current buffer
   to the ~kill-ring~ and also pushes it to the ~magit-revision-stack~.  It
@@ -7072,7 +7072,7 @@ then ~HEAD~ is used in place of ~<branchref>~.
 Checking out another branch (or detaching ~HEAD~) causes the use of
 different wip refs for subsequent changes.
 
-- User Option: magit-wip-mode
+- User Option: magit-wip-mode ::
 
   When this mode is enabled, then uncommitted changes are committed
   to dedicated work-in-progress refs whenever appropriate (i.e. when
@@ -7090,7 +7090,7 @@ To view the log for a branch and its wip refs use the commands
 ~magit-wip-log~ and ~magit-wip-log-current~.  You should use ~--graph~ when
 using these commands.
 
-- Command: magit-wip-log
+- Command: magit-wip-log ::
 
   This command shows the log for a branch and its wip refs.
   With a negative prefix argument only the worktree wip ref is shown.
@@ -7099,7 +7099,7 @@ using these commands.
   "branches" of each wip ref are shown.  This is only relevant if the
   value of ~magit-wip-merge-branch~ is ~nil~.
 
-- Command: magit-wip-log-current
+- Command: magit-wip-log-current ::
 
   This command shows the log for the current branch and its wip refs.
   With a negative prefix argument only the worktree wip ref is shown.
@@ -7108,7 +7108,7 @@ using these commands.
   "branches" of each wip ref are shown.  This is only relevant if the
   value of ~magit-wip-merge-branch~ is ~nil~.
 
-- Key: X w, magit-reset-worktree
+- Key: X w (magit-reset-worktree) ::
 
   This command resets the working tree to some commit read from the
   user and defaulting to the commit at point, while keeping the ~HEAD~
@@ -7130,7 +7130,7 @@ When you are unsure whether Magit did commit a change to the wip refs,
 then you can explicitly request that all changes to all tracked files
 are being committed.
 
-- Key: M-x magit-wip-commit, magit-wip-commit
+- Key: M-x magit-wip-commit (magit-wip-commit) ::
 
   This command commits all changes to all tracked files to the index
   and working tree work-in-progress refs.  Like the modes described above,
@@ -7138,20 +7138,20 @@ are being committed.
   files for changes.  Use this command when you suspect that the modes
   might have overlooked a change made outside Emacs/Magit.
 
-- User Option: magit-wip-namespace
+- User Option: magit-wip-namespace ::
 
   The namespace used for work-in-progress refs.  It has to end with
   a slash.  The wip refs are named ~<namespace>index/<branchref>~ and
   ~<namespace>wtree/<branchref>~.  When snapshots are created while
   the ~HEAD~ is detached then ~HEAD~ is used in place of ~<branchref>~.
 
-- User Option: magit-wip-mode-lighter
+- User Option: magit-wip-mode-lighter ::
 
   Mode-line lighter for ~magit-wip--mode~.
 
 *** Wip Graph
 
-- User Option: magit-wip-merge-branch
+- User Option: magit-wip-merge-branch ::
 
   This option controls whether the current branch is merged into the
   wip refs after a new commit was created on the branch.
@@ -7221,13 +7221,13 @@ Setting the following variables directly does not take effect; either
 use the Custom interface to do so or call the respective mode
 functions.
 
-- User Option: magit-wip-after-save-mode
+- User Option: magit-wip-after-save-mode ::
 
   When this mode is enabled, then saving a buffer that visits a file
   tracked in a Git repository causes its current state to be committed
   to the working tree wip ref for the current branch.
 
-- User Option: magit-wip-after-apply-mode
+- User Option: magit-wip-after-apply-mode ::
 
   When this mode is enabled, then applying (i.e. staging, unstaging,
   discarding, reversing, and regularly applying) a change to a file
@@ -7240,12 +7240,12 @@ each and every change from accidental loss.  In practice nobody does
 that.  Two additional modes exists that do commit to the wip refs
 before making changes that could cause the loss of earlier changes.
 
-- User Option: magit-wip-before-change-mode
+- User Option: magit-wip-before-change-mode ::
 
   When this mode is enabled, then certain commands commit the existing
   changes to the files they are about to make changes to.
 
-- User Option: magit-wip-initial-backup-mode
+- User Option: magit-wip-initial-backup-mode ::
 
   When this mode is enabled, then the current version of a file is
   committed to the worktree wip ref before the buffer visiting that
@@ -7262,19 +7262,19 @@ before making changes that could cause the loss of earlier changes.
   used along-side that function, which is recommended because it only
   backs up files that are tracked in a Git repository.
 
-- User Option: magit-wip-after-save-local-mode-lighter
+- User Option: magit-wip-after-save-local-mode-lighter ::
 
   Mode-line lighter for ~magit-wip-after-save-local-mode~.
 
-- User Option: magit-wip-after-apply-mode-lighter
+- User Option: magit-wip-after-apply-mode-lighter ::
 
   Mode-line lighter for ~magit-wip-after-apply-mode~.
 
-- User Option: magit-wip-before-change-mode-lighter
+- User Option: magit-wip-before-change-mode-lighter ::
 
   Mode-line lighter for ~magit-wip-before-change-mode~.
 
-- User Option: magit-wip-initial-backup-mode-lighter
+- User Option: magit-wip-initial-backup-mode-lighter ::
 
   Mode-line lighter for ~magit-wip-initial-backup-mode~.
 
@@ -7297,7 +7297,7 @@ If you want a better binding, you have to add it yourself:
 The key bindings shown below assume that you have not improved the
 binding for ~magit-file-dispatch~.
 
-- Key: C-c M-g, magit-file-dispatch
+- Key: C-c M-g (magit-file-dispatch) ::
 
   This transient prefix command binds the following suffix commands
   and displays them in a temporary buffer until a suffix is invoked.
@@ -7305,22 +7305,22 @@ binding for ~magit-file-dispatch~.
   When invoked in a buffer that does not visit a file, then it falls
   back to regular ~magit-dispatch~.
 
-- Key: C-c M-g s, magit-stage-file
+- Key: C-c M-g s (magit-stage-file) ::
 
   Stage all changes to the file being visited in the current buffer.
 
-- Key: C-c M-g u, magit-unstage-file
+- Key: C-c M-g u (magit-unstage-file) ::
 
   Unstage all changes to the file being visited in the current buffer.
 
-- Key: C-c M-g c, magit-commit
+- Key: C-c M-g c (magit-commit) ::
 
   This transient prefix command binds the following suffix commands
   along with the appropriate infix arguments and displays them in a
   temporary buffer until a suffix is invoked.  See [[*Initiating a
   Commit]].
 
-- Key: C-c M-g D, magit-diff
+- Key: C-c M-g D (magit-diff) ::
 
   This transient prefix command binds several diff suffix commands and
   infix arguments and displays them in a temporary buffer until a
@@ -7331,17 +7331,17 @@ binding for ~magit-file-dispatch~.
   initial value of the option (~--~) that limits the diff to certain
   file(s) is set to the visited file.
 
-- Key: C-c M-g d, magit-diff-buffer-file
+- Key: C-c M-g d (magit-diff-buffer-file) ::
 
   This command shows the diff for the file of blob that the current
   buffer visits.
 
-- User Option: magit-diff-buffer-file-locked
+- User Option: magit-diff-buffer-file-locked ::
 
   This option controls whether ~magit-diff-buffer-file~ uses a dedicated
   buffer.  See [[*Modes and Buffers]].
 
-- Key: C-c M-g L, magit-log
+- Key: C-c M-g L (magit-log) ::
 
   This transient prefix command binds several log suffix commands and
   infix arguments and displays them in a temporary buffer until a
@@ -7352,23 +7352,23 @@ binding for ~magit-file-dispatch~.
   initial value of the option (~--~) that limits the log to certain
   file(s) is set to the visited file.
 
-- Key: C-c M-g l, magit-log-buffer-file
+- Key: C-c M-g l (magit-log-buffer-file) ::
 
   This command shows the log for the file of blob that the current
   buffer visits.  Renames are followed when a prefix argument is used
   or when ~--follow~ is an active log argument.  When the region is
   active, the log is restricted to the selected line range.
 
-- Key: C-c M-g t, magit-log-trace-definition
+- Key: C-c M-g t (magit-log-trace-definition) ::
 
   This command shows the log for the definition at point.
 
-- User Option: magit-log-buffer-file-locked
+- User Option: magit-log-buffer-file-locked ::
 
   This option controls whether ~magit-log-buffer-file~ uses a dedicated
   buffer.  See [[*Modes and Buffers]].
 
-- Key: C-c M-g B, magit-blame
+- Key: C-c M-g B (magit-blame) ::
 
   This transient prefix command binds all blaming suffix commands
   along with the appropriate infix arguments and displays them in a
@@ -7381,7 +7381,7 @@ In addition to the ~magit-blame~ sub-transient, the dispatch transient
 also binds several blaming suffix commands directly.  See [[*Blaming]] for
 information about those commands and bindings.
 
-- Key: C-c M-g e, magit-edit-line-commit
+- Key: C-c M-g e (magit-edit-line-commit) ::
 
   This command makes the commit editable that added the current line.
 
@@ -7391,26 +7391,26 @@ information about those commands and bindings.
   ~HEAD~, or by checking out the commit (or a branch that points at it)
   otherwise.
 
-- Key: C-c M-g p, magit-blob-previous
+- Key: C-c M-g p (magit-blob-previous) ::
 
   Visit the previous blob which modified the current file.
 
 There are a few additional commands that operate on a single file but
 are not enabled in the file transient command by default:
 
-- Command: magit-file-rename
+- Command: magit-file-rename ::
 
   This command renames a file read from the user.
 
-- Command: magit-file-delete
+- Command: magit-file-delete ::
 
   This command deletes a file read from the user.
 
-- Command: magit-file-untrack
+- Command: magit-file-untrack ::
 
   This command untracks a file read from the user.
 
-- Command: magit-file-checkout
+- Command: magit-file-checkout ::
 
   This command updates a file in the working tree and index to the
   contents from a revision.  Both the revision and file are read
@@ -7428,15 +7428,15 @@ of the commands mentioned below, which also take care of turning on
 this minor mode.  Currently this mode only establishes a few key
 bindings, but this might be extended.
 
-- Key: p, magit-blob-previous
+- Key: p (magit-blob-previous) ::
 
   Visit the previous blob which modified the current file.
 
-- Key: n, magit-blob-next
+- Key: n (magit-blob-next) ::
 
   Visit the next blob which modified the current file.
 
-- Key: q, magit-kill-this-buffer
+- Key: q (magit-kill-this-buffer) ::
 
   Kill the current buffer.
 
@@ -7501,7 +7501,7 @@ repository:
       . ((eval . (magit-disable-section-inserter 'magit-insert-tags-header)))))
   #+END_SRC
 
-- Function: magit-disable-section-inserter fn
+- Function: magit-disable-section-inserter fn ::
 
   This function disables the section inserter FN in the current
   repository.  It is only intended for use in ~.dir-locals.el~ and
@@ -7784,7 +7784,7 @@ for more information.
 
 *** Default Bindings
 
-- User Option: magit-define-global-key-bindings
+- User Option: magit-define-global-key-bindings ::
 
   This option controls whether some Magit commands are automatically
   bound in the global keymap even before Magit is used for the first
@@ -7878,46 +7878,46 @@ These functions run Git in order to get a value, an exit
 status, or output.  Of course you could also use them to run Git
 commands that have side-effects, but that should be avoided.
 
-- Function: magit-git-exit-code &rest args
+- Function: magit-git-exit-code &rest args ::
 
   Executes git with ARGS and returns its exit code.
 
-- Function: magit-git-success &rest args
+- Function: magit-git-success &rest args ::
 
   Executes git with ARGS and returns ~t~ if the exit code is ~0~, ~nil~
   otherwise.
 
-- Function: magit-git-failure &rest args
+- Function: magit-git-failure &rest args ::
 
   Executes git with ARGS and returns ~t~ if the exit code is ~1~, ~nil~
   otherwise.
 
-- Function: magit-git-true &rest args
+- Function: magit-git-true &rest args ::
 
   Executes git with ARGS and returns ~t~ if the first line printed by
   git is the string "true", ~nil~ otherwise.
 
-- Function: magit-git-false &rest args
+- Function: magit-git-false &rest args ::
 
   Executes git with ARGS and returns ~t~ if the first line printed by
   git is the string "false", ~nil~ otherwise.
 
-- Function: magit-git-insert &rest args
+- Function: magit-git-insert &rest args ::
 
   Executes git with ARGS and inserts its output at point.
 
-- Function: magit-git-string &rest args
+- Function: magit-git-string &rest args ::
 
   Executes git with ARGS and returns the first line of its output.  If
   there is no output or if it begins with a newline character, then
   this returns ~nil~.
 
-- Function: magit-git-lines &rest args
+- Function: magit-git-lines &rest args ::
 
   Executes git with ARGS and returns its output as a list of lines.
   Empty lines anywhere in the output are omitted.
 
-- Function: magit-git-items &rest args
+- Function: magit-git-items &rest args ::
 
   Executes git with ARGS and returns its null-separated output as a
   list.  Empty items anywhere in the output are omitted.
@@ -7927,7 +7927,7 @@ commands that have side-effects, but that should be avoided.
   add a section containing git's standard error in the current
   repository's process buffer.
 
-- Function: magit-process-git destination &rest args
+- Function: magit-process-git destination &rest args ::
 
   Calls Git synchronously in a separate process, returning its exit
   code.  DESTINATION specifies how to handle the output, like for
@@ -7935,7 +7935,7 @@ commands that have side-effects, but that should be avoided.
   Cygwin's "noglob" option during the call and ensures unix eol
   conversion.
 
-- Function: magit-process-file process &optional infile buffer display &rest args
+- Function: magit-process-file process &optional infile buffer display &rest args ::
 
   Processes files synchronously in a separate process.  Identical to
   ~process-file~ but temporarily enables Cygwin's "noglob" option during
@@ -7946,7 +7946,7 @@ is usually due to a bug, i.e. using an argument which is not
 actually supported.  Such errors are usually not reported, but when
 they occur we need to be able to debug them.
 
-- User Option: magit-git-debug
+- User Option: magit-git-debug ::
 
   Whether to report errors that occur when using ~magit-git-insert~,
   ~magit-git-string~, ~magit-git-lines~, or ~magit-git-items~.  This does
@@ -7954,7 +7954,7 @@ they occur we need to be able to debug them.
   area, and git's standard error is insert into a new section in the
   current repository's process buffer.
 
-- Function: magit-git-str &rest args
+- Function: magit-git-str &rest args ::
 
   This is a variant of ~magit-git-string~ that ignores the option
   ~magit-git-debug~.  It is mainly intended to be used while handling
@@ -7987,19 +7987,19 @@ wait for git to complete before letting the user do something else.
 For example after staging a change it is useful to wait until after
 the refresh because that also automatically moves to the next change.
 
-- Function: magit-call-git &rest args
+- Function: magit-call-git &rest args ::
 
   Calls git synchronously with ARGS.
 
-- Function: magit-call-process program &rest args
+- Function: magit-call-process program &rest args ::
 
   Calls PROGRAM synchronously with ARGS.
 
-- Function: magit-run-git &rest args
+- Function: magit-run-git &rest args ::
 
   Calls git synchronously with ARGS and then refreshes.
 
-- Function: magit-run-git-with-input &rest args
+- Function: magit-run-git-with-input &rest args ::
 
   Calls git synchronously with ARGS and sends it the content of the
   current buffer on standard input.
@@ -8009,12 +8009,12 @@ the refresh because that also automatically moves to the next change.
   then it waits for the process to return, so the function itself is
   synchronous.
 
-- Function: magit-git &rest args
+- Function: magit-git &rest args ::
 
   Calls git synchronously with ARGS for side-effects only.  This
   function does not refresh the buffer.
 
-- Function: magit-git-wash washer &rest args
+- Function: magit-git-wash washer &rest args ::
 
   Execute Git with ARGS, inserting washed output at point.  Actually
   first insert the raw output at point.  If there is no output call
@@ -8024,7 +8024,7 @@ the refresh because that also automatically moves to the next change.
 
 And now for the asynchronous variants.
 
-- Function: magit-run-git-async &rest args
+- Function: magit-run-git-async &rest args ::
 
   Start Git, prepare for refresh, and return the process object.
   ARGS is flattened and then used as arguments to Git.
@@ -8037,7 +8037,7 @@ And now for the asynchronous variants.
   Unmodified buffers visiting files that are tracked in the current
   repository are reverted if ~magit-revert-buffers~ is non-nil.
 
-- Function: magit-run-git-with-editor &rest args
+- Function: magit-run-git-with-editor &rest args ::
 
   Export GIT_EDITOR and start Git.  Also prepare for refresh and
   return the process object.  ARGS is flattened and then used as
@@ -8049,7 +8049,7 @@ And now for the asynchronous variants.
   current when this function was called (if it is a Magit buffer and
   still alive), as well as the respective Magit status buffer.
 
-- Function: magit-start-git input &rest args
+- Function: magit-start-git input &rest args ::
 
   Start Git, prepare for refresh, and return the process object.
 
@@ -8068,7 +8068,7 @@ And now for the asynchronous variants.
   Unmodified buffers visiting files that are tracked in the current
   repository are reverted if ~magit-revert-buffers~ is non-nil.
 
-- Function: magit-start-process &rest args
+- Function: magit-start-process &rest args ::
 
   Start PROGRAM, prepare for refresh, and return the process object.
 
@@ -8090,12 +8090,12 @@ And now for the asynchronous variants.
   in the current repository are reverted if ~magit-revert-buffers~ is
   non-nil.
 
-- Variable: magit-this-process
+- Variable: magit-this-process ::
 
   The child process which is about to start.  This can be used to
   change the filter and sentinel.
 
-- Variable: magit-process-raise-error
+- Variable: magit-process-raise-error ::
 
   When this is non-nil, then ~magit-process-sentinel~ raises an error if
   git exits with a non-zero exit status.  For debugging purposes.
@@ -8103,7 +8103,7 @@ And now for the asynchronous variants.
 ** Section Plumbing
 *** Creating Sections
 
-- Macro: magit-insert-section &rest args
+- Macro: magit-insert-section &rest args ::
 
   Insert a section at point.
 
@@ -8139,7 +8139,7 @@ And now for the asynchronous variants.
   section by washing Git's output and Git didn't actually output
   anything this time around.
 
-- Function: magit-insert-heading &rest args
+- Function: magit-insert-heading &rest args ::
 
   Insert the heading for the section currently being inserted.
 
@@ -8166,24 +8166,24 @@ And now for the asynchronous variants.
   you are responsible for getting it right.  The only exception is
   that this function does insert a newline character if necessary.
 
-- Function: magit-cancel-section
+- Function: magit-cancel-section ::
 
   Cancel the section currently being inserted.  This exits the
   innermost call to ~magit-insert-section~ and removes all traces of
   what has already happened inside that call.
 
-- Function: magit-define-section-jumper sym title &optional value
+- Function: magit-define-section-jumper sym title &optional value ::
 
   Define an interactive function to go to section SYM.  TITLE is the
   displayed title of the section.
 
 *** Section Selection
 
-- Function: magit-current-section
+- Function: magit-current-section ::
 
   Return the section at point.
 
-- Function: magit-region-sections &optional condition multiple
+- Function: magit-region-sections &optional condition multiple ::
 
   Return a list of the selected sections.
 
@@ -8210,7 +8210,7 @@ And now for the asynchronous variants.
   CONDITION, or nil is returned.  See ~magit-section-match~ for the
   forms CONDITION can take.
 
-- Function: magit-region-values &optional condition multiple
+- Function: magit-region-values &optional condition multiple ::
 
   Return a list of the values of the selected sections.
 
@@ -8219,22 +8219,22 @@ And now for the asynchronous variants.
 
 *** Matching Sections
 
-- Key: M-x magit-describe-section-briefly, magit-describe-section-briefly
+- Key: M-x magit-describe-section-briefly (magit-describe-section-briefly) ::
 
   Show information about the section at point.  This command is
   intended for debugging purposes.
 
-- Function: magit-section-ident section
+- Function: magit-section-ident section ::
 
   Return an unique identifier for SECTION.  The return value has the
   form ~((TYPE . VALUE)...)~.
 
-- Function: magit-get-section ident &optional root
+- Function: magit-get-section ident &optional root ::
 
   Return the section identified by IDENT.  IDENT has to be a list as
   returned by ~magit-section-ident~.
 
-- Function: magit-section-match condition &optional section
+- Function: magit-section-match condition &optional section ::
 
   Return ~t~ if SECTION matches CONDITION.
   SECTION defaults to the section at point.  If SECTION is not
@@ -8276,7 +8276,7 @@ And now for the asynchronous variants.
   lineage as printed by ~magit-describe-section-briefly~, unless
   of course you want to be that precise.
 
-- Function: magit-section-value-if condition &optional section
+- Function: magit-section-value-if condition &optional section ::
 
   If the section at point matches CONDITION, then return its value.
 
@@ -8287,7 +8287,7 @@ And now for the asynchronous variants.
 
   See ~magit-section-match~ for the forms CONDITION can take.
 
-- Function: magit-section-case &rest clauses
+- Function: magit-section-case &rest clauses ::
 
   Choose among clauses on the type of the section at point.
 
@@ -8303,7 +8303,7 @@ And now for the asynchronous variants.
   matches if no other CONDITION match, even if there is no section at
   point.
 
-- Variable: magit-root-section
+- Variable: magit-root-section ::
 
   The root section in the current buffer.  All other sections are
   descendants of this section.  The value of this variable is set by
@@ -8311,7 +8311,7 @@ And now for the asynchronous variants.
 
 For diff related sections a few additional tools exist.
 
-- Function: magit-diff-type &optional section
+- Function: magit-diff-type &optional section ::
 
   Return the diff type of SECTION.
 
@@ -8333,7 +8333,7 @@ For diff related sections a few additional tools exist.
   other means.  In ~magit-revision-mode~ buffers the type is always
   ~committed~.
 
-- Function: magit-diff-scope &optional section strict
+- Function: magit-diff-scope &optional section strict ::
 
   Return the diff scope of SECTION or the selected section(s).
 
@@ -8366,7 +8366,7 @@ of ~magit-refresh-function~ (a function named ~magit-*-refresh-buffer~,
 where ~*~ may be something like ~diff~) with the value of
 ~magit-refresh-args~ as arguments.
 
-- Macro: magit-mode-setup buffer switch-func mode refresh-func &optional refresh-args
+- Macro: magit-mode-setup buffer switch-func mode refresh-func &optional refresh-args ::
 
   This function displays and selects BUFFER, turns on MODE, and
   refreshes a first time.
@@ -8380,7 +8380,7 @@ where ~*~ may be something like ~diff~) with the value of
 
   All arguments are evaluated before switching to BUFFER.
 
-- Function: magit-mode-display-buffer buffer mode &optional switch-function
+- Function: magit-mode-display-buffer buffer mode &optional switch-function ::
 
   This function display BUFFER in some window and select it.  BUFFER
   may be a buffer or a string, the name of a buffer.  The buffer is
@@ -8394,13 +8394,13 @@ where ~*~ may be something like ~diff~) with the value of
   is ~nil~ then ~pop-to-buffer~ is used if the current buffer's major mode
   derives from ~magit-mode~.  Otherwise ~switch-to-buffer~ is used.
 
-- Variable: magit-refresh-function
+- Variable: magit-refresh-function ::
 
   The value of this buffer-local variable is the function used to
   refresh the current buffer.  It is called with ~magit-refresh-args~ as
   arguments.
 
-- Variable: magit-refresh-args
+- Variable: magit-refresh-args ::
 
   The list of arguments used by ~magit-refresh-function~ to refresh the
   current buffer.  ~magit-refresh-function~ is called with these
@@ -8901,13 +8901,13 @@ appreciate it very much if you use those tools before reporting an
 issue.  Please include all relevant output when reporting an
 issue.
 
-- Key: M-x magit-version, magit-version
+- Key: M-x magit-version (magit-version) ::
 
   This command shows the currently used versions of Magit, Git, and
   Emacs in the echo area.  Non-interactively this just returns the
   Magit version.
 
-- Key: M-x magit-emacs-Q-command, magit-emacs-Q-command
+- Key: M-x magit-emacs-Q-command (magit-emacs-Q-command) ::
 
   This command shows a debugging shell command in the echo area and
   adds it to the kill ring.  Paste that command into a shell and run
@@ -8921,13 +8921,13 @@ issue.
   If you run Magit from its Git repository, then you should be able to
   use ~make emacs-Q~ instead of the output of this command.
 
-- Key: M-x magit-toggle-verbose-refresh, magit-toggle-verbose-refresh
+- Key: M-x magit-toggle-verbose-refresh (magit-toggle-verbose-refresh) ::
 
   This command toggles whether Magit refreshes buffers verbosely.
   Enabling this helps figuring out which sections are bottlenecks.
   The additional output can be found in the ~*Messages*~ buffer.
 
-- Key: M-x magit-debug-git-executable, magit-debug-git-executable
+- Key: M-x magit-debug-git-executable (magit-debug-git-executable) ::
 
   This command displays a buffer containing information about the
   available and used ~git~ executable(s), and can be useful when
@@ -8935,7 +8935,7 @@ issue.
 
   Also see [[*Git Executable]].
 
-- Key: M-x with-editor-debug, with-editor-debug
+- Key: M-x with-editor-debug (with-editor-debug) ::
 
   This command displays a buffer containing information about the
   available and used ~emacsclient~ executable(s), and can be useful

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -3,18 +3,13 @@
 #+author: Jonas Bernoulli
 #+email: jonas@bernoul.li
 #+date: 2015-{{{year}}}
-#+language: en
 
 #+texinfo_dir_category: Emacs
 #+texinfo_dir_title: Magit: (magit).
 #+texinfo_dir_desc: Using Git from Emacs with Magit.
 #+subtitle: for version {{{version}}}
 
-#+texinfo_deffn: t
-#+options: H:4 num:3 toc:2
-#+property: header-args :eval never
-#+macro: version (eval (ox-texinfo+-get-version 'mixed))
-#+macro: year (eval (format-time-string "%Y"))
+#+setupfile: .orgconfig
 
 Magit is an interface to the version control system Git, implemented
 as an Emacs package.  Magit aspires to be a complete Git porcelain.


### PR DESCRIPTION
I intend to soon deprecate `ox-texinfo+` and use a new implementation of the same idea in `ox-texinfo`, which I have submitted for inclusion in Org.  That hasn't been merged yet but the initial response when I first brought it up was positive.

@kyleam could you please have a look at the thread starting with id:87ilx19pjh.fsf@bernoul.li on the Org list.  Thanks!

(There is a small hick up in the submitted commits (see first two change lines of second commit); doesn't seem worth submitting a new iteration before I got some feedback.)