### PR TITLE
Fix behaviour of magit-visit-ref outside of magit menus

### DIFF
--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -431,7 +431,7 @@ menu this command always behaves like `magit-show-commit'."
   (interactive)
   (if (and (derived-mode-p 'magit-refs-mode)
            (magit-section-match '(branch tag))
-           (magit-menu-position))
+           (not (magit-menu-position)))
       (let ((ref (oref (magit-current-section) value)))
         (cond (current-prefix-arg
                (cond ((memq 'focus-on-ref magit-visit-ref-behavior)


### PR DESCRIPTION
I noticed that `magit-visit-ref-behavior` was no longer respected in the Magit Refs buffer, and I narrowed down the issue to this part of the code (`magit-visit-ref`) not working according to its intended behavior (in fact, it was behaving the opposite of the documentation afaiu):

``` 
When invoked from a menu this command always behaves like `magit-show-commit'.
``` 

This solves the issue I had with `magit-visit-ref-behavior` not being respected and should actually implement the documented / intended behavior of the function.