### PR TITLE
Support variable-pitch faces in magit-log

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -111,7 +111,8 @@ own faces for the `header-line', or for parts of the
   :group 'magit-faces)
 
 (defface magit-hash
-  '((((class color) (background light)) :foreground "grey60")
+  '((default :inherit fixed-pitch)
+    (((class color) (background light)) :foreground "grey60")
     (((class color) (background  dark)) :foreground "grey40"))
   "Face for the commit object name in the log output."
   :group 'magit-faces)


### PR DESCRIPTION
- specify `fixed-pitch` inheritance for `magit-hash` and `magit-log-graph` to make the initial part align;
- apply properties to the graph even when `--color` isn’t specified;
- apply `magit-log-graph` even when there is an ANSI color face;
- apply `magit-hash` even when there is a signature face; and
- apply `magit-hash` to the spaces used for alignment.