### PR TITLE
magit-revision-fill-summary-line: Use revision buffer's window width

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2598,7 +2598,7 @@ or a ref which is not a branch, then it inserts nothing."
             (delete-region (match-beginning 0) (1+ (match-beginning 0)))))
         (when magit-revision-fill-summary-line
           (let ((fill-column (min magit-revision-fill-summary-line
-                                  (window-width))))
+                                  (window-width (get-buffer-window nil t)))))
             (fill-region (point) (line-end-position))))
         (when magit-revision-use-hash-sections
           (save-excursion


### PR DESCRIPTION
When viewing the log and using `SPC` (`magit-diff-show-or-scroll-up`) to view commits in another window, the `(window-width)` obtained by the following code is the *selected* (log) window, which may be quite narrow due to margin usage for log buffers.  This can cause the summary line in the resulting commit buffer to be wrapped at a smaller number of characters than was specified, even though the revision buffer's window is sufficiently wide.

```el
(defun magit-insert-revision-message ()
  ...
        (when magit-revision-fill-summary-line
          (let ((fill-column (min magit-revision-fill-summary-line
                                  (window-width))))
            (fill-region (point) (line-end-position))))
```

This PR changes that to `(window-width (get-buffer-window nil t))` to find a window for the current buffer (which is the revision buffer).  This does the right thing if the revision buffer is already being displayed in a window somewhere.  If that's not the case, `get-buffer-window` returns `nil` and we get the previous behaviour; but debugging on entry to `magit-insert-revision-message` suggests that the revision buffer *is* being displayed by that point.

If the revision buffer is being displayed in more than one window, then the returned width will depend upon which of those windows was returned by `get-buffer-window`, but it will be correct for at least one of them.  The priority order appears to be `(elisp)Cyclic Window Ordering` and the *selected* window always comes first, so we needn't worry about `get-buffer-window` returning a narrower width for some other window if the *current* window is the revision window.

Version: Magit 20230219.1247 [>= 3.3.0.50-git], Git 2.17.1, Emacs 28.2, gnu/linux
