### PR TITLE
The --no-verify switch key bind of magit-commit changes to -h instead -n

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -144,7 +144,7 @@ must then use a prefix argument."
    ("-a" "Stage all modified and deleted files"   ("-a" "--all"))
    ("-e" "Allow empty commit"                     "--allow-empty")
    ("-v" "Show diff of changes to be committed"   ("-v" "--verbose"))
-   ("-n" "Disable hooks"                          ("-n" "--no-verify"))
+   ("-h" "Disable hooks"                          ("-n" "--no-verify"))
    ("-R" "Claim authorship and reset author date" "--reset-author")
    (magit:--author :description "Override the author")
    (7 "-D" "Override the author date" "--date=" transient-read-date)


### PR DESCRIPTION
Hi, I encountered a unnaturally behavior about magit-push function. It's about `--no-verify` switch character of magit-push, maybe not refrected a correction that merged by magit version 2.11.0.  

## Summary 

By now current master branch, magit-push function use -n key for --no-verify switch. but magit-push and magit-rebase use -h key for --no-verify switch. It is desirable to use the same key from the viewpoint of user experience consistency.

| Function     | Magit2.11 or later | current master branch (Magit3) | Expect behavior (Magit3) | Description  |
|------------ |------------------ |------------------------------ |------------------------ |------------ |
| magit-commit | `-h`               | `-n`                           | `-h`                     | It Changed.  |
| magit-push   | `-h`               | `-h`                           | `-h`                     | Not changed. |
| magit-rebase | `-h`               | `-h`                           | `-h`                     | Not changed. |

## Background and reason

Probably this fix is ​​not reflected in the shift from Magit2 to Magit3.

https://github.com/magit/magit/commit/f8b497d6596a086083379505778449e588937fd6

In Magit 2.11.0 Release note it says:

> 
> * The `--no-verify' switch in `magit-commit-popup' is now bound to "h"
>   instead of "n" for consistency with `magit-push-popup' and
>   `magit-rebase-popup'.  #3144
> 

It can reduce the confusion in the user's operation. I think this is correct about maintaining consistency, and it's good that maintaining this consistency in Magit3 too.


--
Thank you to the wonderful package Magit and all developers.