### PR TITLE
Default names to non-short format

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1903,7 +1903,7 @@ SORTBY is a key or list of keys to pass to the `--sort' flag of
             (magit-git-lines "show-ref"))))
 
 (defun magit-list-refnames (&optional namespaces include-special)
-  (nconc (magit-list-refs namespaces "%(refname:short)")
+  (nconc (magit-list-refs namespaces "%(refname)")
          (and include-special
               (magit-list-special-refnames))))
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1903,7 +1903,7 @@ SORTBY is a key or list of keys to pass to the `--sort' flag of
             (magit-git-lines "show-ref"))))
 
 (defun magit-list-refnames (&optional namespaces include-special)
-  (nconc (magit-list-refs namespaces "%(refname)")
+  (nconc (magit-list-refs namespaces "%(refname:lstrip=2)")
          (and include-special
               (magit-list-special-refnames))))
 


### PR DESCRIPTION
The `refname:short` format is slow. On my repository (with 1000+ branches) it takes about 3.5seconds to show branches with `short` vs. about 0.2 seconds for the default format. Maybe this should be configurable somehow or depend on number of brances. Having `short` makes magit painful to use on repos with many branches. Tested on multiple versions of git and under windows and linux.