### PR TITLE
magit-pull: support `--no-rebase` argument to `git pull`.

### DIFF
--- a/lisp/magit-pull.el
+++ b/lisp/magit-pull.el
@@ -42,11 +42,12 @@
 (transient-define-prefix magit-pull ()
   "Pull from another repository."
   :man-page "git-pull"
-  :incompatible '(("--ff-only" "--rebase"))
+  :incompatible '(("--ff-only" "--rebase" "--no-rebase"))
   [:description
    (lambda () (if magit-pull-or-fetch "Pull arguments" "Arguments"))
    ("-f" "Fast-forward only" "--ff-only")
    ("-r" "Rebase local commits" ("-r" "--rebase"))
+   ("-m" "Merge commits" "--no-rebase")
    ("-A" "Autostash" "--autostash" :level 7)]
   [:description
    (lambda ()


### PR DESCRIPTION
In recent versions of git, non-rebase merges are no longer the default. Instead, when trying to pull divergent branches, if `--no-rebase` is not passed explicitly (and if the default has not been overridden in config), an error message is printed to the effect that the user must specify how to deal with the divergent branch.
