### PR TITLE
magit--shell-command: Use with-connection-local-variables macro

### DIFF
--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -204,7 +204,9 @@ bisect run'."
        (magit-process-git-arguments
         (list "bisect" "start" bad good args)))
       (magit-refresh)))
-  (magit-git-bisect "run" (list shell-file-name shell-command-switch cmdline)))
+  (magit--with-connection-local-variables
+   (magit-git-bisect "run" (list shell-file-name
+                                 shell-command-switch cmdline))))
 
 (defun magit-git-bisect (subcommand &optional args no-assert)
   (unless (or no-assert (magit-bisect-in-progress-p))

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1959,12 +1959,13 @@ Return a list of two integers: (A>B B>A)."
     (cdr (split-string it))))
 
 (defun magit-patch-id (rev)
-  (magit--with-temp-process-buffer
-    (magit-process-file
-     shell-file-name nil '(t nil) nil shell-command-switch
-     (let ((exec (shell-quote-argument (magit-git-executable))))
-       (format "%s diff-tree -u %s | %s patch-id" exec rev exec)))
-    (car (split-string (buffer-string)))))
+  (magit--with-connection-local-variables
+   (magit--with-temp-process-buffer
+     (magit-process-file
+      shell-file-name nil '(t nil) nil shell-command-switch
+      (let ((exec (shell-quote-argument (magit-git-executable))))
+        (format "%s diff-tree -u %s | %s patch-id" exec rev exec)))
+     (car (split-string (buffer-string))))))
 
 (defun magit-rev-format (format &optional rev args)
   (let ((str (magit-git-string "show" "--no-patch"

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -447,8 +447,9 @@ is run in the top-level directory of the current working tree."
   (let ((default-directory (or directory default-directory))
         (process-environment process-environment))
     (push "GIT_PAGER=cat" process-environment)
-    (magit-start-process shell-file-name nil
-                         shell-command-switch command))
+    (magit--with-connection-local-variables
+     (magit-start-process shell-file-name nil
+                          shell-command-switch command)))
   (magit-process-buffer))
 
 (defun magit-read-shell-command (&optional toplevel initial-input)


### PR DESCRIPTION
Use with-connection-local-variables macro to make sure that
`shell-file-name` and `shell-command-switch` have values appropriate
for the machine we are trying to run the command on.

Consider the scenario where we are using Emacs + Magit running on a
Windows machine while manipulating a remote repo on a Linux machine
with Tramp + plink. Without `with-connection-local-variables` we'll
have `shell-file-name` pointing to `cmdproxy.exe` which, for obvious
reasons, won't work on the remote Linux box.