### PR TITLE
Sparse checkout and partial clone support

### DIFF
--- a/default.mk
+++ b/default.mk
@@ -90,6 +90,7 @@ ELS += magit-patch.el
 ELS += magit-bisect.el
 ELS += magit-stash.el
 ELS += magit-blame.el
+ELS += magit-sparse-checkout.el
 ELS += magit-submodule.el
 ELS += magit-subtree.el
 ELS += magit-ediff.el

--- a/docs/RelNotes/3.4.0.org
+++ b/docs/RelNotes/3.4.0.org
@@ -16,6 +16,10 @@
 - New transient ~magit-sparse-checkout~ provides an interface to the
   ~git sparse-checkout~ command, introduced in Git v2.25.  #4102
 
+- New command ~magit-clone-sparse~ makes it possible to clone a
+  repository and then immediately enable a sparse checkout, avoiding a
+  checkout of the full working tree.  #4102
+
 ** Fixes since v3.3.0
 
 - Automatic saving of file-visiting buffers was broken inside remote

--- a/docs/RelNotes/3.4.0.org
+++ b/docs/RelNotes/3.4.0.org
@@ -20,6 +20,10 @@
   repository and then immediately enable a sparse checkout, avoiding a
   checkout of the full working tree.  #4102
 
+- The ~magit-clone~ transient now includes ~--filter~ (hidden by
+  default) to support partial cloning, a feature that is available as
+  of Git v2.17.  #4102
+
 ** Fixes since v3.3.0
 
 - Automatic saving of file-visiting buffers was broken inside remote

--- a/docs/RelNotes/3.4.0.org
+++ b/docs/RelNotes/3.4.0.org
@@ -13,6 +13,9 @@
 - Added new face ~git-rebase-action~ to allow customization of the face
   used for the action words in git-rebase-todo files.
 
+- New transient ~magit-sparse-checkout~ provides an interface to the
+  ~git sparse-checkout~ command, introduced in Git v2.25.  #4102
+
 ** Fixes since v3.3.0
 
 - Automatic saving of file-visiting buffers was broken inside remote

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -4141,6 +4141,13 @@ argument is used and on the value of ~magit-clone-always-transient~.
   By default the depth of the cloned history is a single commit,
   but with a prefix argument the depth is read from the user.
 
+- Key: C > (magit-clone-sparse) ::
+
+  This command creates a clone of an existing repository and
+  initializes a sparse checkout, avoiding a checkout of the full
+  working tree.  To add more directories, use the
+  ~magit-sparse-checkout~ transient (see [[*Sparse checkouts]]).
+
 - Key: C b (magit-clone-bare) ::
 
   This command creates a bare clone of an existing repository.
@@ -7044,6 +7051,10 @@ version.
 
   This command restores the full checkout.  To return to the previous
   sparse checkout, call ~magit-sparse-checkout-enable~.
+
+A sparse checkout can also be initiated when cloning a repository by
+using the ~magit-clone-sparse~ command in the ~magit-clone~ transient
+(see [[*Cloning Repository]]).
 
 If you want the status buffer to indicate when a sparse checkout is
 enabled, add the function ~magit-sparse-checkout-insert-header~ to

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -6990,6 +6990,61 @@ Also see [[man:git-worktree]]
   If the worktree at point is the one whose status is already being
   displayed in the current buffer, then show it in Dired instead.
 
+** Sparse checkouts
+
+Sparse checkouts provide a way to restrict the working tree to a
+subset of directories.  See [[man:git-sparse-checkout]]
+
+*Warning*: Git introduced the ~git sparse-checkout~ command in version
+2.25 and still advertises it as experimental and subject to change.
+Magit's interface should be considered the same.  In particular, if
+Git introduces a backward incompatible change, Magit's sparse checkout
+functionality may be updated in a way that requires a more recent Git
+version.
+
+- Key: > (magit-sparse-checkout) ::
+
+  This transient prefix command binds the following suffix commands
+  and displays them in a temporary buffer until a suffix is invoked.
+
+- Key: > e (magit-sparse-checkout-enable) ::
+
+  This command initializes a sparse checkout that includes only the
+  files in the top-level directory.
+
+  Note that ~magit-sparse-checkout-set~ and
+  ~magit-sparse-checkout-add~ automatically initialize a sparse
+  checkout if necessary.  However, you may want to call
+  ~magit-sparse-checkout-enable~ explicitly to re-initialize a sparse
+  checkout after calling ~magit-sparse-checkout-disable~, to pass
+  additional arguments to ~git sparse-checkout init~, or to execute
+  the initialization asynchronously.
+
+- Key: > s (magit-sparse-checkout-set) ::
+
+  This command takes a list of directories and configures the sparse
+  checkout to include only files in those subdirectories.  Any
+  previously included directories are excluded unless they are in the
+  provided list of directories.
+
+- Key: > a (magit-sparse-checkout-add) ::
+
+  This command is like ~magit-sparse-checkout-set~, but instead adds
+  the specified list of directories to the set of directories that is
+  already included in the sparse checkout.
+
+- Key: > r (magit-sparse-checkout-reapply) ::
+
+  This command applies the currently configured sparse checkout
+  patterns to the working tree.  This is useful to call if excluded
+  files have been checked out after operations such as merging or
+  rebasing.
+
+- Key: > d (magit-sparse-checkout-disable) ::
+
+  This command restores the full checkout.  To return to the previous
+  sparse checkout, call ~magit-sparse-checkout-enable~.
+
 ** Bundle
 
 Also see [[man:git-bundle]]

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -7045,6 +7045,10 @@ version.
   This command restores the full checkout.  To return to the previous
   sparse checkout, call ~magit-sparse-checkout-enable~.
 
+If you want the status buffer to indicate when a sparse checkout is
+enabled, add the function ~magit-sparse-checkout-insert-header~ to
+~magit-status-headers-hook~.
+
 ** Bundle
 
 Also see [[man:git-bundle]]

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -31,7 +31,7 @@ General Public License for more details.
 @finalout
 @titlepage
 @title Magit User Manual
-@subtitle for version v3.3.0-100-g5f23bcd77+1
+@subtitle for version v3.3.0-108-geb56b14bc+1
 @author Jonas Bernoulli
 @page
 @vskip 0pt plus 1filll
@@ -53,7 +53,7 @@ directly from within Emacs.  While many fine Git clients exist, only
 Magit and Git itself deserve to be called porcelains.
 
 @noindent
-This manual is for Magit version v3.3.0-100-g5f23bcd77+1.
+This manual is for Magit version v3.3.0-108-geb56b14bc+1.
 
 @quotation
 Copyright (C) 2015-2022 Jonas Bernoulli <jonas@@bernoul.li>
@@ -260,6 +260,7 @@ Miscellaneous
 * Submodules::
 * Subtree::
 * Worktree::
+* Sparse checkouts::
 * Bundle::
 * Common Commands::
 * Wip Modes::
@@ -5168,6 +5169,14 @@ The repository and the target directory are read from the user.
 By default the depth of the cloned history is a single commit,
 but with a prefix argument the depth is read from the user.
 
+@item @kbd{C >} (@code{magit-clone-sparse})
+@kindex C >
+@findex magit-clone-sparse
+This command creates a clone of an existing repository and
+initializes a sparse checkout, avoiding a checkout of the full
+working tree.  To add more directories, use the
+@code{magit-sparse-checkout} transient (see @ref{Sparse checkouts}).
+
 @item @kbd{C b} (@code{magit-clone-bare})
 @kindex C b
 @findex magit-clone-bare
@@ -8328,6 +8337,7 @@ discards all changes made since the sequence started.
 * Submodules::
 * Subtree::
 * Worktree::
+* Sparse checkouts::
 * Bundle::
 * Common Commands::
 * Wip Modes::
@@ -8755,6 +8765,89 @@ If there is no worktree at point, then read one in the minibuffer.
 If the worktree at point is the one whose status is already being
 displayed in the current buffer, then show it in Dired instead.
 @end table
+
+@node Sparse checkouts
+@section Sparse checkouts
+
+Sparse checkouts provide a way to restrict the working tree to a
+subset of directories.  See 
+@ifinfo
+@ref{git-sparse-checkout,,,gitman,}.
+@end ifinfo
+@ifhtml
+@html
+the <a href="http://git-scm.com/docs/git-sparse-checkout">git-sparse-checkout(1)</a> manpage.
+@end html
+@end ifhtml
+@iftex
+the git-sparse-checkout(1) manpage.
+@end iftex
+
+@strong{Warning}: Git introduced the @code{git sparse-checkout} command in version
+2.25 and still advertises it as experimental and subject to change.
+Magit's interface should be considered the same.  In particular, if
+Git introduces a backward incompatible change, Magit's sparse checkout
+functionality may be updated in a way that requires a more recent Git
+version.
+
+@table @asis
+@item @kbd{>} (@code{magit-sparse-checkout})
+@kindex >
+@findex magit-sparse-checkout
+This transient prefix command binds the following suffix commands
+and displays them in a temporary buffer until a suffix is invoked.
+
+@item @kbd{> e} (@code{magit-sparse-checkout-enable})
+@kindex > e
+@findex magit-sparse-checkout-enable
+This command initializes a sparse checkout that includes only the
+files in the top-level directory.
+
+Note that @code{magit-sparse-checkout-set} and
+@code{magit-sparse-checkout-add} automatically initialize a sparse
+checkout if necessary.  However, you may want to call
+@code{magit-sparse-checkout-enable} explicitly to re-initialize a sparse
+checkout after calling @code{magit-sparse-checkout-disable}, to pass
+additional arguments to @code{git sparse-checkout init}, or to execute
+the initialization asynchronously.
+
+@item @kbd{> s} (@code{magit-sparse-checkout-set})
+@kindex > s
+@findex magit-sparse-checkout-set
+This command takes a list of directories and configures the sparse
+checkout to include only files in those subdirectories.  Any
+previously included directories are excluded unless they are in the
+provided list of directories.
+
+@item @kbd{> a} (@code{magit-sparse-checkout-add})
+@kindex > a
+@findex magit-sparse-checkout-add
+This command is like @code{magit-sparse-checkout-set}, but instead adds
+the specified list of directories to the set of directories that is
+already included in the sparse checkout.
+
+@item @kbd{> r} (@code{magit-sparse-checkout-reapply})
+@kindex > r
+@findex magit-sparse-checkout-reapply
+This command applies the currently configured sparse checkout
+patterns to the working tree.  This is useful to call if excluded
+files have been checked out after operations such as merging or
+rebasing.
+
+@item @kbd{> d} (@code{magit-sparse-checkout-disable})
+@kindex > d
+@findex magit-sparse-checkout-disable
+This command restores the full checkout.  To return to the previous
+sparse checkout, call @code{magit-sparse-checkout-enable}.
+@end table
+
+A sparse checkout can also be initiated when cloning a repository by
+using the @code{magit-clone-sparse} command in the @code{magit-clone} transient
+(see @ref{Cloning Repository}).
+
+If you want the status buffer to indicate when a sparse checkout is
+enabled, add the function @code{magit-sparse-checkout-insert-header} to
+@code{magit-status-headers-hook}.
 
 @node Bundle
 @section Bundle

--- a/lisp/Makefile
+++ b/lisp/Makefile
@@ -14,59 +14,60 @@ magit-utils.elc:
 magit-section.elc:
 ifeq "$(BUILD_MAGIT_LIBGIT)" "true"
 magit-libgit.elc:
-magit-git.elc:          magit-utils.elc magit-section.elc magit-libgit.elc
+magit-git.elc:             magit-utils.elc magit-section.elc magit-libgit.elc
 else
-magit-git.elc:          magit-utils.elc magit-section.elc
+magit-git.elc:             magit-utils.elc magit-section.elc
 endif
-magit-mode.elc:         magit-section.elc magit-git.elc
-magit-margin.elc:       magit-section.elc magit-mode.elc
-magit-process.elc:      magit-utils.elc magit-section.elc \
-                        magit-git.elc magit-mode.elc
-magit-transient.elc:    magit-git.elc magit-mode.elc magit-process.elc
-magit-autorevert.elc:   magit-git.elc magit-process.elc
-magit-core.elc:         magit-margin.elc magit-utils.elc \
-                        magit-section.elc magit-git.elc \
-                        magit-transient.elc magit-mode.elc \
-                        magit-process.elc magit-autorevert.elc
-magit-diff.elc:         git-commit.elc magit-core.elc
-magit-log.elc:          magit-core.elc magit-diff.elc
-magit-wip.elc:          magit-core.elc magit-log.elc
-magit-reflog.elc:       magit-core.elc magit-log.elc
-magit-apply.elc:        magit-core.elc magit-diff.elc magit-wip.elc
-magit-repos.elc:        magit-core.elc
-magit.elc:              git-commit.elc magit-core.elc magit-diff.elc \
-                        magit-log.elc magit-apply.elc magit-repos.elc
-magit-status.elc:       magit.elc
-magit-refs.elc:         magit.elc
-magit-files.elc:        magit.elc
-magit-reset.elc:        magit.elc
-magit-branch.elc:       magit.elc magit-reset.elc
-magit-merge.elc:        magit.elc magit-diff.elc
-magit-tag.elc:          magit.elc
-magit-worktree.elc:     magit.elc
-magit-notes.elc:        magit.elc
-magit-sequence.elc:     magit.elc
-magit-commit.elc:       magit.elc magit-sequence.elc
-magit-remote.elc:       magit.elc
-magit-clone.elc:        magit.elc
-magit-fetch.elc:        magit.elc
-magit-pull.elc:         magit.elc magit-remote.elc
-magit-push.elc:         magit.elc
-magit-bisect.elc:       magit.elc
-magit-stash.elc:        magit.elc magit-sequence.elc magit-reflog.elc
-magit-blame.elc:        magit.elc
-magit-obsolete.elc:     magit.elc
-magit-submodule.elc:    magit.elc
-magit-patch.elc:        magit.elc
-magit-subtree.elc:      magit.elc
-magit-ediff.elc:        magit.elc
-magit-gitignore.elc:    magit.elc
-magit-bundle.elc:       magit.elc
-magit-extras.elc:       magit.elc magit-merge.elc
-git-rebase.elc:         magit.elc
-magit-imenu.elc:        magit.elc git-rebase.elc
-magit-bookmark.elc:     magit.elc
-magit-obsolete.elc:     magit.elc
+magit-mode.elc:            magit-section.elc magit-git.elc
+magit-margin.elc:          magit-section.elc magit-mode.elc
+magit-process.elc:         magit-utils.elc magit-section.elc \
+                           magit-git.elc magit-mode.elc
+magit-transient.elc:       magit-git.elc magit-mode.elc magit-process.elc
+magit-autorevert.elc:      magit-git.elc magit-process.elc
+magit-core.elc:            magit-margin.elc magit-utils.elc \
+                           magit-section.elc magit-git.elc \
+                           magit-transient.elc magit-mode.elc \
+                           magit-process.elc magit-autorevert.elc
+magit-diff.elc:            git-commit.elc magit-core.elc
+magit-log.elc:             magit-core.elc magit-diff.elc
+magit-wip.elc:             magit-core.elc magit-log.elc
+magit-reflog.elc:          magit-core.elc magit-log.elc
+magit-apply.elc:           magit-core.elc magit-diff.elc magit-wip.elc
+magit-repos.elc:           magit-core.elc
+magit.elc:                 git-commit.elc magit-core.elc magit-diff.elc \
+                           magit-log.elc magit-apply.elc magit-repos.elc
+magit-status.elc:          magit.elc
+magit-refs.elc:            magit.elc
+magit-files.elc:           magit.elc
+magit-reset.elc:           magit.elc
+magit-branch.elc:          magit.elc magit-reset.elc
+magit-merge.elc:           magit.elc magit-diff.elc
+magit-tag.elc:             magit.elc
+magit-worktree.elc:        magit.elc
+magit-notes.elc:           magit.elc
+magit-sequence.elc:        magit.elc
+magit-commit.elc:          magit.elc magit-sequence.elc
+magit-remote.elc:          magit.elc
+magit-clone.elc:           magit.elc
+magit-fetch.elc:           magit.elc
+magit-pull.elc:            magit.elc magit-remote.elc
+magit-push.elc:            magit.elc
+magit-bisect.elc:          magit.elc
+magit-stash.elc:           magit.elc magit-sequence.elc magit-reflog.elc
+magit-blame.elc:           magit.elc
+magit-obsolete.elc:        magit.elc
+magit-submodule.elc:       magit.elc
+magit-patch.elc:           magit.elc
+magit-subtree.elc:         magit.elc
+magit-ediff.elc:           magit.elc
+magit-gitignore.elc:       magit.elc
+magit-sparse-checkout.elc: magit.elc
+magit-bundle.elc:          magit.elc
+magit-extras.elc:          magit.elc magit-merge.elc
+git-rebase.elc:            magit.elc
+magit-imenu.elc:           magit.elc git-rebase.elc
+magit-bookmark.elc:        magit.elc
+magit-obsolete.elc:        magit.elc
 
 ## Build #############################################################
 

--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -129,6 +129,9 @@ the name of the owner.  Also see `magit-clone-name-alist'."
    ("s" "shallow"            magit-clone-shallow)
    ("d" "shallow since date" magit-clone-shallow-since :level 7)
    ("e" "shallow excluding"  magit-clone-shallow-exclude :level 7)
+   (">" "sparse checkout"    magit-clone-sparse
+    :if (lambda () (magit-git-version>= "2.25.0"))
+    :level 6)
    ("b" "bare"               magit-clone-bare)
    ("m" "mirror"             magit-clone-mirror)]
   (interactive (list (or magit-clone-always-transient current-prefix-arg)))
@@ -193,7 +196,14 @@ Then show the status buffer for the new repository."
   (interactive (magit-clone-read-args))
   (magit-clone-internal repository directory (cons "--mirror" args)))
 
-(defun magit-clone-internal (repository directory args)
+;;;###autoload
+(defun magit-clone-sparse (repository directory args)
+  "Clone REPOSITORY into DIRECTORY and create a sparse checkout."
+  (interactive (magit-clone-read-args))
+  (magit-clone-internal repository directory (cons "--no-checkout" args)
+                        'sparse))
+
+(defun magit-clone-internal (repository directory args &optional sparse)
   (let* ((checkout (not (memq (car args) '("--bare" "--mirror"))))
          (remote (or (transient-arg-value "--origin" args)
                      (magit-get "clone.defaultRemote")
@@ -234,6 +244,13 @@ Then show the status buffer for the new repository."
                (setf (magit-get "remote.pushDefault") remote))
              (unless magit-clone-set-remote-head
                (magit-remote-unset-head remote))))
+         (when (and sparse checkout)
+           (when (magit-git-version< "2.25.0")
+             (user-error
+              "`git sparse-checkout' not available until Git v2.25"))
+           (let ((default-directory directory))
+             (magit-call-git "sparse-checkout" "init" "--cone")
+             (magit-call-git "checkout" (magit-get-current-branch))))
          (with-current-buffer (process-get process 'command-buf)
            (magit-status-setup-buffer directory)))))))
 

--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -117,6 +117,9 @@ the name of the owner.  Also see `magit-clone-name-alist'."
   ["Setup arguments"
    ("-o" "Set name of remote"     ("-o" "--origin="))
    ("-b" "Set HEAD branch"        ("-b" "--branch="))
+   (magit-clone:--filter
+    :if (lambda () (magit-git-version>= "2.17.0"))
+    :level 7)
    ("-g" "Separate git directory" "--separate-git-dir="
     transient-read-directory :level 7)
    ("-t" "Use template directory" "--template="
@@ -138,6 +141,18 @@ the name of the owner.  Also see `magit-clone-name-alist'."
   (if transient
       (transient-setup #'magit-clone)
     (call-interactively #'magit-clone-regular)))
+
+(transient-define-argument magit-clone:--filter ()
+  :description "Filter some objects"
+  :class 'transient-option
+  :key "-f"
+  :argument "--filter="
+  :reader 'magit-clone-read-filter)
+
+(defun magit-clone-read-filter (prompt initial-input history)
+  (magit-completing-read prompt
+                         (list "blob:none" "tree:0")
+                         nil nil initial-input history))
 
 ;;;###autoload
 (defun magit-clone-regular (repository directory args)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -961,6 +961,12 @@ tracked file."
   (magit-with-toplevel
     (magit-git-items "ls-tree" "-z" "-r" "--name-only" rev)))
 
+(defun magit-revision-directories (rev)
+  "List directories that contain a tracked file in revision REV."
+  (magit-with-toplevel
+    (mapcar #'file-name-as-directory
+            (magit-git-items "ls-tree" "-z" "-r" "-d" "--name-only" rev))))
+
 (defun magit-changed-files (rev-or-range &optional other-rev)
   "Return list of files the have changed between two revisions.
 If OTHER-REV is non-nil, REV-OR-RANGE should be a revision, not a

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -403,6 +403,7 @@ recommended value."
     (define-key map "%" 'magit-worktree)
     (define-key map "$" 'magit-process-buffer)
     (define-key map "!" 'magit-run)
+    (define-key map ">" 'magit-sparse-checkout)
     (define-key map (kbd "C-c C-c") 'magit-dispatch)
     (define-key map (kbd "C-c C-e") 'magit-edit-thing)
     (define-key map (kbd "C-c C-o") 'magit-browse-thing)

--- a/lisp/magit-sparse-checkout.el
+++ b/lisp/magit-sparse-checkout.el
@@ -76,6 +76,9 @@ See the `git sparse-checkout' manpage for details about
 (transient-define-prefix magit-sparse-checkout ()
   "Create and manage sparse checkouts."
   :man-page "git-sparse-checkout"
+  ["Arguments for enabling"
+   :if-not magit-sparse-checkout-enabled-p
+   ("-i" "Use sparse index" "--sparse-index")]
   ["Actions"
    [:if-not magit-sparse-checkout-enabled-p
     ("e" "Enable sparse checkout" magit-sparse-checkout-enable)]
@@ -86,11 +89,11 @@ See the `git sparse-checkout' manpage for details about
     ("a" "Add directories" magit-sparse-checkout-add)]])
 
 ;;;###autoload
-(defun magit-sparse-checkout-enable ()
+(defun magit-sparse-checkout-enable (&optional args)
   "Convert the working tree to a sparse checkout."
-  (interactive)
+  (interactive (list (transient-args 'magit-sparse-checkout)))
   (magit-sparse-checkout--assert-version)
-  (magit-run-git-async "sparse-checkout" "init" "--cone"))
+  (magit-run-git-async "sparse-checkout" "init" "--cone" args))
 
 ;;;###autoload
 (defun magit-sparse-checkout-set (directories)

--- a/lisp/magit-sparse-checkout.el
+++ b/lisp/magit-sparse-checkout.el
@@ -151,6 +151,23 @@ restore the previous sparse checkout."
   (magit-sparse-checkout--assert-version)
   (magit-run-git-async "sparse-checkout" "disable"))
 
+;;; Miscellaneous
+
+(defun magit-sparse-checkout-insert-header ()
+  "Insert header line with sparse checkout information.
+This header is not inserted by default.  To enable it, add it to
+`magit-status-headers-hook'."
+  (when (magit-sparse-checkout-enabled-p)
+    (insert (propertize (format "%-10s" "Sparse! ")
+                        'font-lock-face 'magit-section-heading))
+    (insert
+     (let ((dirs (magit-sparse-checkout-directories)))
+       (pcase (length dirs)
+         (0 "top-level directory")
+         (1 (car dirs))
+         (n (format "%d directories" n)))))
+    (insert ?\n)))
+
 ;;; _
 (provide 'magit-sparse-checkout)
 ;;; magit-sparse-checkout.el ends here

--- a/lisp/magit-sparse-checkout.el
+++ b/lisp/magit-sparse-checkout.el
@@ -1,0 +1,153 @@
+;;; magit-sparse-checkout.el --- sparse checkout support for Magit  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022  The Magit Project Contributors
+;;
+;; You should have received a copy of the AUTHORS.md file which
+;; lists all contributors.  If not, see http://magit.vc/authors.
+
+;; Author: Kyle Meyer <kyle@kyleam.com>
+;; Maintainer: Jonas Bernoulli <jonas@bernoul.li>
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; Magit is free software; you can redistribute it and/or modify it
+;; under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; Magit is distributed in the hope that it will be useful, but WITHOUT
+;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+;; or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+;; License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with Magit.  If not, see http://www.gnu.org/licenses.
+
+;;; Commentary:
+
+;; This library provides an interface to the `git sparse-checkout'
+;; command.  It's been possible to define sparse checkouts since Git
+;; v1.7.0 by adding patterns to $GIT_DIR/info/sparse-checkout and
+;; calling `git read-tree -mu HEAD' to update the index and working
+;; tree.  However, Git v2.25 introduced the `git sparse-checkout'
+;; command along with "cone mode", which restricts the possible
+;; patterns to directories to provide better performance.
+;;
+;; The goal of this library is to support the `git sparse-checkout'
+;; command operating in cone mode.
+
+;;; Code:
+
+(require 'magit)
+
+;;; Utilities
+
+(defun magit-sparse-checkout-enabled-p ()
+  "Return non-nil if working tree is a sparse checkout."
+  (magit-get-boolean "core.sparsecheckout"))
+
+(defun magit-sparse-checkout--assert-version ()
+  ;; Older versions of Git have the ability to define sparse checkout
+  ;; patterns in .git/info/sparse-checkout, but the sparse-checkout
+  ;; command isn't available until 2.25.0.
+  (when (magit-git-version< "2.25.0")
+    (user-error "`git sparse-checkout' not available until Git v2.25")))
+
+(defun magit-sparse-checkout--auto-enable ()
+  (if (magit-sparse-checkout-enabled-p)
+      (unless (magit-get-boolean "core.sparsecheckoutcone")
+        (user-error
+         "Magit's sparse checkout functionality requires cone mode"))
+    ;; Note: Don't use `magit-sparse-checkout-enable' because it's
+    ;; asynchronous.
+    (magit-run-git "sparse-checkout" "init" "--cone")))
+
+(defun magit-sparse-checkout-directories ()
+  "Return directories that are recursively included in the sparse checkout.
+See the `git sparse-checkout' manpage for details about
+\"recursive\" versus \"parent\" directories in cone mode."
+  (and (magit-get-boolean "core.sparsecheckoutcone")
+       (mapcar #'file-name-as-directory
+               (magit-git-lines "sparse-checkout" "list"))))
+
+;;; Commands
+
+;;;###autoload (autoload 'magit-sparse-checkout "magit-sparse-checkout" nil t)
+(transient-define-prefix magit-sparse-checkout ()
+  "Create and manage sparse checkouts."
+  :man-page "git-sparse-checkout"
+  ["Actions"
+   [:if-not magit-sparse-checkout-enabled-p
+    ("e" "Enable sparse checkout" magit-sparse-checkout-enable)]
+   [:if magit-sparse-checkout-enabled-p
+    ("d" "Disable sparse checkout" magit-sparse-checkout-disable)
+    ("r" "Reapply rules" magit-sparse-checkout-reapply)]
+   [("s" "Set directories" magit-sparse-checkout-set)
+    ("a" "Add directories" magit-sparse-checkout-add)]])
+
+;;;###autoload
+(defun magit-sparse-checkout-enable ()
+  "Convert the working tree to a sparse checkout."
+  (interactive)
+  (magit-sparse-checkout--assert-version)
+  (magit-run-git-async "sparse-checkout" "init" "--cone"))
+
+;;;###autoload
+(defun magit-sparse-checkout-set (directories)
+  "Restrict working tree to DIRECTORIES.
+To extend rather than override the currently configured
+directories, call `magit-sparse-checkout-add' instead."
+  (interactive
+   (list (magit-completing-read-multiple*
+          "Include these directories: "
+          ;; Note: Given that the appeal of sparse checkouts is
+          ;; dealing with very large trees, listing all subdirectories
+          ;; may need to be reconsidered.
+          (magit-revision-directories "HEAD"))))
+  (magit-sparse-checkout--assert-version)
+  (magit-sparse-checkout--auto-enable)
+  (magit-run-git-async "sparse-checkout" "set" directories))
+
+;;;###autoload
+(defun magit-sparse-checkout-add (directories)
+  "Add DIRECTORIES to the working tree.
+To override rather than extend the currently configured
+directories, call `magit-sparse-checkout-set' instead."
+  (interactive
+   (list (magit-completing-read-multiple*
+          "Add these directories: "
+          ;; Same performance note as in `magit-sparse-checkout-set',
+          ;; but even more so given the additional processing.
+          (seq-remove
+           (let ((re (concat
+                      "\\`"
+                      (regexp-opt (magit-sparse-checkout-directories)))))
+             (lambda (d) (string-match-p re d)))
+           (magit-revision-directories "HEAD")))))
+  (magit-sparse-checkout--assert-version)
+  (magit-sparse-checkout--auto-enable)
+  (magit-run-git-async "sparse-checkout" "add" directories))
+
+;;;###autoload
+(defun magit-sparse-checkout-reapply ()
+  "Reapply the sparse checkout rules to the working tree.
+Some operations such as merging or rebasing may need to check out
+files that aren't included in the sparse checkout.  Call this
+command to reset to the sparse checkout state."
+  (interactive)
+  (magit-sparse-checkout--assert-version)
+  (magit-run-git-async "sparse-checkout" "reapply"))
+
+;;;###autoload
+(defun magit-sparse-checkout-disable ()
+  "Convert sparse checkout to full checkout.
+Note that disabling the sparse checkout does not clear the
+configured directories.  Call `magit-sparse-checkout-enable' to
+restore the previous sparse checkout."
+  (interactive)
+  (magit-sparse-checkout--assert-version)
+  (magit-run-git-async "sparse-checkout" "disable"))
+
+;;; _
+(provide 'magit-sparse-checkout)
+;;; magit-sparse-checkout.el ends here

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -712,6 +712,7 @@ For X11 something like ~/.xinitrc should work.\n"
     (require 'magit-subtree)
     (require 'magit-ediff)
     (require 'magit-gitignore)
+    (require 'magit-sparse-checkout)
     (require 'magit-extras)
     (require 'git-rebase)
     (require 'magit-imenu)


### PR DESCRIPTION
Commits 1-5 add support for `git sparse-checkout`.  The second commit is the main addition, and its commit message has some background on sparse checkouts and explains which aspects the new magit-sparse-checkout.el library targets.

Commit 6 adds partial clone support by adding `--filter` to `magit-clone`.  Although they can work together, partial clones aren't inherently coupled to sparse checkouts, but I decided to include the last commit given that both features share the same issue (gh-4102).

Closes #4102.

cc @aseltmann

---

I'm marking this as a draft, mostly because I've run out of time to read this over tonight (apologies for bad typos or half-thoughts that may have slipped through).  I think it's likely that I won't get back to this until next weekend, but I'd of course be happy for any feedback in the meantime.

- [x] regenerate manual
