### PR TITLE
magit-commit-diff: Use environment variables supplied by emacsclient

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -563,7 +563,10 @@ See `magit-commit-absorb' for an alternative implementation."
       ;; replaced with the diff buffer.  See #2632.
       (unrecord-window-buffer nil diff-buffer))
     (message "Diffing changes to be committed (C-g to abort diffing)")
-    (let ((inhibit-quit nil))
+    (let ((inhibit-quit nil)
+	  (process-environment
+	   (append process-environment
+		   (frame-parameter nil 'environment))))
       (condition-case nil
           (magit-commit-diff-1)
         (quit)))))


### PR DESCRIPTION
When EDITOR is set to "emacsclient -t" or "emacsclient -c", `git commit -a` or `git commit <pathspec>...` now shows correct diffs.

# Expected behavior

When EDITOR is set to "emacsclient -t" or "emacsclient -c", `git commit -a` or `git commit <pathspec>...` shows correct diffs.

# Observed behavior

It shows already staged changes only.

# How to reproduce

1. export EDITOR="emacsclient -t"
2. edit some file in working tree
3. git commit -a
4. emacsclient displays 2 windows: "COMMIT_EDITMSG" and "magit-diff: repo-name"
5. "magit-diff: repo-name" doesn't show the modification made by step 2

# Limitation

When emacsclient doesn't create a new frame (e.g. EDITOR="emacsclient"), we cannot get the expected behavior.
