### PR TITLE
manual: re-update link to 2.4 release blog post

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -8833,7 +8833,7 @@ also affects the diffs displayed inside Magit.
 
 *** How does branching and pushing work?
 
-Please see [[*Branching]] and http://emacsair.me/2016/01/18/magit-2.4
+Please see [[*Branching]] and http://emacsair.me/2016/01/17/magit-2.4
 
 *** Should I disable VC?
 

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -10793,7 +10793,7 @@ echo "*.gpg filter=gpg diff=gpg" > .gitattributes
 @node How does branching and pushing work?
 @appendixsubsec How does branching and pushing work?
 
-Please see @ref{Branching} and @uref{http://emacsair.me/2016/01/18/magit-2.4}
+Please see @ref{Branching} and @uref{http://emacsair.me/2016/01/17/magit-2.4}
 
 @node Should I disable VC@?
 @appendixsubsec Should I disable VC@?


### PR DESCRIPTION
I noticed today that following the link in the manual to https://emacsair.me/2016/01/18/magit-2.4/ brought up a 404.  Initially I thought to replace it with an Archive.org link, https://web.archive.org/web/20210618023341/https://emacsair.me/2016/01/18/magit-2.4/ , but then when I looked at the `git blame` for that line in the manual I saw it had a bit of a storied history, bouncing back and forth between `.../2016/01/17/...` and `/2016/01/18/...`:

| Commit | Date | Link target |
|---|---|---|
| 41764f9aa0fb6689388cbfdf89b61efb60e10d8f | `2016-01-18 00:05:00 +0100` | `.../2016/01/17/...` |
| 2e757a8c919b53edddb186e36e055e011e3b0ab3 | `2016-01-18 00:09:00 +0100` | `.../2016/01/18/...` |
| 0640097d237fd3cebfc51da107a8c7924bba7421 | `2016-11-24 13:00:58 +0100` | `.../2016/01/18/...` |
| 36d69369f7f9fb64954a4805576010957cf5b29a | `2018-06-07 22:31:29 -0500` | `.../2016/01/17/...` |
| 8081050fc5912936d5894fd7d1cfb9210faa17cd | `2020-01-02 17:04:10 +0100` | `.../2016/01/18/...` |

As of today, `2022-08-13 13:40 -0400`, `.../2016/01/17/...` returns HTTP 200 and `.../2016/01/18/...` returns HTTP 404:

```bash
date -Is;
for url in https://emacsair.me/2016/01/1{7,8}/magit-2.4/ ; do
    curl --silent --output /dev/null --write-out "$url"': %{http_code}\n' "$url"
done
```
```
2022-08-13T13:45:42-04:00
https://emacsair.me/2016/01/17/magit-2.4/: 200
https://emacsair.me/2016/01/18/magit-2.4/: 404
```

This PR updates the manual to be back in sync with the answering blog link.