### PR TITLE
magit-display-buffer: inhibit-same-window for magit-display-buffer-noselect

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -695,7 +695,9 @@ and `magit-post-display-buffer-hook'."
                                 magit-stash-mode
                                 magit-status-mode))))
               '(display-buffer-same-window)
-            nil))) ; display in another window
+            (if magit-display-buffer-noselect
+                t       ; ``t``to display in another window
+              nil))))   ; `nil` for display-buffer-alist
 
 (defun magit-display-buffer-same-window-except-diff-v1 (buffer)
   "Display BUFFER in the selected window except for some modes.


### PR DESCRIPTION

I prefer to use display-buffer-same-window by default via display-buffer-alist. It is the most predictable buffer switching behavior.

But there're some cases, e.g. magit-commit, magit-blame that needs to show the diff in side window. In this case, we pass `t` as `display-buffer` ACTION argument to inhibit displaying in the same window.
