### PR TITLE
Allow magit-clone-url-format to be more dynamic

### DIFF
--- a/docs/RelNotes/3.4.0.org
+++ b/docs/RelNotes/3.4.0.org
@@ -57,6 +57,9 @@ dfe3d03a14 git-commit-save-message: Report whether message was saved
   default) to support partial cloning, a feature that is available as
   of Git v2.17.  #4102
 
+- ~magit-clone-url-format~ can now be configured to an alist to
+  support servers that employ different URL schemes.  #4738
+
 - Added new command ~magit-stash-push~, which allows specifying a list of
   files to be stashed.  #4583
 

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -4333,8 +4333,26 @@ The following suffixes are disabled by default. See
 - User Option: magit-clone-url-format ::
 
   The format specified by this option is used when turning repository
-  names into urls. ~%h~ is the hostname and ~%n~ is the repository name,
-  including the name of the owner.
+  names into urls.  ~%h~ is the hostname and ~%n~ is the repository
+  name, including the name of the owner.  The value can be a string
+  (representing a single static format) or an alist with elements
+  ~(HOSTNAME . FORMAT)~ mapping hostnames to formats.  When an alist
+  is used, the ~nil~ key represents the default format.
+
+  Example of a single format string:
+
+  #+BEGIN_SRC emacs-lisp
+    (setq magit-clone-url-format
+          "git@%h:%n.git")
+  #+END_SRC
+
+  Example of by-hostname format strings:
+
+  #+BEGIN_SRC emacs-lisp
+    (setq magit-clone-url-format
+          '(("git.example.com" . "git@%h:~%n")
+            (nil . "git@%h:%n.git")))
+  #+END_SRC
 
 ** Staging and Unstaging
 

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -5389,8 +5389,26 @@ username itself.
 
 @defopt magit-clone-url-format
 The format specified by this option is used when turning repository
-names into urls. @code{%h} is the hostname and @code{%n} is the repository name,
-including the name of the owner.
+names into urls.  @code{%h} is the hostname and @code{%n} is the repository
+name, including the name of the owner.  The value can be a string
+(representing a single static format) or an alist with elements
+@code{(HOSTNAME . FORMAT)} mapping hostnames to formats.  When an alist
+is used, the @code{nil} key represents the default format.
+
+Example of a single format string:
+
+@lisp
+(setq magit-clone-url-format
+      "git@@%h:%n.git")
+@end lisp
+
+Example of by-hostname format strings:
+
+@lisp
+(setq magit-clone-url-format
+      '(("git.example.com" . "git@@%h:~%n")
+        (nil . "git@@%h:%n.git")))
+@end lisp
 @end defopt
 
 @node Staging and Unstaging

--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -98,7 +98,7 @@ as the username itself."
 the name of the owner.  Also see `magit-clone-name-alist'."
   :package-version '(magit . "3.0.0")
   :group 'magit-commands
-  :type 'regexp)
+  :type 'string)
 
 ;;; Commands
 


### PR DESCRIPTION
This patch permits `magit-clone-url-format` to be represented as an alist mapping hostnames to URL formats. This way Magit can be configured to translate repository names into URLs when using servers that employ different URL schemes. The current value type (string) is kept for backwards compatibility.

Example usage with sr.ht:

``` 1c-enterprise
  ELISP> (add-to-list 'magit-clone-name-alist '("\\`\\(?:sourcehut:\\|sh:\\)\\([^:]+\\)\\'" "git.sr.ht" "sourcehut.user"))
  (("\\`\\(?:sourcehut:\\|sh:\\)\\([^:]+\\)\\'" "git.sr.ht" "sourcehut.user")
   ("\\`\\(?:github:\\|gh:\\)?\\([^:]+\\)\\'" "github.com" "github.user")
   ("\\`\\(?:gitlab:\\|gl:\\)\\([^:]+\\)\\'" "gitlab.com" "gitlab.user"))

  ELISP> (setq magit-clone-url-format '(("git.sr.ht" . "git@%h:~%n") (nil . "git@%h:%n.git")))
  (("git.sr.ht" . "git@%h:~%n")
   (nil . "git@%h:%n.git"))

  ELISP> (magit-clone--name-to-url "gh:nbarrientos/dotfiles")
  "git@github.com:nbarrientos/dotfiles.git"

  ELISP> (magit-clone--name-to-url "sh:nbarrientos/dotfiles")
  "git@git.sr.ht:~nbarrientos/dotfiles"

  ELISP> (magit-clone--name-to-url "gl:nbarrientos/dotfiles")
  "git@gitlab.com:nbarrientos/dotfiles.git"
```

Maybe it makes sense to change the default value of `magit-clone-url-format` and set it to the alist and perhaps add sourcehut to the default `magit-clone-name-alist` but up to you. Dunno where you want to draw the line. Happy to keep the sr.ht specific stuff in my own configuration.

Thanks for considering this patch.