### PR TITLE
Support revisions that match commit message

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2517,7 +2517,7 @@ Staging and applying changes is documented in info node
     "show" "-p" "--cc" "--format=" "--no-prefix"
     (and (member "--stat" magit-buffer-diff-args) "--numstat")
     magit-buffer-diff-args
-    (concat magit-buffer-revision "^{commit}")
+    (magit--rev-dereference magit-buffer-revision)
     "--" magit-buffer-diff-files))
 
 (defun magit-insert-revision-tag ()
@@ -2676,7 +2676,7 @@ or a ref which is not a branch, then it inserts nothing."
     (--when-let (magit-rev-format "%D" magit-buffer-revision "--decorate=full")
       (insert (magit-format-ref-labels it) ?\s))
     (insert (propertize
-             (magit-rev-parse (concat magit-buffer-revision "^{commit}"))
+             (magit-rev-parse (magit--rev-dereference magit-buffer-revision))
              'font-lock-face 'magit-hash))
     (magit-insert-heading)
     (let ((beg (point)))


### PR DESCRIPTION
Git supports revisions that match a commit message:

       :/<text>, e.g. :/fix nasty bug
           A colon, followed by a slash, followed by a text, names a commit whose commit message matches the specified regular expression. This name returns the
           youngest matching commit which is reachable from any ref, including HEAD. The regular expression can match any part of the commit message. To match
           messages starting with a string, one can use e.g.  :/^foo. The special sequence :/! is reserved for modifiers to what is matched.  :/!-foo performs a
           negative match, while :/!!foo matches a literal ! character, followed by foo. Any other sequence beginning with :/! is reserved for now. Depending on
           the given text, the shell’s word splitting rules might require additional quoting.

However, Magit would not support these, because it appends `^{commit}`
in several places to revisions. To fix this, recognize this special
revision syntax and handle it specially.
