### PR TITLE
Enable cloning repositories in Sourcehut by name

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -4337,7 +4337,7 @@ The following suffixes are disabled by default. See
   name, including the name of the owner.  The value can be a string
   (representing a single static format) or an alist with elements
   ~(HOSTNAME . FORMAT)~ mapping hostnames to formats.  When an alist
-  is used, the ~nil~ key represents the default format.
+  is used, the ~t~ key represents the default format.
 
   Example of a single format string:
 

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -5393,7 +5393,7 @@ names into urls.  @code{%h} is the hostname and @code{%n} is the repository
 name, including the name of the owner.  The value can be a string
 (representing a single static format) or an alist with elements
 @code{(HOSTNAME . FORMAT)} mapping hostnames to formats.  When an alist
-is used, the @code{nil} key represents the default format.
+is used, the @code{t} key represents the default format.
 
 Example of a single format string:
 

--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -69,7 +69,8 @@ directly."
 
 (defcustom magit-clone-name-alist
   '(("\\`\\(?:github:\\|gh:\\)?\\([^:]+\\)\\'" "github.com" "github.user")
-    ("\\`\\(?:gitlab:\\|gl:\\)\\([^:]+\\)\\'"  "gitlab.com" "gitlab.user"))
+    ("\\`\\(?:gitlab:\\|gl:\\)\\([^:]+\\)\\'"  "gitlab.com" "gitlab.user")
+    ("\\`\\(?:sourcehut:\\|sh:\\)\\([^:]+\\)\\'" "git.sr.ht" "sourcehut.user"))
   "Alist mapping repository names to repository urls.
 
 Each element has the form (REGEXP HOSTNAME USER).  When the user
@@ -92,7 +93,9 @@ as the username itself."
                        (string :tag "Hostname")
                        (string :tag "User name or git variable"))))
 
-(defcustom magit-clone-url-format "git@%h:%n.git"
+(defcustom magit-clone-url-format
+  '(("git.sr.ht" . "git@%h:~%n")
+    (t . "git@%h:%n.git"))
   "Format(s) used when turning repository names into urls.
 
 In a format string, %h is the hostname and %n is the repository

--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -94,17 +94,19 @@ as the username itself."
 
 (defcustom magit-clone-url-format "git@%h:%n.git"
   "Format(s) used when turning repository names into urls.
-%h is the hostname and %n is the repository name, including the
-name of the owner.  The value can be a string (representing a
-single static format) or an alist with elements (HOSTNAME
-. FORMAT) mapping hostnames to formats.  When an alist is used,
-the nil key represents the default.  Also see
-`magit-clone-name-alist'."
+
+In a format string, %h is the hostname and %n is the repository
+name, including the name of the owner.
+
+The value can be a string (representing a single static format)
+or an alist with elements (HOSTNAME . FORMAT) mapping hostnames
+to formats.  When an alist is used, the t key represents the
+default.  Also see `magit-clone-name-alist'."
   :package-version '(magit . "3.4.0")
   :group 'magit-commands
   :type '(choice (string :tag "Format")
                  (alist :key-type (choice (string :tag "Host")
-                                          (const :tag "Default" nil))
+                                          (const :tag "Default" t))
                         :value-type (string :tag "Format"))))
 
 ;;; Commands
@@ -321,7 +323,7 @@ Then show the status buffer for the new repository."
   (if-let ((url-format
             (cond ((listp magit-clone-url-format)
                    (cdr (or (assoc host magit-clone-url-format)
-                            (assoc nil magit-clone-url-format))))
+                            (assoc t magit-clone-url-format))))
                   ((stringp magit-clone-url-format)
                    magit-clone-url-format))))
       (format-spec

--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -86,11 +86,11 @@ default user specified in the matched entry is used.
 If USER contains a dot, then it is treated as a Git variable and
 the value of that is used as the username.  Otherwise it is used
 as the username itself."
-  :package-version '(magit . "3.0.0")
+  :package-version '(magit . "3.4.0")
   :group 'magit-commands
   :type '(repeat (list regexp
-                       (string :tag "hostname")
-                       (string :tag "user name or git variable"))))
+                       (string :tag "Hostname")
+                       (string :tag "User name or git variable"))))
 
 (defcustom magit-clone-url-format "git@%h:%n.git"
   "Format(s) used when turning repository names into urls.
@@ -100,10 +100,12 @@ single static format) or an alist with elements (HOSTNAME
 . FORMAT) mapping hostnames to formats.  When an alist is used,
 the nil key represents the default.  Also see
 `magit-clone-name-alist'."
-  :package-version '(magit . "3.0.0")
+  :package-version '(magit . "3.4.0")
   :group 'magit-commands
-  :type '(choice (string)
-                 (alist :key-type string :value-type string)))
+  :type '(choice (string :tag "Format")
+                 (alist :key-type (choice (string :tag "Host")
+                                          (const :tag "Default" nil))
+                        :value-type (string :tag "Format"))))
 
 ;;; Commands
 

--- a/test/magit-tests.el
+++ b/test/magit-tests.el
@@ -305,6 +305,38 @@ Enter passphrase for key '/home/user/.ssh/id_rsa': "
 
 ;;; Clone
 
+(ert-deftest magit-clone:--name-to-url-format-defaults ()
+  (magit-with-test-repository
+   (magit-git "config" "--add" "sourcehut.user" "shuser")
+   (magit-git "config" "--add" "github.user" "ghuser")
+   (magit-git "config" "--add" "gitlab.user" "gluser")
+   ;; No explicit service
+   (should (string-equal (magit-clone--name-to-url "a/b")
+                         "git@github.com:a/b.git"))
+   (should (string-equal (magit-clone--name-to-url "b")
+                         "git@github.com:ghuser/b.git"))
+   ;; User in config
+   (should (string-equal (magit-clone--name-to-url "gh:b")
+                         "git@github.com:ghuser/b.git"))
+   (should (string-equal (magit-clone--name-to-url "gl:n")
+                         "git@gitlab.com:gluser/n.git"))
+   (should (string-equal (magit-clone--name-to-url "sh:l")
+                         "git@git.sr.ht:~shuser/l"))
+   ;; Explicit user (abbreviated service names)
+   (should (string-equal (magit-clone--name-to-url "gh:a/b")
+                         "git@github.com:a/b.git"))
+   (should (string-equal (magit-clone--name-to-url "gl:t/s")
+                         "git@gitlab.com:t/s.git"))
+   (should (string-equal (magit-clone--name-to-url "sh:x/y")
+                         "git@git.sr.ht:~x/y"))
+   ;; Explicit user (long service names)
+   (should (string-equal (magit-clone--name-to-url "github:a1/b1")
+                         "git@github.com:a1/b1.git"))
+   (should (string-equal (magit-clone--name-to-url "gitlab:t1/s1")
+                         "git@gitlab.com:t1/s1.git"))
+   (should (string-equal (magit-clone--name-to-url "sourcehut:x1/y1")
+                         "git@git.sr.ht:~x1/y1"))))
+
 (ert-deftest magit-clone:--name-to-url-format-single-string ()
   (let ((magit-clone-url-format "bird@%h:%n.git")
         (magit-clone-name-alist

--- a/test/magit-tests.el
+++ b/test/magit-tests.el
@@ -330,7 +330,7 @@ Enter passphrase for key '/home/user/.ssh/id_rsa': "
            ("\\`\\(?:gh:\\)?\\([^:]+\\)\\'" "github.com" "u")))
         (magit-clone-url-format
          '(("git.example.com" . "cow@%h:~%n")
-           (nil . "git@%h:%n.git"))))
+           (t . "git@%h:%n.git"))))
     (should (string-equal (magit-clone--name-to-url "gh:a/b")
                           "git@github.com:a/b.git"))
     (should (string-equal (magit-clone--name-to-url "ex:a/b")


### PR DESCRIPTION
The patch adds a new item to the default value of `magit-clone-name-alist` so Magit knows about Sourcehut. The default value of `magit-clone-url-format` has to be also changed to accommodate the URL scheme used by Sourcehut which differs from the ones provided by Github and Gitlab.

See #4738 for more details/discussion.

Before the patch:

``` emacs-lisp
ELISP> (magit-clone--name-to-url "sh:nbarrientos/dotfiles")
*** Eval error ***  Not an url and no matching entry in ‘magit-clone-name-alist’
```

After the patch:

``` emacs-lisp
ELISP> (magit-clone--name-to-url "sh:nbarrientos/dotfiles")
"git@git.sr.ht:~nbarrientos/dotfiles"
ELISP> (magit-clone--name-to-url "sourcehut:pkal/compat")
"git@git.sr.ht:~pkal/compat"
```

In other words, invocations like:

```
M-x magit-clone u sh:nbarrientos/dotfiles
```

should now work out of the box without any custom user configuration.