### PR TITLE
Support bookmark-handler-type for Magit bookmarks

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1540,6 +1540,8 @@ with the variables' values as arguments, which were recorded by
       (funcall bmkp-jump-display-function (current-buffer)))
     nil))
 
+(put 'magit--handle-bookmark 'bookmark-handler-type "Magit")
+
 (cl-defgeneric magit-bookmark-name ()
   "Return name for bookmark to current buffer."
   (format "%s%s"


### PR DESCRIPTION
Hi Jonas,

```
From etc/NEWS in emacs.git:
  *** 'list-bookmarks' now includes a type column.
  Types are registered via a 'bookmark-handler-type' symbol property on
  the jumping function.
```
This adds support for it to Magit.