### PR TITLE
magit-rebase-edit-command -> magit-rebase-edit-commit

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -3236,7 +3236,7 @@ Files and Blobs from a Diff]] for more information and the key bindings.
 
   Neither the blob nor the file buffer are killed when finishing
   the rebase.  If that is undesirable, then it might be better to
-  use ~magit-rebase-edit-command~ instead of this command.
+  use ~magit-rebase-edit-commit~ instead of this command.
 
 - Key: j (magit-jump-to-diffstat-or-diff) ::
 

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -4047,7 +4047,7 @@ visited.
 
 Neither the blob nor the file buffer are killed when finishing
 the rebase.  If that is undesirable, then it might be better to
-use @code{magit-rebase-edit-command} instead of this command.
+use @code{magit-rebase-edit-commit} instead of this command.
 
 @item @kbd{j} (@code{magit-jump-to-diffstat-or-diff})
 @kindex j

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -506,7 +506,7 @@ to be visited.
 
 Neither the blob nor the file buffer are killed when finishing
 the rebase.  If that is undesirable, then it might be better to
-use `magit-rebase-edit-command' instead of this command."
+use `magit-rebase-edit-commit' instead of this command."
   (interactive (list (magit-file-at-point t t)))
   (let ((magit-diff-visit-previous-blob nil))
     (with-current-buffer


### PR DESCRIPTION
I was reading about `magit-diff-edit-hunk-commit` when I saw a comment about `magit-rebase-edit-command`, mentioned there once. I've struggled finding further information, until I realized there is command with a very similar name, `magit-rebase-edit-commit`. I might be wrong, but I assume this should be the right name to mention.

I updated the 2 files where this command is mentioned, keeping `magit.texi` unchanged.