### PR TITLE
Introduce customization to `magit-insert-worktrees'

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -7145,6 +7145,13 @@ Also see [[man:git-worktree]]
   If the worktree at point is the one whose status is already being
   displayed in the current buffer, then show it in Dired instead.
 
+- User Option: magit-worktree-section-details-function ::
+
+  The function used to insert worktree details in
+  ~magit-insert-worktrees~. The default is to insert the worktree path,
+  but it can be used to extract ticket information from commit data,
+  for example.
+
 ** Sparse checkouts
 
 Sparse checkouts provide a way to restrict the working tree to a

--- a/lisp/magit-worktree.el
+++ b/lisp/magit-worktree.el
@@ -39,15 +39,15 @@ Used by `magit-worktree-checkout' and `magit-worktree-branch'."
   :group 'magit-commands
   :type 'function)
 
-(defcustom magit-worktree-section-details-function
-  #'magit-insert-worktree-path
-  "A function used to insert details about a given worktree.
-This function takes two arguments: the current HEAD of the
-worktree and the path to the worktree itself. It is respected by
-`magit-insert-worktrees'."
-  :package-version '(magit . "3.3.0")
-  :type 'function
-  :group 'magit-commands)
+(defcustom magit-worktree-section-summary-function
+  #'magit-worktree-format-path
+  "Function used to format information about a given worktree.
+`magit-insert-worktrees' calls this function with two arguments,
+the current HEAD of the worktree and the path to the worktree
+itself."
+  :package-version '(magit . "4.0.0")
+  :group 'magit-commands
+  :type '(choice (function-item magit-worktree-format-path) function))
 
 ;;; Commands
 
@@ -190,23 +190,19 @@ If there is only one worktree, then insert nothing."
             (magit-insert-section (worktree path)
               (insert head)
               (insert (make-string (- align (length head)) ?\s))
-              (funcall magit-worktree-section-details-function
-                       (substring-no-properties head)
-                       path)
+              (insert (funcall magit-worktree-section-summary-function
+                               (substring-no-properties head)
+                               path))
               (insert ?\n))))
         (insert ?\n)))))
 
-(defun magit-insert-worktree-path (_head path)
-  "Insert the given PATH at point.
-Use the shortest unambiguous representation of the given worktree
-PATH."
-  (insert
-   (let ((r (file-relative-name path))
-         (a (abbreviate-file-name path)))
-     (if (or (> (string-width r) (string-width a))
-             (equal r "./"))
-         a
-       r))))
+(defun magit-worktree-format-path (_head path)
+  "Return shortest unambiguous representation of PATH."
+  (let ((r (file-relative-name path))
+        (a (abbreviate-file-name path)))
+    (if (or (> (string-width r) (string-width a)) (equal r "./"))
+        a
+      r)))
 
 ;;; _
 (provide 'magit-worktree)

--- a/lisp/magit-worktree.el
+++ b/lisp/magit-worktree.el
@@ -39,6 +39,16 @@ Used by `magit-worktree-checkout' and `magit-worktree-branch'."
   :group 'magit-commands
   :type 'function)
 
+(defcustom magit-worktree-section-details-function
+  #'magit-insert-worktree-path
+  "A function used to insert details about a given worktree.
+This function takes two arguments: the current HEAD of the
+worktree and the path to the worktree itself. It is respected by
+`magit-insert-worktrees'."
+  :package-version '(magit . "3.3.0")
+  :type 'function
+  :group 'magit-commands)
+
 ;;; Commands
 
 ;;;###autoload (autoload 'magit-worktree "magit-worktree" nil t)
@@ -180,14 +190,23 @@ If there is only one worktree, then insert nothing."
             (magit-insert-section (worktree path)
               (insert head)
               (insert (make-string (- align (length head)) ?\s))
-              (insert (let ((r (file-relative-name path))
-                            (a (abbreviate-file-name path)))
-                        (if (or (> (string-width r) (string-width a))
-                                (equal r "./"))
-                            a
-                          r)))
+              (funcall magit-worktree-section-details-function
+                       (substring-no-properties head)
+                       path)
               (insert ?\n))))
         (insert ?\n)))))
+
+(defun magit-insert-worktree-path (_head path)
+  "Insert the given PATH at point.
+Use the shortest unambiguous representation of the given worktree
+PATH."
+  (insert
+   (let ((r (file-relative-name path))
+         (a (abbreviate-file-name path)))
+     (if (or (> (string-width r) (string-width a))
+             (equal r "./"))
+         a
+       r))))
 
 ;;; _
 (provide 'magit-worktree)


### PR DESCRIPTION
A common workflow when using worktrees is to have one worktree per feature-/fix-branch. In this workflow, it can be more useful to provide details on the ticket being worked rather than the location of the worktree (which might even be generated on the ticket ID).

Introduce `magit-worktree-section-details-function` to allow customizing the details inserted into worktree sections -- extracting the default behavior into `magit-insert-worktree-path`.

---

I'm not 100% sure about the changes to the documentation. I've noticed that there's no mention of `magit-insert-worktrees` in the current documentation at all -- so depending on where that should go, the new user option here might go somewhere else. Whatever you'd like to do is obviously fine by me 😃 