### PR TITLE
manual: fix a typo

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -8797,7 +8797,7 @@ to pronounce Magit like magic, while taking into account that C and T
 do not sound the same.
 
 The German "Magie" is not pronounced the same as the English "magic",
-so if you speak German then you can use the above rational to justify
+so if you speak German then you can use the above rationale to justify
 using the former pronunciation; ~Mag{ie => it}~.
 
 You can also choose to use the former pronunciation just because you

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -10753,7 +10753,7 @@ to pronounce Magit like magic, while taking into account that C and T
 do not sound the same.
 
 The German "Magie" is not pronounced the same as the English "magic",
-so if you speak German then you can use the above rational to justify
+so if you speak German then you can use the above rationale to justify
 using the former pronunciation; @code{Mag@{ie => it@}}.
 
 You can also choose to use the former pronunciation just because you


### PR DESCRIPTION
Fixed a typo: `rational` -> `rationale`.

I've tried updating the manual and attached its output, but that also changed the `magit.texi` in two other places. Those changes look odd to me. One adds (or removes?) a newline at EOF, the other mangles an s-expression's indentation. So of course just tell me and I'll just drop that part of the commit!