### PR TITLE
Make gravatar regexes more flexible

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -3409,7 +3409,9 @@ that they are available here too.
   author's image.  The top half of the image is inserted right
   after the matched text, the bottom half on the next line in the
   same column.  The cdr specifies where to insert the committer's
-  image, accordingly.  Either the car or the cdr may be nil."
+  image, accordingly.  Either the car or the cdr may be nil.  If the
+  regular expression contains grouped subexpressions, the image is
+  inserted after the first subexpression.
 
 - User Option: magit-revision-use-hash-sections ::
 

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -423,7 +423,9 @@ two regular expressions.  The car specifies where to insert the
 author's image.  The top half of the image is inserted right
 after the matched text, the bottom half on the next line in the
 same column.  The cdr specifies where to insert the committer's
-image, accordingly.  Either the car or the cdr may be nil."
+image, accordingly.  Either the car or the cdr may be nil.  If the
+regular expression contains grouped subexpressions, the image is
+inserted after the first subexpression."
   :package-version '(magit . "2.3.0")
   :group 'magit-revision
   :type '(choice (const :tag "Don't show gravatars" nil)
@@ -2771,8 +2773,9 @@ or a ref which is not a branch, then it inserts nothing."
   (save-excursion
     (goto-char beg)
     (when (re-search-forward regexp nil t)
+      (goto-char (or (match-end 1) (match-end 0)))
       (when-let ((window (get-buffer-window)))
-        (let* ((column   (length (match-string 0)))
+        (let* ((column   (length (or (match-string 1) (match-string 0))))
                (font-obj (query-font (font-at (point) window)))
                (size     (* 2 (+ (aref font-obj 4)
                                  (aref font-obj 5))))


### PR DESCRIPTION
This extends the regex support in `magit-revision-show-gravatars` so that gravatars can be inserted before or between matched text. Existing regexes
should behave as before, but now a regex like `^\(\)Author:     ` will place the
image in column 0 (after the first matched subexpression).

Implements #4859.