### PR TITLE
GitHub Workflow Hardening

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -2,6 +2,7 @@ name: manual
 on:
   push:
     branches: master
+permissions: read-all
 jobs:
   manual:
     name: "Generate and distribute manual"

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -2,6 +2,7 @@ name: stats
 on:
   push:
     branches: master
+permissions: read-all
 jobs:
   manual:
     name: "Generate and distribute statistics"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: test
 on: [ push, pull_request ]
+permissions: read-all
 env:
   BUILD_MAGIT_LIBGIT: "false"
 jobs:
@@ -23,34 +24,39 @@ jobs:
         git config --global user.name "A U Thor"
         git config --global user.email a.u.thor@example.com
     - name: Install emacs
-      uses: purcell/setup-emacs@master
+      uses: purcell/setup-emacs@bea3d9e95785b8412caf802b320cd6de386be7a3 # v3.0
       with:
         version: ${{ matrix.emacs_version }}
     - name: Checkout compat
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: emacsmirror/compat
         path: compat
+        persist-credentials: false
     - name: Checkout dash
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: magnars/dash.el
         path: dash
+        persist-credentials: false
     - name: Checkout transient
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: magit/transient
         path: transient
+        persist-credentials: false
     - name: Checkout with-editor
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: magit/with-editor
         path: with-editor
+        persist-credentials: false
     - name: Checkout magit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: magit/magit
         path: magit
+        persist-credentials: false
     - name: Build compat
       run: make -C compat compile
     - name: Build magit


### PR DESCRIPTION
This patch aims to harden the GitHub workflows a bit. The following things were done:

- Where possible, limit the scope of the GitHub token (`secrets.GITHUB_TOKEN`) as much as possible, ideally to just `read-all` so that code and actions executed from the workflow have no chance of doing anything bad.
- Consistently set `persist-credentials: false` for the `actions/checkout` action so that the token cannot be easily grabbed by code and actions executed from the workflow.
- Pin down third-party actions to their commit instead of a version branch or `main`/`master` so that builds are more reproducible and lessen the chance of an action doing something bad. (Except for actions written and owned by GitHub itself.)
