### PR TITLE
magit:--gpg-sign: Add default git user.signingKey

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -493,6 +493,8 @@ is run in the top-level directory of the current working tree."
   :shortarg "-S"
   :argument "--gpg-sign="
   :allow-empty t
+  :init-value (lambda (obj)
+                (oset obj value (magit-git-string "config" "user.signingKey")))
   :reader #'magit-read-gpg-signing-key)
 
 (defvar magit-gpg-secret-key-hist nil)


### PR DESCRIPTION
Allows user-specified `user.signingKey` to show up in the transient UI. This was always working before, just clarifies inside the transient interface.

Have also tested with `buildIf` in `.gitconfig` and it also picked up the change there.