### PR TITLE
Add custom date format variable for magit-margin

### DIFF
--- a/lisp/magit-margin.el
+++ b/lisp/magit-margin.el
@@ -88,7 +88,7 @@ does not carry to other options."
           (`age 'age-abbreviated)
           (`age-abbreviated
            (let ((default (cadr (symbol-value (magit-margin-option)))))
-             (if (stringp default) default "%Y-%m-%d %H:%M ")))
+             (if (stringp default) default magit-log-margin-date-time-format)))
           (_ 'age)))
   (magit-set-buffer-margin nil t))
 
@@ -174,6 +174,12 @@ does not carry to other options."
 
 ;;; Custom Support
 
+(defcustom magit-log-margin-date-time-format "%Y-%m-%d %H:%M "
+  "Format of the author or committer date in `magit-log-mode' buffers"
+  :group 'magit-log
+  :group 'magit-margin
+  :type 'string)
+
 (defun magit-margin-set-variable (mode symbol value)
   (set-default symbol value)
   (message "Updating margins in %s buffers..." mode)
@@ -187,7 +193,7 @@ does not carry to other options."
 (defconst magit-log-margin--custom-type
   '(list (boolean :tag "Show margin initially")
          (choice  :tag "Show committer"
-                  (string :tag "date using time-format" "%Y-%m-%d %H:%M ")
+                  (string :tag "date using time-format" magit-log-margin-date-time-format)
                   (const  :tag "date's age" age)
                   (const  :tag "date's age (abbreviated)" age-abbreviated))
          (const   :tag "Calculate width using magit-log-margin-width"


### PR DESCRIPTION
# Background
Although you can customize date format with current version of magit like this,
```lisp
(setq magit-status-margin '(t "%Y-%m-%d %H:%M:%S " magit-log-margin-width t 18))
```
~this format will be lost if you cycle styles by pressing `L-l` (`magit-cycle-margin-style`) and also~ you can't set initial style as `age-abbreviated` or `age` along with customized date format.

# Summary
This PR adds ability to set custom date format for `magit-log-margin`.

Let users allow to define custom date format from `customize-group` or like the following.
```lisp
(setq magit-log-margin-date-time-format "%Y-%m-%d %H:%M:%S ") ;; Show seconds
(setq magit-log-margin '(t age-abbreviated magit-log-margin-width t 18)) ;; Initial style for magit-log buffer (`l-l`)
(setq magit-status-margin '(t age-abbreviated magit-log-margin-width t 18)) ;; Initial style for Recent commits
````