### PR TITLE
magit-base: consolidate ellipsis customisation

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1531,7 +1531,7 @@ The shortstat style is experimental and rather slow."
                             (or author "")
                             details-width
                             nil ?\s
-                            (if (char-displayable-p ?…) "…" ">"))
+                            (magit--ellipsis 'margin))
                            'magit-log-author)
                           " "))
              (magit--propertize-face

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -664,10 +664,7 @@ Magit status buffer."
     (concat (propertize (file-name-nondirectory program)
                         'font-lock-face 'magit-section-heading)
             " "
-            (propertize (if (stringp magit-ellipsis)
-                            magit-ellipsis
-                          ;; For backward compatibility.
-                          (char-to-string magit-ellipsis))
+            (propertize (magit--ellipsis)
                         'font-lock-face 'magit-section-heading
                         'help-echo (mapconcat #'identity (car args) " "))
             " "

--- a/test/magit-tests.el
+++ b/test/magit-tests.el
@@ -446,6 +446,45 @@ Enter passphrase for key '/home/user/.ssh/id_rsa': "
     (should (equal (get-text-property 0 'font-lock-face str) '(bold highlight)))
     (should (equal (get-text-property 2 'font-lock-face str) '(bold)))))
 
+(ert-deftest magit-base:ellipsis-default-values ()
+  (cl-letf (((symbol-function 'char-displayable-p) (lambda (_) t)))
+    (should (equal "…" (magit--ellipsis 'margin)))
+    (should (equal "…" (magit--ellipsis))))
+  (cl-letf (((symbol-function 'char-displayable-p) (lambda (_) nil)))
+    (should (equal ">" (magit--ellipsis 'margin)))
+    (should (equal "..." (magit--ellipsis)))))
+
+(ert-deftest magit-base:ellipsis-customisations-are-respected ()
+  (let ((magit-ellipsis '((margin (?· . "!")) (t (?. . ">")))))
+    (cl-letf (((symbol-function 'char-displayable-p) (lambda (_) t)))
+      (should (equal "·" (magit--ellipsis 'margin)))
+      (should (equal "." (magit--ellipsis))))
+    (cl-letf (((symbol-function 'char-displayable-p) (lambda (_) nil)))
+      (should (equal "!" (magit--ellipsis 'margin)))
+      (should (equal ">" (magit--ellipsis))))))
+
+(ert-deftest magit-base:ellipsis-fancy-nil-defaults-to-universal ()
+  (let ((magit-ellipsis '((margin (nil . "...")) (t (nil . "^^^")))))
+    (should (equal "..." (magit--ellipsis 'margin)))
+    (should (equal "^^^" (magit--ellipsis)))))
+
+(ert-deftest magit-base:ellipsis-legacy-type-allowed ()
+  (let ((magit-ellipsis "⋮"))
+    (should (equal "⋮" (magit--ellipsis 'margin)))
+    (should (equal "⋮" (magit--ellipsis)))))
+
+(ert-deftest magit-base:ellipsis-malformed-customisation-no-default ()
+  (let ((magit-ellipsis '((margin (?· . "!")))))
+    (should-error (magit--ellipsis)
+                  :type 'user-error)))
+
+(ert-deftest magit-base:ellipsis-unknown-use-case-defaults-to-default ()
+  (let ((magit-ellipsis '((margin (?· . "!")) (t (?. . ">")))))
+    (cl-letf (((symbol-function 'char-displayable-p) (lambda (_) t)))
+      (should (equal (magit--ellipsis 'foo) (magit--ellipsis))))
+    (cl-letf (((symbol-function 'char-displayable-p) (lambda (_) nil)))
+      (should (equal (magit--ellipsis 'foo) (magit--ellipsis))))))
+
 ;;; magit-tests.el ends soon
 (provide 'magit-tests)
 ;; Local Variables:


### PR DESCRIPTION
This patch centralises the generation of ellipses by extending the functionality provided by `magit-ellipsis`, allowing end users to customise for instance the ellipsis used in `magit-log` buffers.

See [discussions/4907](https://github.com/magit/magit/discussions/4907) for more background and extra information.