### PR TITLE
Use eq instead of = in magit-log-insert-child-count

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1863,7 +1863,7 @@ Show the last `magit-log-section-commit-count' commits."
   (when magit-section-show-child-count
     (let ((count (length (oref magit-insert-section--current children))))
       (when (> count 0)
-        (when (= count (magit-log-get-commit-limit))
+        (when (eq count (magit-log-get-commit-limit))
           (setq count (format "%s+" count)))
         (save-excursion
           (goto-char (- (oref magit-insert-section--current content) 2))


### PR DESCRIPTION
A call to magit-log-get-commit-limit can return nil, so make sure we don't try
to compare nil to a number. I ran into this when running `magit-status` in a repository because of a call to the `magit-log-insert-child-count` function where we compare the result of calling `magit-log-get-commit-limit` with `=`. It seems to be the case that if `magit-buffer-log-args` is `nil`, then the result of the whole call to `magit-log-get-commit-limit` will also be `nil` and so a call of the form `(= <num> nil)` will cause a failure.