### PR TITLE
Updates for compatibility with SHA-256 repositories

### DIFF
--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -250,7 +250,7 @@ bisect run'."
                       "It appears you have invoked `git bisect' from a shell."
                       "There is nothing wrong with that, we just cannot display"
                       "anything useful here.  Consult the shell output instead.")))
-           (done-re "^\\([a-z0-9]\\{40\\}\\) is the first bad commit$")
+           (done-re "^\\([a-z0-9]\\{40,\\}\\) is the first bad commit$")
            (bad-line (or (and (string-match done-re (car lines))
                               (pop lines))
                          (--first (string-match done-re it) lines))))
@@ -299,7 +299,7 @@ bisect run'."
                               (magit-abbrev-length)))
             (insert ?\n)))))
     (when (re-search-forward
-           "# first bad commit: \\[\\([a-z0-9]\\{40\\}\\)\\] [^\n]+\n" nil t)
+           "# first bad commit: \\[\\([a-z0-9]\\{40,\\}\\)\\] [^\n]+\n" nil t)
       (magit-bind-match-strings (hash) nil
         (magit-delete-match)
         (magit-insert-section (bisect-item)

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -638,7 +638,7 @@ modes is toggled, then this mode also gets toggled automatically.
 
 (defun magit-blame--format-string-1 (rev revinfo format face)
   (let ((str
-         (if (equal rev "0000000000000000000000000000000000000000")
+         (if (string-match-p "\\`0\\{40,\\}\\'" rev)
              (propertize (concat (if (string-prefix-p "\s" format) "\s" "")
                                  "Not Yet Committed"
                                  (if (string-suffix-p "\n" format) "\n" ""))

--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -476,7 +476,7 @@ modes is toggled, then this mode also gets toggled automatically.
 
 (defun magit-blame--parse-chunk (type)
   (let (chunk revinfo)
-    (unless (looking-at "^\\(.\\{40\\}\\) \\([0-9]+\\) \\([0-9]+\\) \\([0-9]+\\)")
+    (unless (looking-at "^\\(.\\{40,\\}\\) \\([0-9]+\\) \\([0-9]+\\) \\([0-9]+\\)")
       (error "Blaming failed due to unexpected output: %s"
              (buffer-substring-no-properties (point) (line-end-position))))
     (with-slots (orig-rev orig-file prev-rev prev-file)
@@ -491,7 +491,7 @@ modes is toggled, then this mode also gets toggled automatically.
           (cond ((looking-at "^filename \\(.+\\)")
                  (setq done t)
                  (setf orig-file (magit-decode-git-path (match-string 1))))
-                ((looking-at "^previous \\(.\\{40\\}\\) \\(.+\\)")
+                ((looking-at "^previous \\(.\\{40,\\}\\) \\(.+\\)")
                  (setf prev-rev  (match-string 1))
                  (setf prev-file (magit-decode-git-path (match-string 2))))
                 ((looking-at "^\\([^ ]+\\) \\(.+\\)")

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2221,7 +2221,7 @@ section or a child thereof."
                        ("removed in remote" "removed"))))
       (magit-delete-line)
       (while (looking-at
-              "^  \\([^ ]+\\) +[0-9]\\{6\\} \\([a-z0-9]\\{40\\}\\) \\(.+\\)$")
+              "^  \\([^ ]+\\) +[0-9]\\{6\\} \\([a-z0-9]\\{40,\\}\\) \\(.+\\)$")
         (magit-bind-match-strings (side _blob name) nil
           (pcase side
             ("result" (setq file name))

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -377,7 +377,7 @@ points at it) otherwise."
   (interactive (list (and current-prefix-arg 'removal)))
   (let* ((chunk (magit-current-blame-chunk (or type 'addition)))
          (rev   (oref chunk orig-rev)))
-    (if (equal rev "0000000000000000000000000000000000000000")
+    (if (string-match-p "\\`0\\{40,\\}\\'" rev)
         (message "This line has not been committed yet")
       (let ((rebase (magit-rev-ancestor-p rev "HEAD"))
             (file   (expand-file-name (oref chunk orig-file)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1833,7 +1833,7 @@ SORTBY is a key or list of keys to pass to the `--sort' flag of
           (magit-git-lines "submodule" "status")))
 
 (defun magit-list-module-paths ()
-  (--mapcat (and (string-match "^160000 [0-9a-z]\\{40\\} 0\t\\(.+\\)$" it)
+  (--mapcat (and (string-match "^160000 [0-9a-z]\\{40,\\} 0\t\\(.+\\)$" it)
                  (list (match-string 1 it)))
             (magit-git-items "ls-files" "-z" "--stage")))
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1161,7 +1161,7 @@ Do not add this to a hook variable."
   ;; ++header is used.
   (concat "^"
           "\\(?4:[-_/|\\*o<>. ]*\\)"               ; graph
-          "\\(?1:[0-9a-fA-F]+\\)?"               ; sha1
+          "\\(?1:[0-9a-fA-F]+\\)?"               ; hash
           "\\(?3:[^\n]+\\)?"                   ; refs
           "\\(?7:[BGUXYREN]\\)?"                 ; gpg
           "\\(?5:[^\n]*\\)"                    ; author
@@ -1173,31 +1173,31 @@ Do not add this to a hook variable."
 (defconst magit-log-cherry-re
   (concat "^"
           "\\(?8:[-+]\\) "                         ; cherry
-          "\\(?1:[0-9a-fA-F]+\\) "                 ; sha1
+          "\\(?1:[0-9a-fA-F]+\\) "                 ; hash
           "\\(?2:.*\\)$"))                         ; msg
 
 (defconst magit-log-module-re
   (concat "^"
           "\\(?:\\(?11:[<>]\\) \\)?"               ; side
-          "\\(?1:[0-9a-fA-F]+\\) "                 ; sha1
+          "\\(?1:[0-9a-fA-F]+\\) "                 ; hash
           "\\(?2:.*\\)$"))                         ; msg
 
 (defconst magit-log-bisect-vis-re
   (concat "^"
           "\\(?4:[-_/|\\*o<>. ]*\\)"               ; graph
-          "\\(?1:[0-9a-fA-F]+\\)?\0"               ; sha1
+          "\\(?1:[0-9a-fA-F]+\\)?\0"               ; hash
           "\\(?3:[^\0\n]+\\)?\0"                   ; refs
           "\\(?2:.*\\)$"))                         ; msg
 
 (defconst magit-log-bisect-log-re
   (concat "^# "
           "\\(?3:[^: \n]+:\\) "                    ; "refs"
-          "\\[\\(?1:[^]\n]+\\)\\] "                ; sha1
+          "\\[\\(?1:[^]\n]+\\)\\] "                ; hash
           "\\(?2:.*\\)$"))                         ; msg
 
 (defconst magit-log-reflog-re
   (concat "^"
-          "\\(?1:[^\0\n]+\\)\0"                    ; sha1
+          "\\(?1:[^\0\n]+\\)\0"                    ; hash
           "\\(?5:[^\0\n]*\\)\0"                    ; author
           "\\(?:\\(?:[^@\n]+@{\\(?6:[^}\n]+\\)}\0" ; date
           "\\(?10:merge \\|autosave \\|restart \\|[^:\n]+: \\)?" ; refsub
@@ -1210,7 +1210,7 @@ Do not add this to a hook variable."
 
 (defconst magit-log-stash-re
   (concat "^"
-          "\\(?1:[^\0\n]+\\)\0"                    ; "sha1"
+          "\\(?1:[^\0\n]+\\)\0"                    ; "hash"
           "\\(?5:[^\0\n]*\\)\0"                    ; author
           "\\(?6:[^\0\n]+\\)\0"                    ; date
           "\\(?2:.*\\)$"))                         ; msg

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -92,7 +92,7 @@ own faces for the `header-line', or for parts of the
 (defface magit-hash
   '((((class color) (background light)) :foreground "grey60")
     (((class color) (background  dark)) :foreground "grey40"))
-  "Face for the sha1 part of the log output."
+  "Face for the commit object name in the log output."
   :group 'magit-faces)
 
 (defface magit-tag


### PR DESCRIPTION
This series fixes spots in the code base that are incompatible with Git's recent and experimental SHA-256 support (basically anywhere that hard codes the expectaion of 40-character object names).

I found these spots with two checks:

```
$ git grep '\b40\b'
$ git grep -E '[a-f0-9]{40}'
```

I expected that the empty tree hash might pop up somewhere in there, but `magit-headish` already handles this in a nicely compatible way.

Fixes #4516.
