### PR TITLE
magit-push: Fix magit-push-implicitly--desc

### DIFF
--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -300,15 +300,17 @@ what this command will do.  To add it use something like:
   ;; so it doesn't make sense to talk about "pushing to upstream".
   ;; Depending on the options, you could end up pushing to the
   ;; "upstream" remote but not the "upstream" branch, and vice versa.
-  (let ((branch (magit-get-current-branch))
-        (remote (or (magit-get-push-remote)
-                    (magit-get-remote)
-                    (let ((remotes (magit-list-remotes)))
-                      (cond
-                       ((and (magit-git-version>= "2.27")
-                             (= (length remotes) 1))
-                        (car remotes))
-                       ((member "origin" remotes) "origin"))))))
+  (let* ((branch (magit-get-current-branch))
+         (remote (or (magit-get-push-remote branch)
+                     ;; Note: Avoid `magit-get-remote' because it
+                     ;; filters out the local repo case (".").
+                     (magit-get "branch" branch "remote")
+                     (let ((remotes (magit-list-remotes)))
+                       (cond
+                        ((and (magit-git-version>= "2.27")
+                              (= (length remotes) 1))
+                         (car remotes))
+                        ((member "origin" remotes) "origin"))))))
     (if (null remote)
         "nothing (no remote)"
       (let ((refspec (magit-get "remote" remote "push")))


### PR DESCRIPTION
The previous implementation was basically wrong because it didn't
handle push.default or resolve the remotes and refspecs separately
like git push actually does.

An easy example is if you have a branch `fork` tracking `fork/master`, the previous implementation said it would push to `fork/master` even though the default `push.default` value `simple` means it would push to `fork/fork`.