### PR TITLE
Fix magit-submodule-remove when in sub-dirs & list all submodules regarding submodule's init status

### DIFF
--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -628,7 +628,9 @@ These sections can be expanded to show the respective commits."
 
 ;;;###autoload
 (defun magit-list-submodules ()
-  "Display a list of the current repository's submodules."
+  "Display a list of the current repository's submodules. By default, this only
+list populated submodules. If a prefix is given to the command, all submodules
+are listed."
   (interactive)
   (magit-submodule-list-setup magit-submodule-list-columns))
 
@@ -666,7 +668,7 @@ These sections can be expanded to show the respective commits."
         (-keep (lambda (module)
                  (let ((default-directory
                         (expand-file-name (file-name-as-directory module))))
-                   (and (file-exists-p ".git")
+                   (and (or (file-exists-p ".git") current-prefix-arg)
                         (or (not magit-submodule-list-predicate)
                             (funcall magit-submodule-list-predicate module))
                         (list module

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -378,7 +378,8 @@ to recover from making a mistake here, but don't count on it."
   (interactive
    (list (if-let ((modules (magit-region-values 'magit-module-section t)))
              (magit-confirm 'remove-modules nil "Remove %i modules" nil modules)
-           (list (magit-read-module-path "Remove module")))
+           (list (file-relative-name (magit-read-module-path "Remove module")
+                                     (magit-toplevel))))
          (magit-submodule-arguments "--force")
          current-prefix-arg))
   (when (magit-git-version< "2.12.0")


### PR DESCRIPTION
-   magit-submodule-remove: Resolve submodule path to magit-toplevel
  
  With paths relative to the current directory can cause issues when using
  using =magit-submodule-remove= in project sub-directories.

-  magit-list-submodules: List all submodules when a prefix is given
  
  By default, =magit-list-submodules= only list populated submodules.
  With a prefix is given to the command, all submodules can be
  listed now.