### PR TITLE
magit-autorevert.el: don't enable if global-auto-revert-mode is on

### DIFF
--- a/lisp/magit-autorevert.el
+++ b/lisp/magit-autorevert.el
@@ -141,7 +141,8 @@ seconds of user inactivity.  That is not desirable."
 Do not use this function elsewhere, and don't remove it from
 the `after-init-hook'.  For more information see the comments
 and code surrounding the definition of this function."
-  (if magit-auto-revert-mode
+  (if (and magit-auto-revert-mode
+           (not global-auto-revert-mode))
       (let ((start (current-time)))
         (magit-message "Turning on magit-auto-revert-mode...")
         (magit-auto-revert-mode 1)


### PR DESCRIPTION
Judging by comments inside the `(define-globalized-minor-mode magit-auto-revert-mode …`, it wasn't supposed to be enabled when global-auto-revert-mode is on. Unfortunately that doesn't quite work out, the mode is enabled disregarding the state of global-auto-revert-mode. Let's work around that by adding another check for whether the mode is enabled.

In case anybody wants a testcase for magit **prior** to this commit failing to **not** enable the mode: given this `.emacs` file:

```lisp
(use-package autorevert
  :config
  (global-auto-revert-mode 1))

(use-package magit)
```

Upon starting Emacs and opening `*Messages*` buffer you'll see a `Turning on magit-auto-revert-mode...done` line.