### PR TITLE
Fix display buffer action alist syntax

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -613,7 +613,7 @@ See `magit-commit-absorb' for an alternative implementation."
              display-buffer-overriding-action))
         (when magit-commit-diff-inhibit-same-window
           (setq display-buffer-overriding-action
-                '(nil (inhibit-same-window t))))
+                '(nil (inhibit-same-window . t))))
         (magit-diff-setup-buffer rev arg (car (magit-diff-arguments)) nil)))))
 
 (add-hook 'server-switch-hook #'magit-commit-diff)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1604,7 +1604,7 @@ the Magit-Status buffer for DIRECTORY."
       (dired-jump other-window (concat directory "/."))
     (let ((display-buffer-overriding-action
            (if other-window
-               '(nil (inhibit-same-window t))
+               '(nil (inhibit-same-window . t))
              '(display-buffer-same-window))))
       (magit-status-setup-buffer directory))))
 


### PR DESCRIPTION
Technically `(t)` and `t` are equally valid non-`nil` values for the `inhibit-same-window` display buffer action alist entry, but to minimize confusion and proliferation of future mistakes, use the simpler and more widespread boolean.