### PR TITLE
magit-patch-apply: apply patch with reverse option -R.

### DIFF
--- a/lisp/magit-patch.el
+++ b/lisp/magit-patch.el
@@ -242,7 +242,8 @@ which creates patches for all commits that are reachable from
   ["Arguments"
    ("-i" "Also apply to index" "--index")
    ("-c" "Only apply to index" "--cached")
-   ("-3" "Fall back on 3way merge" ("-3" "--3way"))]
+   ("-3" "Fall back on 3way merge" ("-3" "--3way"))
+   ("-R" "Apply reverse patch" "-R")]
   ["Actions"
    ("a"  "Apply patch" magit-patch-apply)]
   (interactive


### PR DESCRIPTION
This patch includes the reverse (`-R`) option to `magit-patch-apply`

The patch to the command is `a -> a -R -> a`

![Screenshot from 2023-01-20 20-42-23](https://user-images.githubusercontent.com/362368/213827322-896cd4ec-ea4b-4f2c-8183-41b4e4c066bd.png)

![Screenshot from 2023-01-20 21-05-12](https://user-images.githubusercontent.com/362368/213827393-e2c1d351-023e-4818-8e38-e058b1257dde.png)

 