### PR TITLE
Replace preserve-merges by rebase-merges

### DIFF
--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -514,7 +514,7 @@ This discards all changes made since the sequence started."
   ["Arguments"
    :if-not magit-rebase-in-progress-p
    ("-k" "Keep empty commits"       "--keep-empty")
-   ("-p" "Preserve merges"          ("-p" "--preserve-merges"))
+   ("-r" "Rebase merges"          ("-r" "--rebase-merges"))
    (7 magit-merge:--strategy)
    (7 magit-merge:--strategy-option)
    (7 "=X" magit-diff:--diff-algorithm :argument "-Xdiff-algorithm=")


### PR DESCRIPTION
This replaces --preserve-merges by --rebase-merges in rebase popup.

--preserve-merges is obsolete and new git version gives the error "fatal: --preserve-merges has been replaced by --rebase-merges"

git version 2.34.1
