### PR TITLE
Small doc updates

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -1282,7 +1282,7 @@ transient prefix command is later invoked again, then the arguments
 are initially reset to the default value.  This default value can be
 set for the current Emacs session or saved permanently, see
 [[info:transient#Saving Values]].  It is also possible to cycle through
-previously used sets of arguments using ~M-p~ and ~M-n~, see
+previously used sets of arguments using ~C-M-p~ and ~C-M-n~, see
 [[info:transient#Using History]].
 
 However the infix arguments of many other transient commands continue
@@ -1301,7 +1301,7 @@ As mentioned above, it is possible to cycle through previously used
 sets of arguments while a transient popup is visible.  That means that
 we could always reset the infix arguments to the default because the
 set of arguments that is active in the existing buffer is only a few
-~M-p~ away.  Magit can be configured to behave like that, but because I
+~C-M-p~ away.  Magit can be configured to behave like that, but because I
 expect that most users would not find that very convenient, it is not
 the default.
 

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -1717,7 +1717,7 @@ transient prefix command is later invoked again, then the arguments
 are initially reset to the default value.  This default value can be
 set for the current Emacs session or saved permanently, see
 @ref{Saving Values,,,transient,}.  It is also possible to cycle through
-previously used sets of arguments using @code{M-p} and @code{M-n}, see
+previously used sets of arguments using @code{C-M-p} and @code{C-M-n}, see
 @ref{Using History,,,transient,}.
 
 However the infix arguments of many other transient commands continue
@@ -1736,7 +1736,7 @@ As mentioned above, it is possible to cycle through previously used
 sets of arguments while a transient popup is visible.  That means that
 we could always reset the infix arguments to the default because the
 set of arguments that is active in the existing buffer is only a few
-@code{M-p} away.  Magit can be configured to behave like that, but because I
+@code{C-M-p} away.  Magit can be configured to behave like that, but because I
 expect that most users would not find that very convenient, it is not
 the default.
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1265,7 +1265,7 @@ be committed."
   "Show diff for the blob or file visited in the current buffer.
 
 When the buffer visits a blob, then show the respective commit.
-When the buffer visits a file, then show the differenced between
+When the buffer visits a file, then show the differences between
 `HEAD' and the working tree.  In both cases limit the diff to
 the file or blob."
   (interactive)


### PR DESCRIPTION
Two minor doc updates:
* Typo in docstring for `magit-diff-buffer-file`.
* Update for the keybindings used to cycle through previous arguments in a transient (`transient-history-prev` and `transient-history-next`).
