### PR TITLE
Make magit-dispatch slightly more discoverable

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -372,7 +372,14 @@ Also see info node `(magit)Commands for Buffers Visiting Files'."
     ("q" "       bury current buffer"      magit-mode-bury-buffer)
     ("<tab>" "   toggle section at point"  magit-section-toggle)
     ("<return>" "visit thing at point"     magit-visit-thing)]
-   [("C-x m"    "show all key bindings"    describe-mode)]])
+   [("C-x m"    "show all key bindings"    describe-mode)
+    ("C-x i"    "show Info manual"         magit-info)]])
+
+;;;###autoload
+(defun magit-info ()
+  "Show Magit's Info manual."
+  (interactive)
+  (info "magit"))
 
 ;;; Git Popup
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -369,6 +369,7 @@ Also see info node `(magit)Commands for Buffers Visiting Files'."
   ["Essential commands"
    :if-derived magit-mode
    ("g" "       refresh current buffer"   magit-refresh)
+   ("q" "       bury current buffer"      magit-mode-bury-buffer)
    ("<tab>" "   toggle section at point"  magit-section-toggle)
    ("<return>" "visit thing at point"     magit-visit-thing)
    ("C-x m" "   show all key bindings"    describe-mode)])

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -368,11 +368,11 @@ Also see info node `(magit)Commands for Buffers Visiting Files'."
     ("U" "Unstage all"    magit-unstage-all)]]
   ["Essential commands"
    :if-derived magit-mode
-   ("g" "       refresh current buffer"   magit-refresh)
-   ("q" "       bury current buffer"      magit-mode-bury-buffer)
-   ("<tab>" "   toggle section at point"  magit-section-toggle)
-   ("<return>" "visit thing at point"     magit-visit-thing)
-   ("C-x m" "   show all key bindings"    describe-mode)])
+   [("g" "       refresh current buffer"   magit-refresh)
+    ("q" "       bury current buffer"      magit-mode-bury-buffer)
+    ("<tab>" "   toggle section at point"  magit-section-toggle)
+    ("<return>" "visit thing at point"     magit-visit-thing)]
+   [("C-x m"    "show all key bindings"    describe-mode)]])
 
 ;;; Git Popup
 


### PR DESCRIPTION
In response to #4572.

@kyleam what do you think?

Additionally (but optionally) adding all alphabetic bindings would
look like this:

``` diff
diff --git a/lisp/magit.el b/lisp/magit.el
index d83ccbb90..19cbd3d30 100644
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -373,7 +373,15 @@ (transient-define-prefix magit-dispatch ()
     ("<tab>" "   toggle section at point"  magit-section-toggle)
     ("<return>" "visit thing at point"     magit-visit-thing)]
    [("C-x m"    "show all key bindings"    describe-mode)
-    ("C-x i"    "show Info manual"         magit-info)]])
+    ("C-x i"    "show Info manual"         magit-info)]]
+  ["Other commands"
+   :level 7
+   ("G" "Refresh repository buffers" magit-refresh-all)
+   ("K" "Untrack file"               magit-file-untrack)
+   ("n" "Goto next section"          magit-section-forward)
+   ("p" "Goto previous section"      magit-section-backward)
+   ("R" "Rename file"                magit-file-rename)
+   ("x" "Reset quickly"              magit-reset-quickly)])
 
 ;;;###autoload
 (defun magit-info ()
```

The problem with that is that those who could benefit the most don't get to see it because it is opt-in, while some of those that likely need it the least get to see it because they have set `transient-default-level` to 7.