### PR TITLE
Refactor Git version asserts

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2053,15 +2053,9 @@ Staging and applying changes is documented in info node
                (remove "--literal-pathspecs" magit-git-global-arguments)))
     ;; As of Git 2.19.0, we need to generate diffs with
     ;; --ita-visible-in-index so that `magit-stage' can work with
-    ;; intent-to-add files (see #4026).  Cache the result for each
-    ;; repo to avoid a `git version' call for every diff insertion.
+    ;; intent-to-add files (see #4026).
     (when (and (not (equal cmd "merge-tree"))
-               (pcase (magit-repository-local-get 'diff-ita-kludge-p 'unset)
-                 (`unset
-                  (let ((val (magit-git-version>= "2.19.0")))
-                    (magit-repository-local-set 'diff-ita-kludge-p val)
-                    val))
-                 (val val)))
+               (magit-git-version>= "2.19.0"))
       (push "--ita-visible-in-index" args))
     (setq args (magit-diff--maybe-add-stat-arguments args))
     (when (cl-member-if (lambda (arg) (string-prefix-p "--color-moved" arg)) args)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -593,6 +593,43 @@ call function WASHER with ARGS as its sole argument."
   "Return t if `magit-git-version's value is smaller than N."
   (version< (magit-git-version) n))
 
+(defun magit-debug-git-executable ()
+  "Display a buffer with information about `magit-git-executable'.
+Also include information about `magit-remote-git-executable'.
+See info node `(magit)Debugging Tools' for more information."
+  (interactive)
+  (with-current-buffer (get-buffer-create "*magit-git-debug*")
+    (pop-to-buffer (current-buffer))
+    (erase-buffer)
+    (insert (format "magit-remote-git-executable: %S\n"
+                    magit-remote-git-executable))
+    (insert (concat
+             (format "magit-git-executable: %S" magit-git-executable)
+             (and (not (file-name-absolute-p magit-git-executable))
+                  (format " [%S]" (executable-find magit-git-executable)))
+             (format " (%s)\n"
+                     (let* ((errmsg nil)
+                            (magit-git-debug (lambda (err) (setq errmsg err))))
+                       (or (magit-git-version t) errmsg)))))
+    (insert (format "exec-path: %S\n" exec-path))
+    (--when-let (cl-set-difference
+                 (-filter #'file-exists-p (remq nil (parse-colon-path
+                                                     (getenv "PATH"))))
+                 (-filter #'file-exists-p (remq nil exec-path))
+                 :test #'file-equal-p)
+      (insert (format "  entries in PATH, but not in exec-path: %S\n" it)))
+    (dolist (execdir exec-path)
+      (insert (format "  %s (%s)\n" execdir (car (file-attributes execdir))))
+      (when (file-directory-p execdir)
+        (dolist (exec (directory-files
+                       execdir t (concat
+                                  "\\`git" (regexp-opt exec-suffixes) "\\'")))
+          (insert (format "    %s (%s)\n" exec
+                          (let* ((magit-git-executable exec)
+                                 (errmsg nil)
+                                 (magit-git-debug (lambda (err) (setq errmsg err))))
+                            (or (magit-git-version t) errmsg)))))))))
+
 ;;; Variables
 
 (defun magit-config-get-from-cached-list (key)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -574,6 +574,10 @@ call function WASHER with ARGS as its sole argument."
         (magit-cancel-section))
       (magit-maybe-make-margin-overlay))))
 
+;;; Git Version
+
+(defvar magit--remotes-using-recent-git nil)
+
 (defun magit-git-version (&optional raw)
   "Return the installed Git version."
   (--when-let (let (magit-git-global-arguments)

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1425,7 +1425,7 @@ Unless specified, REPOSITORY is the current buffer's repository."
   "Zap caches for the current repository.
 
 Remove the repository's entry from `magit-repository-local-cache',
-remove the host's entry from `magit--remotes-using-recent-git', set
+remove the host's entry from `magit--host-git-version-cache', set
 `magit-section-visibility-cache' to nil for all Magit buffers of
 the repository and set `magit--libgit-available-p' to `unknown'.
 
@@ -1434,7 +1434,7 @@ mentioned caches completely."
   (interactive)
   (cond (all
          (setq magit-repository-local-cache nil)
-         (setq magit--remotes-using-recent-git nil)
+         (setq magit--host-git-version-cache nil)
          (dolist (buffer (buffer-list))
            (with-current-buffer buffer
              (when (derived-mode-p 'magit-mode)
@@ -1445,9 +1445,10 @@ mentioned caches completely."
                  (cl-delete default-directory
                             magit-repository-local-cache
                             :key #'car :test #'equal))
-           (setq magit--remotes-using-recent-git
-                 (delete (file-remote-p default-directory)
-                         magit--remotes-using-recent-git)))
+           (setq magit--host-git-version-cache
+                 (cl-delete (file-remote-p default-directory)
+                            magit--host-git-version-cache
+                            :key #'car :test #'equal)))
          (dolist (buffer (magit-mode-get-buffers))
            (with-current-buffer buffer
              (setq magit-section-visibility-cache nil)))))

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1424,15 +1424,17 @@ Unless specified, REPOSITORY is the current buffer's repository."
 (defun magit-zap-caches (&optional all)
   "Zap caches for the current repository.
 
-Remove the repository's entry from `magit-repository-local-cache'
-and set `magit-section-visibility-cache' to nil in all of the
-repository's Magit buffers.
+Remove the repository's entry from `magit-repository-local-cache',
+remove the host's entry from `magit--remotes-using-recent-git', set
+`magit-section-visibility-cache' to nil for all Magit buffers of
+the repository and set `magit--libgit-available-p' to `unknown'.
 
 With a prefix argument or if optional ALL is non-nil, discard the
 mentioned caches completely."
   (interactive)
   (cond (all
          (setq magit-repository-local-cache nil)
+         (setq magit--remotes-using-recent-git nil)
          (dolist (buffer (buffer-list))
            (with-current-buffer buffer
              (when (derived-mode-p 'magit-mode)
@@ -1442,7 +1444,10 @@ mentioned caches completely."
            (setq magit-repository-local-cache
                  (cl-delete default-directory
                             magit-repository-local-cache
-                            :key #'car :test #'equal)))
+                            :key #'car :test #'equal))
+           (setq magit--remotes-using-recent-git
+                 (delete (file-remote-p default-directory)
+                         magit--remotes-using-recent-git)))
          (dolist (buffer (magit-mode-get-buffers))
            (with-current-buffer buffer
              (setq magit-section-visibility-cache nil)))))

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1421,20 +1421,31 @@ Unless specified, REPOSITORY is the current buffer's repository."
         (magit-repository-local-get
          (cons mode 'magit-section-visibility-cache))))
 
-(defun magit-zap-caches ()
+(defun magit-zap-caches (&optional all)
   "Zap caches for the current repository.
+
 Remove the repository's entry from `magit-repository-local-cache'
 and set `magit-section-visibility-cache' to nil in all of the
-repository's Magit buffers."
+repository's Magit buffers.
+
+With a prefix argument or if optional ALL is non-nil, discard the
+mentioned caches completely."
   (interactive)
-  (magit-with-toplevel
-    (setq magit-repository-local-cache
-          (cl-delete default-directory
-                     magit-repository-local-cache
-                     :key #'car :test #'equal)))
-  (dolist (buffer (magit-mode-get-buffers))
-    (with-current-buffer buffer
-      (setq magit-section-visibility-cache nil)))
+  (cond (all
+         (setq magit-repository-local-cache nil)
+         (dolist (buffer (buffer-list))
+           (with-current-buffer buffer
+             (when (derived-mode-p 'magit-mode)
+               (setq magit-section-visibility-cache nil)))))
+        (t
+         (magit-with-toplevel
+           (setq magit-repository-local-cache
+                 (cl-delete default-directory
+                            magit-repository-local-cache
+                            :key #'car :test #'equal)))
+         (dolist (buffer (magit-mode-get-buffers))
+           (with-current-buffer buffer
+             (setq magit-section-visibility-cache nil)))))
   (setq magit--libgit-available-p 'unknown))
 
 ;;; Utilities

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -333,8 +333,6 @@ init file: (global-set-key (kbd \"C-x g\") 'magit-status-quick)."
       (magit-display-buffer buffer)
     (call-interactively #'magit-status)))
 
-(defvar magit--remotes-using-recent-git nil)
-
 (defun magit--tramp-asserts (directory)
   (when-let ((remote (file-remote-p directory)))
     (unless (member remote magit--remotes-using-recent-git)

--- a/lisp/magit-utils.el
+++ b/lisp/magit-utils.el
@@ -40,6 +40,9 @@
 
 ;;; Code:
 
+(defconst magit--minimal-git "2.2.0")
+(defconst magit--minimal-emacs "25.1")
+
 (require 'cl-lib)
 (require 'dash)
 (require 'eieio)

--- a/lisp/magit-wip.el
+++ b/lisp/magit-wip.el
@@ -301,14 +301,7 @@ commit message."
                        ;; deleted in the temporary index.
                        (magit-call-git
                         "update-index" "--add" "--remove"
-                        (and (pcase (magit-repository-local-get
-                                     'update-index-has-ignore-sw-p 'unset)
-                               (`unset
-                                (let ((val (magit-git-version>= "2.25.0")))
-                                  (magit-repository-local-set
-                                   'update-index-has-ignore-sw-p val)
-                                  val))
-                               (val val))
+                        (and (magit-git-version>= "2.25.0")
                              "--ignore-skip-worktree-entries")
                         "--" files)
                      (magit-with-toplevel

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -657,8 +657,7 @@ https://github.com/magit/magit/wiki/Don't-set-$GIT_DIR-and-alike" val))
 https://github.com/magit/magit/wiki/Don't-set-$GIT_DIR-and-alike" val))
   (let ((version (magit-git-version)))
     (when (and version
-               (version< version magit--minimal-git)
-               (not (equal (getenv "CI") "true")))
+               (version< version magit--minimal-git))
       (display-warning 'magit (format "\
 Magit requires Git >= %s, you are using %s.
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -605,45 +605,6 @@ and Emacs to it."
         (message "Cannot determine Magit's version %S" debug)))
     magit-version))
 
-;;; Debugging Tools
-
-(defun magit-debug-git-executable ()
-  "Display a buffer with information about `magit-git-executable'.
-Also include information about `magit-remote-git-executable'.
-See info node `(magit)Debugging Tools' for more information."
-  (interactive)
-  (with-current-buffer (get-buffer-create "*magit-git-debug*")
-    (pop-to-buffer (current-buffer))
-    (erase-buffer)
-    (insert (format "magit-remote-git-executable: %S\n"
-                    magit-remote-git-executable))
-    (insert (concat
-             (format "magit-git-executable: %S" magit-git-executable)
-             (and (not (file-name-absolute-p magit-git-executable))
-                  (format " [%S]" (executable-find magit-git-executable)))
-             (format " (%s)\n"
-                     (let* ((errmsg nil)
-                            (magit-git-debug (lambda (err) (setq errmsg err))))
-                       (or (magit-git-version t) errmsg)))))
-    (insert (format "exec-path: %S\n" exec-path))
-    (--when-let (cl-set-difference
-                 (-filter #'file-exists-p (remq nil (parse-colon-path
-                                                     (getenv "PATH"))))
-                 (-filter #'file-exists-p (remq nil exec-path))
-                 :test #'file-equal-p)
-      (insert (format "  entries in PATH, but not in exec-path: %S\n" it)))
-    (dolist (execdir exec-path)
-      (insert (format "  %s (%s)\n" execdir (car (file-attributes execdir))))
-      (when (file-directory-p execdir)
-        (dolist (exec (directory-files
-                       execdir t (concat
-                                  "\\`git" (regexp-opt exec-suffixes) "\\'")))
-          (insert (format "    %s (%s)\n" exec
-                          (let* ((magit-git-executable exec)
-                                 (errmsg nil)
-                                 (magit-git-debug (lambda (err) (setq errmsg err))))
-                            (or (magit-git-version t) errmsg)))))))))
-
 ;;; Startup Asserts
 
 (defun magit-startup-asserts ()

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -610,22 +610,7 @@ https://github.com/magit/magit/wiki/Don't-set-$GIT_DIR-and-alike" val))
 https://github.com/magit/magit/wiki/Don't-set-$GIT_DIR-and-alike" val))
   ;; Git isn't required while building Magit.
   (cl-eval-when (load eval)
-    (when (magit-git-version< magit--minimal-git)
-      (display-warning 'magit (format "\
-Magit requires Git >= %s, you are using %s.
-
-If this comes as a surprise to you, because you do actually have
-a newer version installed, then that probably means that the
-older version happens to appear earlier on the `$PATH'.  If you
-always start Emacs from a shell, then that can be fixed in the
-shell's init file.  If you start Emacs by clicking on an icon,
-or using some sort of application launcher, then you probably
-have to adjust the environment as seen by graphical interface.
-For X11 something like ~/.xinitrc should work.
-
-If you use Tramp to work inside remote Git repositories, then you
-have to make sure a suitable Git is used on the remote machines
-too.\n" magit--minimal-git (magit-git-version)) :error)))
+    (magit-git-version-assert))
   (when (version< emacs-version magit--minimal-emacs)
     (display-warning 'magit (format "\
 Magit requires Emacs >= %s, you are using %s.

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -65,9 +65,6 @@
 (require 'package nil t) ; used in `magit-version'
 (require 'with-editor)
 
-(defconst magit--minimal-git "2.2.0")
-(defconst magit--minimal-emacs "25.1")
-
 ;;; Faces
 
 (defface magit-header-line
@@ -587,12 +584,7 @@ and Emacs to it."
                                              (locate-library "magit.el" t))
                                             (lm-header "Package-Version"))))))
                              "")
-                         (or (let ((magit-git-debug
-                                    (lambda (err)
-                                      (display-warning '(magit git)
-                                                       err :error))))
-                               (magit-git-version t))
-                             "(unknown)")
+                         (magit--safe-git-version)
                          emacs-version
                          system-type)
                  print-dest))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -655,9 +655,9 @@ https://github.com/magit/magit/wiki/Don't-set-$GIT_DIR-and-alike" val))
     (setenv "GIT_WORK_TREE")
     (message "Magit unset $GIT_WORK_TREE (was %S).  See \
 https://github.com/magit/magit/wiki/Don't-set-$GIT_DIR-and-alike" val))
-  (let ((version (magit-git-version)))
-    (when (and version
-               (version< version magit--minimal-git))
+  ;; Git isn't required while building Magit.
+  (cl-eval-when (load eval)
+    (when (magit-git-version< magit--minimal-git)
       (display-warning 'magit (format "\
 Magit requires Git >= %s, you are using %s.
 
@@ -672,7 +672,7 @@ For X11 something like ~/.xinitrc should work.
 
 If you use Tramp to work inside remote Git repositories, then you
 have to make sure a suitable Git is used on the remote machines
-too.\n" magit--minimal-git version) :error)))
+too.\n" magit--minimal-git (magit-git-version)) :error)))
   (when (version< emacs-version magit--minimal-emacs)
     (display-warning 'magit (format "\
 Magit requires Emacs >= %s, you are using %s.


### PR DESCRIPTION
This is response to #4065 but doesn't go as far as the changes @phil-s linked to in that issue.

I have come to the conclusion that it is not necessary to try to catch the very first call to `git` that a user invokes on a new host using Magit (even if `magit-status` wasn't responsible for that), because I cannot remember the last time that would have been useful and because I did not like the introduction of `magit-process-file-git`.  However if we later decide otherwise, we could simply add that function and add a call to `magit-git-version-assert` there.

The central idea is that callers `magit-git-version<` and `magit-git-version>` do not have to worry about caching and error reporting because these functions use `magit-git-version`, which takes care of all that.  They obviously should still select another code-path or report an error based on the result of the comparison.  `magit-git-version-assert`, which checks for the global minimum, also uses that function.

Unlike @phil-s' implementation, this does not add a central place that records all the functionality that need a more recent Git version than the global default.  I feel that it is more useful to see the needed version along-side the affected code and if one needs a list of such functionality, then one can just grep for `magit-git-version[<>]`.

Still needs some testing but I plan to merge in a few days once I have done that. Please let me know if you see any issues with this approach.