### PR TITLE
Docs - performance notes on macOS

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -7999,6 +7999,12 @@ faster ~vfork~ will be used.  (The creation of child processes still
 takes about twice as long on Darwin compared to Linux.)  See [fn:mac1]
 for more information.
 
+Additionally, ~git~ installed from a package manager like ~brew~ or ~nix~
+seems to be slower than the native executable. Profile the ~git~
+executable you're running against the one at ~/usr/bin/git~, and if
+you notice a notable difference try using the latter as
+~magit-git-executable~.
+
 [fn:mac1] https://lists.gnu.org/archive/html/bug-gnu-emacs/2017-04/msg00201.html
 
 *** Default Bindings

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -9894,6 +9894,12 @@ faster @code{vfork} will be used.  (The creation of child processes still
 takes about twice as long on Darwin compared to Linux.)  See @footnote{@uref{https://lists.gnu.org/archive/html/bug-gnu-emacs/2017-04/msg00201.html}}
 for more information.
 
+Additionally, @code{git} installed from a package manager like @code{brew} or @code{nix}
+seems to be slower than the native executable. Profile the @code{git}
+executable you're running against the one at @code{/usr/bin/git}, and if
+you notice a notable difference try using the latter as
+@code{magit-git-executable}.
+
 @node Default Bindings
 @subsection Default Bindings
 


### PR DESCRIPTION
I have been suffering degraded magit performance on macOS for a long time. This [superuser question](https://superuser.com/questions/1452865/git-is-working-painfully-slow) finally gave me the hint to check the performance of the two executables and turns out the native mac `git` is indeed much faster than the one I had installed using `nix`. This resulted in much faster response times from `magit`.

This PR updates the "MacOS Performance" section of the docs to note this
