### PR TITLE
git-commit-buffer-message: point-at-bol -> line-beginning-position

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -784,7 +784,7 @@ Save current message first."
       (insert str)
       (goto-char (point-min))
       (when (re-search-forward (concat flush " -+ >8 -+$") nil t)
-        (delete-region (point-at-bol) (point-max)))
+        (delete-region (line-beginning-position) (point-max)))
       (goto-char (point-min))
       (flush-lines flush)
       (goto-char (point-max))


### PR DESCRIPTION
Per Emacs 29.1 obsoletion of point-at-bol in
b7e867b841f47dcff3aeaef9b5608a237386ce70.