### PR TITLE
Support mousing

### DIFF
--- a/docs/magit-section.org
+++ b/docs/magit-section.org
@@ -151,6 +151,10 @@ source for suitable examples before asking me for help.  Thanks!
 
   Return the section at point.
 
+- Function magit-section-at &optional position ::
+
+  Return the section at POSITION, defaulting to point.
+
 - Function: magit-section-ident section ::
 
   Return an unique identifier for SECTION. The return value has the

--- a/docs/magit-section.org
+++ b/docs/magit-section.org
@@ -184,6 +184,10 @@ source for suitable examples before asking me for help.  Thanks!
   Return the lineage of SECTION.
   The return value has the form ~(TYPE...)~.
 
+- Function: magit-section-content-p section ::
+
+  Return non-nil if SECTION has content or an unused washer function.
+
 * Matching Functions
 
 - Function: magit-section-match condition &optional (section (magit-current-section)) ::

--- a/docs/magit-section.org
+++ b/docs/magit-section.org
@@ -149,11 +149,15 @@ source for suitable examples before asking me for help.  Thanks!
 
 - Function: magit-current-section ::
 
-  Return the section at point.
+  Return the section at point or where the context menu was invoked.
+  When using the context menu, return the section that the user
+  clicked on, provided the current buffer is the buffer in which
+  the click occured.  Otherwise return the section at point.
 
 - Function magit-section-at &optional position ::
 
-  Return the section at POSITION, defaulting to point.
+  Return the section at POSITION, defaulting to point.  Default to
+  point even when the context menu is used.
 
 - Function: magit-section-ident section ::
 
@@ -187,6 +191,31 @@ source for suitable examples before asking me for help.  Thanks!
 - Function: magit-section-content-p section ::
 
   Return non-nil if SECTION has content or an unused washer function.
+
+The next two functions are replacements for the Emacs functions that
+have the same name except for the ~magit-~ prefix.  Like
+~magit-current-section~ they do not act on point, the cursors position,
+but on the position where the user clicked to invoke the context menu.
+
+If your package provides a context menu and some of its commands act
+on the "thing at point", even if just as a default, then use the
+prefixed functions to teach them to instead use the click location
+when appropriate.
+
+- Function magit-point ::
+
+  Return point or the position where the context menu was invoked.
+  When using the context menu, return the position the user clicked
+  on, provided the current buffer is the buffer in which the click
+  occured.  Otherwise return the same value as ~point~.
+
+- Function magit-thing-at-point thing &optional no-properties ::
+
+  Return the THING at point or where the context menu was invoked.
+  When using the context menu, return the thing the user clicked
+  on, provided the current buffer is the buffer in which the click
+  occured.  Otherwise return the same value as ~thing-at-point~.
+  For the meaning of THING and NO-PROPERTIES see that function.
 
 * Matching Functions
 

--- a/docs/magit-section.texi
+++ b/docs/magit-section.texi
@@ -193,12 +193,16 @@ buffer is reached.  FUNCTION has to move point forward or return
 @chapter Core Functions
 
 @defun magit-current-section
-Return the section at point.
+Return the section at point or where the context menu was invoked.
+When using the context menu, return the section that the user
+clicked on, provided the current buffer is the buffer in which
+the click occured.  Otherwise return the section at point.
 @end defun
 
 @table @asis
 @item Function magit-section-at &optional position
-Return the section at POSITION, defaulting to point.
+Return the section at POSITION, defaulting to point.  Default to
+point even when the context menu is used.
 @end table
 
 @defun magit-section-ident section
@@ -233,6 +237,31 @@ The return value has the form @code{(TYPE...)}.
 @defun magit-section-content-p section
 Return non-nil if SECTION has content or an unused washer function.
 @end defun
+
+The next two functions are replacements for the Emacs functions that
+have the same name except for the @code{magit-} prefix.  Like
+@code{magit-current-section} they do not act on point, the cursors position,
+but on the position where the user clicked to invoke the context menu.
+
+If your package provides a context menu and some of its commands act
+on the "thing at point", even if just as a default, then use the
+prefixed functions to teach them to instead use the click location
+when appropriate.
+
+@table @asis
+@item Function magit-point
+Return point or the position where the context menu was invoked.
+When using the context menu, return the position the user clicked
+on, provided the current buffer is the buffer in which the click
+occured.  Otherwise return the same value as @code{point}.
+
+@item Function magit-thing-at-point thing &optional no-properties
+Return the THING at point or where the context menu was invoked.
+When using the context menu, return the thing the user clicked
+on, provided the current buffer is the buffer in which the click
+occured.  Otherwise return the same value as @code{thing-at-point}.
+For the meaning of THING and NO-PROPERTIES see that function.
+@end table
 
 @node Matching Functions
 @chapter Matching Functions

--- a/docs/magit-section.texi
+++ b/docs/magit-section.texi
@@ -230,6 +230,10 @@ Return the lineage of SECTION@.
 The return value has the form @code{(TYPE...)}.
 @end defun
 
+@defun magit-section-content-p section
+Return non-nil if SECTION has content or an unused washer function.
+@end defun
+
 @node Matching Functions
 @chapter Matching Functions
 

--- a/docs/magit-section.texi
+++ b/docs/magit-section.texi
@@ -196,6 +196,11 @@ buffer is reached.  FUNCTION has to move point forward or return
 Return the section at point.
 @end defun
 
+@table @asis
+@item Function magit-section-at &optional position
+Return the section at POSITION, defaulting to point.
+@end table
+
 @defun magit-section-ident section
 Return an unique identifier for SECTION@. The return value has the
 form @code{((TYPE . VALUE)...)}.

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -368,6 +368,9 @@ In file visiting buffers ~C-c M-g~ brings up a similar menu featuring
 commands that act on just the visited file, see [[*Commands for Buffers
 Visiting Files]].
 
+Magit also provides a context menu and other mouse commands, see
+[[*Mouse Support]].
+
 It is not necessary that you do so now, but if you stick with Magit,
 then it is highly recommended that you read the next section too.
 
@@ -1782,6 +1785,16 @@ will also have to install the ~ido-completing-read+~ package and use
   values include any key accepted by the ~--sort~ flag of ~git
   for-each-ref~.  By default, refs are sorted alphabetically by their
   full name (e.g., "refs/heads/master").
+
+** Mouse Support
+
+Double clicking on a section heading toggles the visibility of its
+body, if any.  Likewise clicking in the left fringe toggles the
+visibility of the appropriate section.
+
+A context menu is provided but has to be enabled explicitly.  In Emacs
+28 and greater, enable the global mode ~context-menu-mode~.  If you use an
+older Emacs release, set ~magit-section-show-context-menu-for-emacs<28~.
 
 ** Running Git
 *** Viewing Git Output

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -104,6 +104,7 @@ Interface Concepts
 * Transient Commands::
 * Transient Arguments and Buffer Variables::
 * Completion, Confirmation and the Selection: Completion Confirmation and the Selection. 
+* Mouse Support::
 * Running Git::
 
 Modes and Buffers
@@ -702,6 +703,9 @@ non-Magit buffers.  The global binding is @code{C-x M-g}.
 In file visiting buffers @code{C-c M-g} brings up a similar menu featuring
 commands that act on just the visited file, see @ref{Commands for Buffers Visiting Files}.
 
+Magit also provides a context menu and other mouse commands, see
+@ref{Mouse Support}.
+
 It is not necessary that you do so now, but if you stick with Magit,
 then it is highly recommended that you read the next section too.
 
@@ -714,6 +718,7 @@ then it is highly recommended that you read the next section too.
 * Transient Commands::
 * Transient Arguments and Buffer Variables::
 * Completion, Confirmation and the Selection: Completion Confirmation and the Selection. 
+* Mouse Support::
 * Running Git::
 @end menu
 
@@ -2303,6 +2308,17 @@ values include any key accepted by the @code{--sort} flag of @code{git
   for-each-ref}.  By default, refs are sorted alphabetically by their
 full name (e.g., "refs/heads/master").
 @end defopt
+
+@node Mouse Support
+@section Mouse Support
+
+Double clicking on a section heading toggles the visibility of its
+body, if any.  Likewise clicking in the left fringe toggles the
+visibility of the appropriate section.
+
+A context menu is provided but has to be enabled explicitly.  In Emacs
+28 and greater, enable the global mode @code{context-menu-mode}.  If you use an
+older Emacs release, set @code{magit-section-show-context-menu-for-emacs<28}.
 
 @node Running Git
 @section Running Git

--- a/lisp/magit-base.el
+++ b/lisp/magit-base.el
@@ -439,10 +439,13 @@ and delay of your graphical environment or operating system."
 
 ;;; Section Classes
 
-(defclass magit-commit-section (magit-section)
-  ())
+(defclass magit-commit-section (magit-section) ())
 
-(defclass magit-file-section (magit-section)
+(setf (alist-get 'commit magit--section-type-alist) 'magit-commit-section)
+
+(defclass magit-diff-section (magit-section) () :abstract t)
+
+(defclass magit-file-section (magit-diff-section)
   ((keymap :initform 'magit-file-section-map)
    (source :initform nil)
    (header :initform nil)))
@@ -451,7 +454,7 @@ and delay of your graphical environment or operating system."
   ((keymap :initform 'magit-module-section-map)
    (range  :initform nil)))
 
-(defclass magit-hunk-section (magit-section)
+(defclass magit-hunk-section (magit-diff-section)
   ((keymap      :initform 'magit-hunk-section-map)
    (refined     :initform nil)
    (combined    :initform nil)
@@ -460,10 +463,18 @@ and delay of your graphical environment or operating system."
    (to-range    :initform nil)
    (about       :initform nil)))
 
-(setf (alist-get 'commit magit--section-type-alist) 'magit-commit-section)
 (setf (alist-get 'file   magit--section-type-alist) 'magit-file-section)
 (setf (alist-get 'module magit--section-type-alist) 'magit-module-section)
 (setf (alist-get 'hunk   magit--section-type-alist) 'magit-hunk-section)
+
+(defclass magit-log-section (magit-section) () :abstract t)
+(defclass magit-unpulled-section (magit-log-section) ())
+(defclass magit-unpushed-section (magit-log-section) ())
+(defclass magit-unmerged-section (magit-log-section) ())
+
+(setf (alist-get 'unpulled magit--section-type-alist) 'magit-unpulled-section)
+(setf (alist-get 'unpushed magit--section-type-alist) 'magit-unpushed-section)
+(setf (alist-get 'unmerged magit--section-type-alist) 'magit-unmerged-section)
 
 ;;; User Input
 

--- a/lisp/magit-base.el
+++ b/lisp/magit-base.el
@@ -448,7 +448,7 @@ and delay of your graphical environment or operating system."
    (header :initform nil)))
 
 (defclass magit-module-section (magit-file-section)
-  ((keymap :initform 'magit-hunk-section-map)
+  ((keymap :initform 'magit-module-section-map)
    (range  :initform nil)))
 
 (defclass magit-hunk-section (magit-section)

--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -224,7 +224,7 @@ bisect run'."
          (magit-process-sentinel process event)
          (when (buffer-live-p (process-buffer process))
            (with-current-buffer (process-buffer process)
-             (when-let ((section (get-text-property (point) 'magit-section))
+             (when-let ((section (magit-section-at))
                         (output (buffer-substring-no-properties
                                  (oref section content)
                                  (oref section end))))

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1942,7 +1942,9 @@ Staging and applying changes is documented in info node
                 (list 'unstaged magit-buffer-typearg)))
          (and magit-buffer-diff-files (cons "--" magit-buffer-diff-files))))
 
-(defvar magit-diff-section-base-map
+(define-obsolete-variable-alias 'magit-diff-section-base-map
+  'magit-diff-section-map "Magit-Section 3.4.0")
+(defvar magit-diff-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-j")            'magit-diff-visit-worktree-file)
     (define-key map (kbd "C-<return>")     'magit-diff-visit-worktree-file)
@@ -1961,7 +1963,10 @@ Staging and applying changes is documented in info node
     (define-key map (kbd "C-c C-t") 'magit-diff-trace-definition)
     (define-key map (kbd "C-c C-e") 'magit-diff-edit-hunk-commit)
     map)
-  "Parent of `magit-{hunk,file}-section-map'.")
+  "Keymap for diff sections.
+The classes `magit-file-section' and `magit-hunk-section' derive
+from the abstract `magit-diff-section' class.  Accordingly this
+keymap is the parent of their keymaps.")
 
 (defvar magit-file-section-map
   (let ((map (make-sparse-keymap)))
@@ -2814,9 +2819,8 @@ It the SECTION has a different type, then do nothing."
 (defvar magit-unstaged-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap magit-visit-thing]  'magit-diff-unstaged)
+    (define-key map [remap magit-stage-file]   'magit-stage)
     (define-key map [remap magit-delete-thing] 'magit-discard)
-    (define-key map "s" 'magit-stage)
-    (define-key map "u" 'magit-unstage)
     map)
   "Keymap for the `unstaged' section.")
 
@@ -2833,10 +2837,9 @@ It the SECTION has a different type, then do nothing."
 (defvar magit-staged-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap magit-visit-thing]      'magit-diff-staged)
+    (define-key map [remap magit-unstage-file]     'magit-unstage)
     (define-key map [remap magit-delete-thing]     'magit-discard)
     (define-key map [remap magit-revert-no-commit] 'magit-reverse)
-    (define-key map "s" 'magit-stage)
-    (define-key map "u" 'magit-unstage)
     map)
   "Keymap for the `staged' section.")
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1296,7 +1296,7 @@ for a revision."
   (interactive
    (pcase-let* ((mcommit (magit-section-value-if 'module-commit))
                 (atpoint (or mcommit
-                             (thing-at-point 'git-revision t)
+                             (magit-thing-at-point 'git-revision t)
                              (magit-branch-or-commit-at-point)))
                 (`(,args ,files) (magit-show-commit--arguments)))
      (list (or (and (not current-prefix-arg) atpoint)
@@ -1677,7 +1677,7 @@ the Magit-Status buffer for DIRECTORY."
   (and magit-diff-visit-previous-blob
        (not in-worktree)
        (not (oref section combined))
-       (not (< (point) (oref section content)))
+       (not (< (magit-point) (oref section content)))
        (= (char-after (line-beginning-position)) ?-)))
 
 (defvar magit-diff-visit-jump-to-change t)
@@ -1703,7 +1703,7 @@ the Magit-Status buffer for DIRECTORY."
            offset)))))
 
 (defun magit-diff-hunk-column (section goto-from)
-  (if (or (< (point)
+  (if (or (< (magit-point)
              (oref section content))
           (and (not goto-from)
                (= (char-after (line-beginning-position)) ?-)))
@@ -3346,7 +3346,7 @@ last (visual) lines of the region."
   "Return non-nil if point is inside the body of a hunk."
   (and (magit-section-match 'hunk)
        (when-let ((content (oref (magit-current-section) content)))
-         (> (point) content))))
+         (> (magit-point) content))))
 
 ;;; Diff Extract
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1457,13 +1457,13 @@ to, or to some other symbolic-ref that points to the same ref."
 
 (defun magit--painted-branch-at-point (&optional type)
   (or (and (not (eq type 'remote))
-           (memq (get-text-property (point) 'font-lock-face)
+           (memq (get-text-property (magit-point) 'font-lock-face)
                  (list 'magit-branch-local
                        'magit-branch-current))
-           (when-let ((branch (thing-at-point 'git-revision t)))
+           (when-let ((branch (magit-thing-at-point 'git-revision t)))
              (cdr (magit-split-branch-name branch))))
       (and (not (eq type 'local))
-           (memq (get-text-property (point) 'font-lock-face)
+           (memq (get-text-property (magit-point) 'font-lock-face)
                  (list 'magit-branch-remote
                        'magit-branch-remote-head))
            (thing-at-point 'git-revision t))))
@@ -1486,7 +1486,7 @@ to, or to some other symbolic-ref that points to the same ref."
 
 (defun magit-commit-at-point ()
   (or (magit-section-value-if 'commit)
-      (thing-at-point 'git-revision t)
+      (magit-thing-at-point 'git-revision t)
       (when-let ((chunk (magit-current-blame-chunk 'addition t)))
         (oref chunk orig-rev))
       (and (derived-mode-p 'magit-stash-mode
@@ -1506,7 +1506,7 @@ to, or to some other symbolic-ref that points to the same ref."
                            (forge--pullreq-branch (oref it value))))
                      (magit-ref-p (format "refs/pullreqs/%s"
                                           (oref (oref it value) number))))))
-      (thing-at-point 'git-revision t)
+      (magit-thing-at-point 'git-revision t)
       (when-let ((chunk (magit-current-blame-chunk 'addition t)))
         (oref chunk orig-rev))
       (and magit-buffer-file-name

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1760,6 +1760,15 @@ keymap is the parent of their keymaps.")
     map)
   "Keymap for `unpulled' sections.")
 
+(cl-defmethod magit-section-ident-value ((section magit-unpulled-section))
+  "\"..@{push}\" cannot be used as the value because that is
+ambigious if `push.default' does not allow a 1:1 mapping, and
+many commands would fail because of that.  But here that does
+not matter and we need an unique value so we use that string
+in the pushremote case."
+  (let ((value (oref section value)))
+    (if (equal value "..@{upstream}") value "..@{push}")))
+
 (magit-define-section-jumper magit-jump-to-unpulled-from-upstream
   "Unpulled from @{upstream}" unpulled "..@{upstream}")
 
@@ -1795,6 +1804,15 @@ keymap is the parent of their keymaps.")
     (set-keymap-parent map magit-log-section-map)
     map)
   "Keymap for `unpushed' sections.")
+
+(cl-defmethod magit-section-ident-value ((section magit-unpushed-section))
+  "\"..@{push}\" cannot be used as the value because that is
+ambigious if `push.default' does not allow a 1:1 mapping, and
+many commands would fail because of that.  But here that does
+not matter and we need an unique value so we use that string
+in the pushremote case."
+  (let ((value (oref section value)))
+    (if (equal value "@{upstream}..") value "@{push}..")))
 
 (magit-define-section-jumper magit-jump-to-unpushed-to-upstream
   "Unpushed to @{upstream}" unpushed "@{upstream}..")

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1142,13 +1142,12 @@ Do not add this to a hook variable."
 (defvar magit-commit-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap magit-visit-thing] 'magit-show-commit)
-    (define-key map "a" 'magit-cherry-apply)
     map)
   "Keymap for `commit' sections.")
 
 (defvar magit-module-commit-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing] 'magit-show-commit)
+    (set-keymap-parent map magit-commit-section-map)
     map)
   "Keymap for `module-commit' sections.")
 
@@ -1746,9 +1745,18 @@ Type \\[magit-cherry-pick] to apply the commit at point.
 ;;; Log Sections
 ;;;; Standard Log Sections
 
-(defvar magit-unpulled-section-map
+(defvar magit-log-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap magit-visit-thing] 'magit-diff-dwim)
+    map)
+  "Keymap for log sections.
+The classes `magit-{unpulled,unpushed,unmerged}-section' derive
+from the abstract `magit-log-section' class.  Accordingly this
+keymap is the parent of their keymaps.")
+
+(defvar magit-unpulled-section-map
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map magit-log-section-map)
     map)
   "Keymap for `unpulled' sections.")
 
@@ -1784,7 +1792,7 @@ Type \\[magit-cherry-pick] to apply the commit at point.
 
 (defvar magit-unpushed-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing] 'magit-diff-dwim)
+    (set-keymap-parent map magit-log-section-map)
     map)
   "Keymap for `unpushed' sections.")
 

--- a/lisp/magit-merge.el
+++ b/lisp/magit-merge.el
@@ -294,7 +294,7 @@ then also remove the respective remote branch."
 
 (defvar magit-unmerged-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing] 'magit-diff-dwim)
+    (set-keymap-parent map magit-log-section-map)
     map)
   "Keymap for `unmerged' sections.")
 

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -462,53 +462,62 @@ which visits the thing at point using `browse-url'."
 
 (easy-menu-define magit-mode-menu magit-mode-map
   "Magit menu"
+  ;; Similar to `magit-dispatch' but exclude:
+  ;; - commands that are available from context menus:
+  ;;   apply, reverse, discard, stage, unstage,
+  ;;   cherry-pick, revert, reset,
+  ;;   describe-section
+  ;; - commands that are available from submenus:
+  ;;   git-command, ediff-dwim
+  ;; - and: refresh-all, status-jump, status-quick.
   '("Magit"
-    ["Refresh" magit-refresh t]
-    ["Refresh all" magit-refresh-all t]
+    "---" "Inspect"
+    ["     Bisect..."             magit-bisect t]
+    ["     Cherries..."           magit-cherry t]
+    ["     Diff..."               magit-diff t]
+    ["     Ediff..."              magit-ediff t]
+    ["     Log..."                magit-log t]
+    ["     References..."         magit-show-refs t]
+    "---" "Manipulate"
+    ["     Commit..."             magit-commit t]
+    ["     Stash..."              magit-stash t]
+    ["     Tag..."                magit-tag t]
     "---"
-    ["Stage" magit-stage t]
-    ["Stage modified" magit-stage-modified t]
-    ["Unstage" magit-unstage t]
-    ["Reset index" magit-reset-index t]
-    ["Commit" magit-commit t]
-    ["Add log entry" magit-commit-add-log t]
-    ["Tag" magit-tag-create t]
+    ["     Branch..."             magit-branch t]
+    ["     Remote..."             magit-remote t]
     "---"
-    ["Diff working tree" magit-diff-working-tree t]
-    ["Diff" magit-diff t]
-    ("Log"
-     ["Log" magit-log-other t]
-     ["Reflog" magit-reflog-other t]
-     ["Extended..." magit-log t])
+    ["     Merge..."              magit-merge t]
+    ["     Rebase..."             magit-rebase t]
+    "---" "Transfer"
+    ["     Fetch..."              magit-fetch t]
+    ["     Pull..."               magit-pull t]
+    ["     Push..."               magit-push t]
+    "---" "Setup"
+    ["     Clone..."              magit-clone t]
+    ["     Ignore..."             magit-gitignore t]
+    ["     Init..."               magit-init t]
     "---"
-    ["Cherry pick" magit-cherry-pick t]
-    ["Revert commit" magit-revert t]
+    ("Advanced"
+     ["Run..."                    magit-run t]
+     "---"
+     ["Apply patches..."          magit-am t]
+     ["Format patches..."         magit-patch t]
+     "---"
+     ["Note..."                   magit-notes t]
+     "---"
+     ["Submodule..."              magit-submodule t]
+     ["Subtree..."                magit-subtree t]
+     ["Worktree..."               magit-worktree t])
     "---"
-    ["Ignore at toplevel" magit-gitignore-in-topdir t]
-    ["Ignore in subdirectory" magit-gitignore-in-subdir t]
-    ["Discard" magit-discard t]
-    ["Reset head and index" magit-reset-mixed t]
-    ["Stash" magit-stash-both t]
-    ["Snapshot" magit-snapshot-both t]
+    ["Show command dispatcher..." magit-dispatch t]
+    ["Show manual"                magit-help t]
+    ["Show another buffer"        magit-display-repository-buffer t]
     "---"
-    ["Branch..." magit-checkout t]
-    ["Merge" magit-merge t]
-    ["Ediff resolve" magit-ediff-resolve t]
-    ["Rebase..." magit-rebase t]
-    "---"
-    ["Push" magit-push t]
-    ["Pull" magit-pull-branch t]
-    ["Remote update" magit-fetch-all t]
-    ("Submodule"
-     ["Submodule update" magit-submodule-update t]
-     ["Submodule update and init" magit-submodule-setup t]
-     ["Submodule init" magit-submodule-init t]
-     ["Submodule sync" magit-submodule-sync t])
-    "---"
-    ("Extensions")
-    "---"
-    ["Display Git output" magit-process-buffer t]
-    ["Quit Magit" magit-mode-bury-buffer t]))
+    ("Change buffer arguments"
+     ["Diff arguments"            magit-diff-refresh t]
+     ["Log arguments"             magit-log-refresh t])
+    ["Refresh buffer"             magit-refresh t]
+    ["Bury buffer"                magit-mode-bury-buffer t]))
 
 ;;; Mode
 

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1098,7 +1098,7 @@ Run hooks `magit-pre-refresh-hook' and `magit-post-refresh-hook'."
                        (lambda (window)
                          (with-selected-window window
                            (with-current-buffer buffer
-                             (when-let ((section (magit-current-section)))
+                             (when-let ((section (magit-section-at)))
                                `(( ,window
                                    ,section
                                    ,@(magit-refresh-get-relative-position)))))))
@@ -1135,16 +1135,17 @@ Run hooks `magit-pre-refresh-hook' and `magit-post-refresh-hook'."
 
 (defun magit-refresh-get-relative-position ()
   (when-let ((section (magit-current-section)))
-    (let ((start (oref section start)))
-      (list (- (line-number-at-pos (point))
+    (let ((start (oref section start))
+          (point (magit-point)))
+      (list (- (line-number-at-pos point)
                (line-number-at-pos start))
-            (- (point) (line-beginning-position))
+            (- point (line-beginning-position))
             (and (magit-hunk-section-p section)
                  (region-active-p)
                  (progn (goto-char (line-beginning-position))
                         (when  (looking-at "^[-+]") (forward-line))
                         (while (looking-at "^[ @]") (forward-line))
-                        (let ((beg (point)))
+                        (let ((beg point))
                           (cond ((looking-at "^[-+]")
                                  (forward-line)
                                  (while (looking-at "^[-+]") (forward-line))

--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -449,7 +449,8 @@ which visits the thing at point using `browse-url'."
   (interactive)
   (user-error "There is no thing at point that could be browsed"))
 
-(defun magit-help ()
+;;;###autoload
+(defun magit-info ()
   "Visit the Magit manual."
   (interactive)
   (info "magit"))

--- a/lisp/magit-pkg.el
+++ b/lisp/magit-pkg.el
@@ -2,9 +2,9 @@
   "A Git porcelain inside Emacs."
   '((emacs "25.1")
     (dash "20210826")
-    (git-commit "20211004")
-    (magit-section "20211004")
-    (transient "20210920")
-    (with-editor "20211001"))
+    (git-commit "20220222")
+    (magit-section "20220325")
+    (transient "20220325")
+    (with-editor "20220318"))
   :homepage "https://magit.vc"
   :keywords '("git" "tools" "vc"))

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -429,10 +429,12 @@ This command behaves just like `magit-show-commit', except if
 point is on a reference in a `magit-refs-mode' buffer (a buffer
 listing branches and tags), in which case the behavior may be
 different, but only if you have customized the option
-`magit-visit-ref-behavior' (which see)."
+`magit-visit-ref-behavior' (which see).  When invoked from a
+menu this command always behaves like `magit-show-commit'."
   (interactive)
   (if (and (derived-mode-p 'magit-refs-mode)
-           (magit-section-match '(branch tag)))
+           (magit-section-match '(branch tag))
+           (magit-menu-position))
       (let ((ref (oref (magit-current-section) value)))
         (cond (current-prefix-arg
                (cond ((memq 'focus-on-ref magit-visit-ref-behavior)
@@ -476,23 +478,23 @@ Branch %s already exists.
 
 (defvar magit-remote-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-delete-thing] 'magit-remote-remove)
-    (define-key map [remap magit-file-rename]  'magit-remote-rename)
+    (magit-menu-set map [magit-delete-thing] #'magit-remote-remove "Remove %m")
+    (magit-menu-set map [magit-file-rename]  #'magit-remote-rename "Rename %s")
     map)
   "Keymap for `remote' sections.")
 
 (defvar magit-branch-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing]  'magit-visit-ref)
-    (define-key map [remap magit-delete-thing] 'magit-branch-delete)
-    (define-key map [remap magit-file-rename]  'magit-branch-rename)
+    (magit-menu-set map [magit-visit-thing]  #'magit-visit-ref     "Visit commit")
+    (magit-menu-set map [magit-delete-thing] #'magit-branch-delete "Delete %m")
+    (magit-menu-set map [magit-file-rename]  #'magit-branch-rename "Rename %s")
     map)
   "Keymap for `branch' sections.")
 
 (defvar magit-tag-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing]  'magit-visit-ref)
-    (define-key map [remap magit-delete-thing] 'magit-tag-delete)
+    (magit-menu-set map [magit-visit-thing]  #'magit-visit-ref  "Visit %s")
+    (magit-menu-set map [magit-delete-thing] #'magit-tag-delete "Delete %m")
     map)
   "Keymap for `tag' sections.")
 

--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -477,7 +477,7 @@ Branch %s already exists.
 (defvar magit-remote-section-map
   (let ((map (make-sparse-keymap)))
     (define-key map [remap magit-delete-thing] 'magit-remote-remove)
-    (define-key map "R"                        'magit-remote-rename)
+    (define-key map [remap magit-file-rename]  'magit-remote-rename)
     map)
   "Keymap for `remote' sections.")
 
@@ -485,7 +485,7 @@ Branch %s already exists.
   (let ((map (make-sparse-keymap)))
     (define-key map [remap magit-visit-thing]  'magit-visit-ref)
     (define-key map [remap magit-delete-thing] 'magit-branch-delete)
-    (define-key map "R"                        'magit-branch-rename)
+    (define-key map [remap magit-file-rename]  'magit-branch-rename)
     map)
   "Keymap for `branch' sections.")
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -325,6 +325,9 @@ but that ship has sailed, thus this option."
 
 (defvar magit-section-heading-map
   (let ((map (make-sparse-keymap)))
+    (define-key map [double-down-mouse-1] 'ignore)
+    (define-key map [double-mouse-1] 'magit-mouse-toggle-section)
+    (define-key map [double-mouse-2] 'magit-mouse-toggle-section)
     map)
   "Keymap used in the heading line of all expandable sections.
 This keymap is used in addition to the section-specifi keymap,
@@ -333,6 +336,8 @@ if any.")
 (defvar magit-section-mode-map
   (let ((map (make-keymap)))
     (suppress-keymap map t)
+    (define-key map [left-fringe mouse-1] 'magit-mouse-toggle-section)
+    (define-key map [left-fringe mouse-2] 'magit-mouse-toggle-section)
     (define-key map (kbd "TAB") 'magit-section-toggle)
     (define-key map [C-tab]     'magit-section-cycle)
     (define-key map [M-tab]     'magit-section-cycle)
@@ -801,6 +806,22 @@ Sections at higher levels are hidden."
   "Show all sections up to fourth level."
   (interactive)
   (magit-section-show-level -4))
+
+(defun magit-mouse-toggle-section (event)
+  "Toggle visibility of the clicked section.
+Clicks outside either the section heading or the left fringe are
+silently ignored."
+  (interactive "e")
+  (let* ((pos (event-start event))
+         (section (magit-section-at (posn-point pos))))
+    (if (eq (posn-area pos) 'left-fringe)
+        (when section
+          (while (not (magit-section-content-p section))
+            (setq section (oref section parent)))
+          (unless (eq section magit-root-section)
+            (goto-char (oref section start))
+            (magit-section-toggle section)))
+      (magit-section-toggle section))))
 
 ;;;; Auxiliary
 

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -344,7 +344,8 @@ but that ship has sailed, thus this option."
     (define-key map (kbd "M-2") 'magit-section-show-level-2-all)
     (define-key map (kbd "M-3") 'magit-section-show-level-3-all)
     (define-key map (kbd "M-4") 'magit-section-show-level-4-all)
-    map))
+    map)
+  "Parent keymap for all keymaps of modes derived from `magit-section-mode'.")
 
 (define-derived-mode magit-section-mode special-mode "Magit-Sections"
   "Parent major mode from which major modes with Magit-like sections inherit.

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -305,7 +305,7 @@ but that ship has sailed, thus this option."
 (defvar magit--section-type-alist nil)
 
 (defclass magit-section ()
-  ((keymap   :initform nil :allocation :class)
+  ((keymap   :initform nil)
    (type     :initform nil :initarg :type)
    (value    :initform nil :initarg :value)
    (start    :initform nil :initarg :start)
@@ -1142,14 +1142,16 @@ anything this time around.
            (magit-insert-child-count ,s)
            (set-marker-insertion-type (oref ,s start) t)
            (let* ((end (oset ,s end (point-marker)))
-                  (class-map (oref-default ,s keymap))
+                  (class-map (oref ,s keymap))
                   (magit-map (intern (format "magit-%s-section-map"
                                              (oref ,s type))))
                   (forge-map (intern (format "forge-%s-section-map"
                                              (oref ,s type))))
-                  (map (or (and         class-map  (symbol-value class-map))
-                           (and (boundp magit-map) (symbol-value magit-map))
-                           (and (boundp forge-map) (symbol-value forge-map)))))
+                  (map (and class-map (symbol-value class-map))))
+             (unless map
+               (setq map (or (and (boundp magit-map) (symbol-value magit-map))
+                             (and (boundp forge-map) (symbol-value forge-map))))
+               (oset ,s keymap map))
              (save-excursion
                (goto-char (oref ,s start))
                (while (< (point) end)

--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -395,7 +395,11 @@ never modify it.")
 
 (defun magit-current-section ()
   "Return the section at point."
-  (or (get-text-property (point) 'magit-section) magit-root-section))
+  (or (magit-section-at) magit-root-section))
+
+(defun magit-section-at (&optional position)
+  "Return the section at POSITION, defaulting to point."
+  (get-text-property (or position (point)) 'magit-section))
 
 (defun magit-section-ident (section)
   "Return an unique identifier for SECTION.
@@ -1118,7 +1122,7 @@ anything this time around.
                  (let ((next (or (next-single-property-change
                                   (point) 'magit-section)
                                  end)))
-                   (unless (get-text-property (point) 'magit-section)
+                   (unless (magit-section-at)
                      (put-text-property (point) next 'magit-section ,s)
                      (when map
                        (put-text-property (point) next 'keymap map)))
@@ -1625,8 +1629,8 @@ forms CONDITION can take."
   (when (region-active-p)
     (let* ((rbeg (region-beginning))
            (rend (region-end))
-           (sbeg (get-text-property rbeg 'magit-section))
-           (send (get-text-property rend 'magit-section)))
+           (sbeg (magit-section-at rbeg))
+           (send (magit-section-at rend)))
       (when (and send
                  (not (eq send magit-root-section))
                  (not (and multiple (eq send sbeg))))
@@ -1663,8 +1667,8 @@ current section."
 If optional SECTION is nil, use the current section."
   (and (region-active-p)
        (or section (setq section (magit-current-section)))
-       (let ((beg (get-text-property (region-beginning) 'magit-section)))
-         (and (eq beg (get-text-property   (region-end) 'magit-section))
+       (let ((beg (magit-section-at (region-beginning))))
+         (and (eq beg (magit-section-at (region-end)))
               (eq beg section)))
        (not (or (magit-section-position-in-heading-p section (region-beginning))
                 (magit-section-position-in-heading-p section (region-end))))

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -377,17 +377,17 @@ current branch or `HEAD' as the start-point."
 
 (defvar magit-stashes-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing]  'magit-stash-list)
-    (define-key map [remap magit-delete-thing] 'magit-stash-clear)
+    (magit-menu-set map [magit-visit-thing]  #'magit-stash-list  "List %t")
+    (magit-menu-set map [magit-delete-thing] #'magit-stash-clear "Clear %t")
     map)
   "Keymap for `stashes' section.")
 
 (defvar magit-stash-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing]  'magit-stash-show)
-    (define-key map [remap magit-delete-thing] 'magit-stash-drop)
-    (define-key map [remap magit-cherry-apply] 'magit-stash-apply)
-    (define-key map [remap magit-cherry-pick]  'magit-stash-pop)
+    (magit-menu-set map [magit-visit-thing]  #'magit-stash-show  "Visit %v")
+    (magit-menu-set map [magit-delete-thing] #'magit-stash-drop  "Delete %M")
+    (magit-menu-set map [magit-cherry-apply] #'magit-stash-apply "Apply %M")
+    (magit-menu-set map [magit-cherry-pick]  #'magit-stash-pop   "Pop %M")
     map)
   "Keymap for `stash' sections.")
 

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -386,8 +386,8 @@ current branch or `HEAD' as the start-point."
   (let ((map (make-sparse-keymap)))
     (define-key map [remap magit-visit-thing]  'magit-stash-show)
     (define-key map [remap magit-delete-thing] 'magit-stash-drop)
-    (define-key map "a"  'magit-stash-apply)
-    (define-key map "A"  'magit-stash-pop)
+    (define-key map [remap magit-cherry-apply] 'magit-stash-apply)
+    (define-key map [remap magit-cherry-pick]  'magit-stash-pop)
     map)
   "Keymap for `stash' sections.")
 

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -715,8 +715,8 @@ remote in alphabetic order."
 
 (defvar magit-untracked-section-map
   (let ((map (make-sparse-keymap)))
+    (define-key map [remap magit-stage-file]   'magit-stage)
     (define-key map [remap magit-delete-thing] 'magit-discard)
-    (define-key map "s" 'magit-stage)
     map)
   "Keymap for the `untracked' section.")
 

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -512,7 +512,8 @@ The sections are inserted by running the functions on the hook
 
 (defvar magit-error-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing] 'magit-process-buffer)
+    (magit-menu-set map [magit-visit-thing]
+      #'magit-process-buffer "Visit process output")
     map)
   "Keymap for `error' sections.")
 
@@ -715,8 +716,8 @@ remote in alphabetic order."
 
 (defvar magit-untracked-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-stage-file]   'magit-stage)
-    (define-key map [remap magit-delete-thing] 'magit-discard)
+    (magit-menu-set map [magit-stage-file]   #'magit-stage   "Stage files")
+    (magit-menu-set map [magit-delete-thing] #'magit-discard "Discard files")
     map)
   "Keymap for the `untracked' section.")
 

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -510,19 +510,25 @@ or, failing that, the abbreviated HEAD commit hash."
 
 (defvar magit-modules-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing] 'magit-list-submodules)
+    (magit-menu-set map [remap magit-visit-thing]
+      #'magit-list-submodules "List %t")
     map)
   "Keymap for `modules' sections.")
 
 (defvar magit-module-section-map
   (let ((map (make-sparse-keymap)))
-    (set-keymap-parent map magit-file-section-map)
     (define-key map (kbd "C-j") 'magit-submodule-visit)
     (define-key map [C-return]  'magit-submodule-visit)
-    (define-key map [remap magit-visit-thing]  'magit-submodule-visit)
-    (define-key map [remap magit-delete-thing] 'magit-submodule-unpopulate)
-    (define-key map "K" 'magit-file-untrack)
-    (define-key map "R" 'magit-file-rename)
+    (magit-menu-set map [magit-visit-thing]
+      #'magit-submodule-visit "Visit %s")
+    (magit-menu-set map [magit-stage-file]
+      #'magit-stage "Stage %T"
+      '(:visible (eq (magit-diff-type) 'unstaged)))
+    (magit-menu-set map [magit-unstage-file]
+      #'magit-unstage "Unstage %T"
+      '(:visible (eq (magit-diff-type) 'staged)))
+    (define-key-after map [separator-magit-submodule] menu-bar-separator)
+    (magit-menu-set map [magit-submodule] #'magit-submodule "Module commands...")
     map)
   "Keymap for `module' sections.")
 

--- a/lisp/magit-worktree.el
+++ b/lisp/magit-worktree.el
@@ -150,8 +150,10 @@ then show it in Dired instead."
 
 (defvar magit-worktree-section-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [remap magit-visit-thing]  'magit-worktree-status)
-    (define-key map [remap magit-delete-thing] 'magit-worktree-delete)
+    (magit-menu-set map [magit-visit-thing]  #'magit-worktree-status "Visit %s")
+    (magit-menu-set map [magit-delete-thing] #'magit-worktree-delete "Delete %m")
+    (define-key-after map [separator-magit-worktree] menu-bar-separator)
+    (magit-menu-set map [magit-worktree ] #'magit-worktree "Worktree commands...")
     map)
   "Keymap for `worktree' sections.")
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -315,7 +315,7 @@ Also see info node `(magit)Commands for Buffers Visiting Files'."
     ("F" "Pull"           magit-pull)
     ;; g                  ↓
     ;; G                → magit-refresh-all
-    ("h" "Help"           magit-help)
+    ("h" "Help"           magit-info)
     ("H" "Section info"   magit-describe-section :if-derived magit-mode)]
    [("i" "Ignore"         magit-gitignore)
     ("I" "Init"           magit-init)
@@ -372,12 +372,6 @@ Also see info node `(magit)Commands for Buffers Visiting Files'."
     ("<return>" "visit thing at point"     magit-visit-thing)]
    [("C-x m"    "show all key bindings"    describe-mode)
     ("C-x i"    "show Info manual"         magit-info)]])
-
-;;;###autoload
-(defun magit-info ()
-  "Show Magit's Info manual."
-  (interactive)
-  (info "magit"))
 
 ;;; Git Popup
 


### PR DESCRIPTION
Get out the cheese!

It took a while (see #2554) but you can now use the mouse to perform many actions:

- Double click (mouse-1 or mouse-2) a section heading to expand or collapse it.
- Single click in the left fringe to expand or collapse the appropriate section.
- Right click (mouse-3) to show a context menu, with common as well as
  section-specific commands.
  - If you are using Emacs 28 or greater you have to enable `context-menu-mode`
    for this to work.
  - For older Emacsen set `magit-section-show-context-menu-for-emacs<28` to `t`
    before loading `magit-section`.
- Magit's menu-bar menu now features all transient commands and most others
  as well.
  - This menu is also available from the context-menu.
- By default "popup navigation" is now enabled in Transient popups, including
  mouse support.
  - This is useful if you use the context-menu or menu-bar to invoke a transient
    command, as you can then continue to use the mouse to select a suffix.
	
Make sure to update `transient`, `magit-section` and `magit`, in that order.
On Melpa (non-stable) this should happen automatically when you update Magit.

You might also want to update/recompile all packages that depend on
`magit`/`magit-section`.  The `magit-insert-section` macro changed and while the
old expansions continue to work, the heading and fringe clicks won't have an
effect until you recompile.