### PR TITLE
Documentation: correct magit-toggle-margin key binding

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -2707,7 +2707,7 @@ the status buffer.
   future sessions.  Other existing buffers of the same type are not
   affected because their local values have already been initialized.
 
-- Key: L t (magit-toggle-margin) ::
+- Key: L L (magit-toggle-margin) ::
 
   Show or hide the margin.
 

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -3370,8 +3370,8 @@ the same type as that of the current buffer, and saves the value for
 future sessions.  Other existing buffers of the same type are not
 affected because their local values have already been initialized.
 
-@item @kbd{L t} (@code{magit-toggle-margin})
-@kindex L t
+@item @kbd{L L} (@code{magit-toggle-margin})
+@kindex L L
 @findex magit-toggle-margin
 Show or hide the margin.
 @end table


### PR DESCRIPTION
The margin toggle command was documented as `L t` but the transient menu shows `L L`: https://github.com/magit/magit/blob/main/lisp/magit-log.el#L520
