### PR TITLE
magit-revert-rev-file-buffer: Use set-auto-mode

### DIFF
--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -152,7 +152,7 @@ then only after asking.  A non-nil value for REVERT is ignored if REV is
 
 (defun magit-get-revision-buffer (rev file &optional create)
   (funcall (if create #'get-buffer-create #'get-buffer)
-           (format "%s.~%s~" file (subst-char-in-string ?/ ?_ rev))))
+           (format "%s:%s" (subst-char-in-string ?/ ?_ rev) file)))
 
 (defun magit-revert-rev-file-buffer (_ignore-auto noconfirm)
   (when (or noconfirm
@@ -175,12 +175,12 @@ then only after asking.  A non-nil value for REVERT is ignored if REV is
                             (concat ":" file)
                           (concat magit-buffer-refname ":" file)))
       (setq buffer-file-coding-system last-coding-system-used))
-    (let ((buffer-file-name magit-buffer-file-name)
+    (let ((delay-mode-hooks t)
           (after-change-major-mode-hook
            (remq 'global-diff-hl-mode-enable-in-buffers
                  after-change-major-mode-hook)))
       (delay-mode-hooks
-        (normal-mode t)))
+        (set-auto-mode)))
     (setq buffer-read-only t)
     (set-buffer-modified-p nil)
     (goto-char (point-min))))


### PR DESCRIPTION
For that newly-opened buffer to have syntax coloring this function
briefly sets buffer-file-name and performs (normal-mode t).  This,
in turn, triggers related major-mode hooks, which at least in the
case of lsp causes issues.

An attempt was made to resolve this in f331092df but it didn't seem
to resolve the issue.

Because of how the buffers are named, set-auto-mode couldn't
work out which mode to use; so this has been swapped around.

This PR is slightly more disruptive than the previous change, so I accept that I may have to make other changes :) 

Closes https://github.com/doomemacs/doomemacs/pull/6309