### PR TITLE
Improve file renames identification

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2168,9 +2168,8 @@ section or a child thereof."
             (push (magit-decode-git-path
                    (let ((f (match-string 1)))
                      (cond
-                      ((string-match "\\`\\([^{]+\\){\\(.+\\) => \\(.+\\)}\\'" f)
-                       (concat (match-string 1 f)
-                               (match-string 3 f)))
+                      ((string-match "{.+ => \\(.+\\)}" f)
+                       (replace-match (match-string 1 f) nil t f))
                       ((string-match " => " f)
                        (substring f (match-end 0)))
                       (t f))))


### PR DESCRIPTION
Currently Magit can only identify renames in diffstats like:

```
file1 => file2
dir1/dir2/{file1 => file2}
dir1/{dir2/file1 => dir3/file2}
```

This patch allows discovering directory renames like:

```
dir1/{dir2 => dir3}/file1
{dir1 => dir2}/file1
```

by handling any construct `{A => B}` as a replacement rule and simply applying it.

This change improves the user experience when using `magit-jump-to-diffstat-or-diff`.