### PR TITLE
apply blame highlight-overlay to just one line

### DIFF
--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -594,7 +594,9 @@ modes is toggled, then this mode also gets toggled automatically.
     (magit-blame--update-heading-overlay ov)))
 
 (defun magit-blame--make-highlight-overlay (chunk beg)
-  (let ((ov (make-overlay beg (1+ (line-end-position)))))
+  (let ((ov (make-overlay beg (save-excursion
+                                (goto-char beg)
+                                (1+ (line-end-position))))))
     (overlay-put ov 'magit-blame-chunk chunk)
     (overlay-put ov 'magit-blame-highlight t)
     (magit-blame--update-highlight-overlay ov)))


### PR DESCRIPTION
fix #4619, see there for more detailed discussion

In brief, `magit-blame--make-highlight-overlay` should add an overlay from `beg`
to end-of-line that contains `beg`. Previously, however, it was from `beg` to
end-of-line that contained point, but this should fix that.

Wrapping things in `save-excursion` and `save-restriction` is probably overkill
since `magit-blame--make-highlight-overlay` is currently only called from
`magit-blame--make-overlays` where it is already warpped in `save-excursion` and
`save-restriction`, but it's included to be extra cautious.