### PR TITLE
Fix imenu/which-func-mode in magit-submodule-list buffers

### DIFF
--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -32,6 +32,7 @@
 ;;; Code:
 
 (require 'magit-core)
+(require 'seq)
 
 (declare-function magit-status-setup-buffer "magit-status" (&optional directory))
 
@@ -483,8 +484,8 @@ Point should be at the beginning of the line.  This function
 is used as a value for `imenu-extract-index-name-function'."
   (let ((entry (tabulated-list-get-entry)))
     (format "%s (%s)"
-            (car entry)
-            (car (last entry)))))
+            (seq-first entry)
+            (seq-elt entry (1- (seq-length entry))))))
 
 ;;; Read Repository
 

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'magit)
+(require 'seq)
 
 (defvar x-stretch-cursor)
 
@@ -703,7 +704,7 @@ Used as a value for `imenu-prev-index-position-function'."
   "Return imenu name for line at point.
 Point should be at the beginning of the line.  This function
 is used as a value for `imenu-extract-index-name-function'."
-  (car (tabulated-list-get-entry)))
+  (seq-first (tabulated-list-get-entry)))
 
 ;;; Utilities
 


### PR DESCRIPTION
`tabulated-list-get-entry` returns a vector.  This led to a `(wrong-type-argument listp ["path/to/submodule" ...])` error in `which-func-ff-hook` when using Emacs 28.1.
