### PR TITLE
Add hook `magit-after-successful-clone-hook'

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -4354,6 +4354,12 @@ The following suffixes are disabled by default. See
             (nil . "git@%h:%n.git")))
   #+END_SRC
 
+- User Option: magit-post-clone-hook ::
+
+  Hook run after the Git process has successfully finished cloning the
+  repository.  When the hook is called, ~default-directory~ is
+  let-bound to the directory where the repository has been cloned.
+
 ** Staging and Unstaging
 
 Like Git, Magit can of course stage and unstage complete files.

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -5410,6 +5410,12 @@ Example of by-hostname format strings:
 @end lisp
 @end defopt
 
+@defopt magit-post-clone-hook
+Hook run after the Git process has successfully finished cloning the
+repository.  When the hook is called, @code{default-directory} is
+let-bound to the directory where the repository has been cloned.
+@end defopt
+
 @node Staging and Unstaging
 @section Staging and Unstaging
 

--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -112,6 +112,15 @@ default.  Also see `magit-clone-name-alist'."
                                           (const :tag "Default" t))
                         :value-type (string :tag "Format"))))
 
+(defcustom magit-post-clone-hook nil
+  "Hook run after the repository has been successfully cloned.
+
+When the hook is called, `default-directory' is let-bound to the
+directory where the repository has been cloned."
+  :package-version '(magit . "3.4.0")
+  :group 'magit-commands
+  :type 'hook)
+
 ;;; Commands
 
 ;;;###autoload (autoload 'magit-clone "magit-clone" nil t)
@@ -275,6 +284,8 @@ Then show the status buffer for the new repository."
            (let ((default-directory directory))
              (magit-call-git "sparse-checkout" "init" "--cone")
              (magit-call-git "checkout" (magit-get-current-branch))))
+         (let ((default-directory directory))
+           (run-hooks 'magit-post-clone-hook))
          (with-current-buffer (process-get process 'command-buf)
            (magit-status-setup-buffer directory)))))))
 


### PR DESCRIPTION
I vaguely remember somebody trying to add something like this to Magit in the past but not sure it has been proposed in this context. My apologies in advance if this has been already deemed not necessary.

I need to run code after a new repository is cloned, but only after the Git process has successfully finished. What I want to do is to add the repository to the project's database. 

Before, I was doing something like this:

```lisp
(defun my/magit-maybe-remember-project (repository directory args)
    (when (file-directory-p directory)
      (project-remember-project (cons 'vc directory))))
(advice-add 'magit-clone-internal :after #'my/magit-maybe-remember-project)
```

However this is not good enough as there's a race condition between Git finishing (async process) and my code being executed. It could happen that `magit-clone-internal` exits but `directory` does not exist *yet*. The `when` guard is necessary because the repository may also fail to clone, hence the need to execute code only *after* a *successful* clone operation.

This patch adds a new hook allowing user code to be executed right after the Git `clone` process has exited 0, which guarantees that the repository has been correctly cloned and the target directory exists. The hook can be used like this:

```lisp
(defun my/magit-remember-project (repository directory)
  (project-remember-project (cons 'vc directory)))
(add-hook 'magit-after-successful-clone-hook #'my/magit-remember-project)
```

Thanks.