### PR TITLE
Fix hash/commit summary order in push branch header

### DIFF
--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -658,11 +658,11 @@ arguments are for internal use only."
       (insert (format "%-10s" "Push: "))
       (insert
        (if (magit-rev-verify target)
-           (concat target " "
-                   (and magit-status-show-hashes-in-headers
+           (concat (and magit-status-show-hashes-in-headers
                         (concat (propertize (magit-rev-format "%h" target)
                                             'font-lock-face 'magit-hash)
                                 " "))
+                   target " "
                    (funcall magit-log-format-message-function target
                             (funcall magit-log-format-message-function nil
                                      (or (magit-rev-format "%s" target)


### PR DESCRIPTION
I use `magit-status-show-hashes-in-headers`, and noticed that the order of hash and commit summary is not consistent in the header, the push header has the wrong order. This PR fixes this.