### PR TITLE
Revert "Use compat-dired-marked-files"

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -263,9 +263,9 @@ is no file at point, then instead visit `default-directory'."
   (interactive "P")
   (if-let ((topdir (magit-toplevel default-directory)))
       (let ((args (car (magit-log-arguments)))
-            (files (compat-call dired-get-marked-files
-                                nil nil #'magit-file-tracked-p nil
-                                "No marked file is being tracked by Git")))
+            (files (dired-get-marked-files nil nil #'magit-file-tracked-p)))
+        (unless files
+          (user-error "No marked file is being tracked by Git"))
         (when (and follow
                    (not (member "--follow" args))
                    (not (cdr files)))
@@ -286,7 +286,10 @@ for a repository."
   (interactive (list (or (magit-toplevel)
                          (magit-read-repository t))
                      current-prefix-arg))
-  (let ((files (compat-call dired-get-marked-files nil arg nil nil t)))
+  ;; Note: The ERROR argument of `dired-get-marked-files' isn't
+  ;; available until Emacs 27.
+  (let ((files (or (dired-get-marked-files nil arg)
+                   (user-error "No files specified"))))
     (magit-status-setup-buffer repo)
     (magit-am-apply-patches files)))
 


### PR DESCRIPTION
Hello @tarsius,

I want to start a discussion about reasonable limitations of the Compat package. When I went over the Compat code base, I found one function which I think stands a bit out. This is the function `dired-get-marked-files`, which I think should not be part of Compat. I think reasonable limitations for Compat are the following:

- No advices and no overrides to avoid jeopardizing Emacs stability.
- No interactive commands to not change the user interface.
- No modes, since they are usually user facing.
- No functionality which is impossible to backport obviously, e.g., bigint support.
- No functionality which will be too slow and will result in performance bugs, e.g., `string-pixel-width` cannot be backported with sufficient performance from my current understanding.
- No backports of "application-level" functionality, this is additional functionality of programming modes, Dired, etc. This is certainly a gray zone.
- No backports of functions which are not useful to package authors and only to end users, e.g., `setopt`.
- No backports of functions of separate ELPA packages (project, xref, seq, map, org, ...). 

An additional criterion is that functions which are `:extended` and have to go through `compat-call` should have higher requirements for addition, since they increase complexity and make Compat harder to use for package authors. On top, functions which are provided as part of a `:feature` should have higher requirements for addition. Note that `:feature` backports in Compat have a certain associated cost since they use `with-eval-after-load` behind the scene. The `dired-get-marked-files` function of Compat needs both `:feature` and `:extended`. See https://github.com/emacs-compat/compat/blob/41460f01f0a808c9e8855f41417ded8cf804f442/compat-27.el#L572-L573. As this PR and reverted commit shows, the function only provides marginal benefits for package authors. It even decreases readability in my opinion.

I should make it clear that the goal of the aforementioned limitations is to keep Compat somewhat in check, such that it doesn't grow beyond limits. I think if Compat grows too large it will prevent adoption, which we surely wouldn't want. I hope that Compat can stay in reasonable size limits (maybe two times as large as it is now in the worst case). Also it is important to me to define reasonable limits since this will ensure long term maintainability and robustness of the library. I value robustness above all for such a library. All the provided functionality must be rock solid to prevent breakage. I would rather not provide cetain functionality if it jeopardizes stability - less is more in this case.

I hope you agree with me on this one, even if this change is a slight inconvenience for you. If you do and merge this PR, I would move on and deprecate `compat--dired-get-marked-files` such that it would result in a byte compilation warning and then I will remove it a few releases later. This way we should not get any compilation hiccups as we had with the recent Compat updates.

See also the discussion with @oantolin in the context of Embark, which also adopted Compat, where we talked about possible limitations of Compat: https://github.com/oantolin/embark/issues/586. 

Daniel