### PR TITLE
Resolve magit-find-file calling hooks

### DIFF
--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -179,7 +179,8 @@ then only after asking.  A non-nil value for REVERT is ignored if REV is
           (after-change-major-mode-hook
            (remq 'global-diff-hl-mode-enable-in-buffers
                  after-change-major-mode-hook)))
-      (normal-mode t))
+      (delay-mode-hooks
+        (normal-mode t)))
     (setq buffer-read-only t)
     (set-buffer-modified-p nil)
     (goto-char (point-min))))


### PR DESCRIPTION
Calling `magit-find-file` in a rust lsp environment causes `#'lsp` to be
called again with the contents of the older file instead.

This commit seems to resolve it, but I'm not sure if I also have to wrap
the let-bind to prevent buffer hooks from being called.

See linked issue[1] for more information and a lengthier discussion

[1] https://github.com/doomemacs/doomemacs/pull/6309