### PR TITLE
magit-stash: Disable external diff tools

### DIFF
--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -317,7 +317,7 @@ current branch or `HEAD' as the start-point."
                            (magit-stash-create message index worktree untracked))
         (if (eq keep 'worktree)
             (with-temp-buffer
-              (magit-git-insert "diff" "--cached")
+              (magit-git-insert "diff" "--cached" "--no-ext-diff")
               (magit-run-git-with-input
                "apply" "--reverse" "--cached" "--ignore-space-change" "-")
               (magit-run-git-with-input


### PR DESCRIPTION
External diff tools may cause git to produce errors like "unrecognized
input" when the output is fed back into `git apply`.  Pass
`--no-ext-diff` to `git diff` where necessary in magit-stash.el.
