### PR TITLE
manual: Remove references to git-commit-fill-column

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -4857,8 +4857,7 @@ The following functions are suitable for this hook:
 
 - Function: git-commit-turn-on-auto-fill ::
 
-  Turn on ~auto-fill-mode~ and set ~fill-column~ to the value of
-  ~git-commit-fill-column~.
+  Turn on ~auto-fill-mode~.
 
 - Function: git-commit-turn-on-flyspell ::
 
@@ -4913,11 +4912,6 @@ who has to waste some time telling you to fix your commits.
   The intended maximal length of the summary line of commit messages.
   Characters beyond this column are colorized to indicate that this
   preference has been violated.
-
-- User Option: git-commit-fill-column ::
-
-  Column beyond which automatic line-wrapping should happen in commit
-  message buffers.
 
 - User Option: git-commit-finish-query-functions ::
 

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -6013,8 +6013,7 @@ paragraphs.
 @end defun
 
 @defun git-commit-turn-on-auto-fill
-Turn on @code{auto-fill-mode} and set @code{fill-column} to the value of
-@code{git-commit-fill-column}.
+Turn on @code{auto-fill-mode}.
 @end defun
 
 @defun git-commit-turn-on-flyspell
@@ -6070,11 +6069,6 @@ who has to waste some time telling you to fix your commits.
 The intended maximal length of the summary line of commit messages.
 Characters beyond this column are colorized to indicate that this
 preference has been violated.
-@end defopt
-
-@defopt git-commit-fill-column
-Column beyond which automatic line-wrapping should happen in commit
-message buffers.
 @end defopt
 
 @defopt git-commit-finish-query-functions


### PR DESCRIPTION
git-commit-fill-column was deprecated in Magit 2.9.0. It should be removed from the manual to avoid confusion since the variable is no longer present in the codebase.


Link: https://github.com/magit/magit/commit/a277432e806af89c3bdd6046721c4db948443120
Link: https://github.com/magit/magit/issues/3067
