### PR TITLE
Add conventional commits highlights

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1414,7 +1414,13 @@ Do not add this to a hook variable."
       (magit--put-face (match-beginning 0) (1- boundary)
                        'magit-keyword-squash msg))
     (when magit-log-highlight-keywords
+      ;; Case [...]
       (while (string-match "\\[[^[]*?]" msg boundary)
+        (setq boundary (match-end 0))
+        (magit--put-face (match-beginning 0) boundary
+                         'magit-keyword msg))
+      ;; Conventional commits
+      (while (string-match "^\\(?:feat\\|fix\\|chore\\|docs\\|style\\|refactor\\|perf\\|test\\)\\(?:\\(?:[(].*[)]\\)\\|\\(?:!\\)\\)?:" msg boundary)
         (setq boundary (match-end 0))
         (magit--put-face (match-beginning 0) boundary
                          'magit-keyword msg))))


### PR DESCRIPTION
This commit aims to solve #4027 by just adding a new set of regex rules to highlight conventional commits keywords (see https://www.conventionalcommits.org/en/v1.0.0/). 

Please let me know if I missed something. 

Best. 
