### PR TITLE
Fix bug in `magit-log-merged`

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -2154,12 +2154,15 @@ exists in the current repository is considered its main branch."
                      (cons (magit-get "init.defaultBranch")
                            magit-main-branch-names))))))
 
-(defun magit-rev-diff-count (a b)
+(defun magit-rev-diff-count (a b &optional first-parent)
   "Return the commits in A but not B and vice versa.
-Return a list of two integers: (A>B B>A)."
+Return a list of two integers: (A>B B>A).
+
+If `first-parent' is set, traverse only first parents."
   (mapcar #'string-to-number
           (split-string (magit-git-string "rev-list"
                                           "--count" "--left-right"
+                                          (and first-parent "--first-parent")
                                           (concat a "..." b))
                         "\t")))
 

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -845,7 +845,7 @@ https://github.com/mhagger/git-when-merged."
       (if (equal m "Commit is directly on this branch.")
           (let* ((from (format "%s~%d" commit
                                (/ magit-log-merged-commit-count 2)))
-                 (to (- (car (magit-rev-diff-count branch commit))
+                 (to (- (car (magit-rev-diff-count branch commit t))
                         (/ magit-log-merged-commit-count 2)))
                  (to (if (<= to 0)
                          branch


### PR DESCRIPTION
When calculating the position of the given commit in the branch's history (for constructing the revision range), we were erroneously counting _all_ the commits that are in the branch but not ancestors of the given commit. However, revision descriptions like `branch~N` count `N` _first parent_ links; therefore, we need to calculate the position of the commit in the same way.