### PR TITLE
magit-remote-add: Allow whitespace in remote URL

### DIFF
--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -90,7 +90,7 @@ has to be used to view and change remote related variables."
   (transient-setup 'magit-remote nil nil :scope remote))
 
 (defun magit-read-url (prompt &optional initial-input)
-  (let ((url (magit-read-string-ns prompt initial-input)))
+  (let ((url (magit-read-string prompt initial-input)))
     (if (string-prefix-p "~" url)
         (expand-file-name url)
       url)))


### PR DESCRIPTION
It’s possible to add remote URLs containing whitespace when calling git
directly on the command line (e.g. `git remote set-url something
"host:/path/to/folder name/"`), so I believe magit-remote-add should
also allow whitespace in URLs.

As far as I can see, `'magit-read-url` is only called in
`'magit-remote-add`, so it seems ok to make the modification there.