### PR TITLE
manual: update chapter Repository List

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -2487,8 +2487,7 @@ buffers.
 
   This command displays a list of repositories in a separate buffer.
 
-  The options ~magit-repository-directories~ and
-  ~magit-repository-directories-depth~ control which repositories are
+  The option ~magit-repository-directories~ controls which repositories are
   displayed.
 
 - User Option: magit-repolist-columns ::
@@ -2563,6 +2562,14 @@ The following functions can be added to the above option:
   - ~S~ if there is at least one staged file.
 
   Only the first one of these that applies is shown.
+
+- Function: magit-repolist-column-flags ::
+
+  This functions insert all flags as specified by
+  ~magit-repolist-column-flag-alist~.
+
+  This is an alternative to function ~magit-repolist-column-flag~,
+  which only lists the first one found.
 
 - Function: magit-repolist-column-unpulled-from-upstream ::
 

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -3100,8 +3100,7 @@ buffers.
 @deffn Command magit-list-repositories
 This command displays a list of repositories in a separate buffer.
 
-The options @code{magit-repository-directories} and
-@code{magit-repository-directories-depth} control which repositories are
+The option @code{magit-repository-directories} controls which repositories are
 displayed.
 @end deffn
 
@@ -3181,6 +3180,14 @@ By default this indicates whether there are uncommitted changes.
 @end itemize
 
 Only the first one of these that applies is shown.
+@end defun
+
+@defun magit-repolist-column-flags
+This functions insert all flags as specified by
+@code{magit-repolist-column-flag-alist}.
+
+This is an alternative to function @code{magit-repolist-column-flag},
+which only lists the first one found.
 @end defun
 
 @defun magit-repolist-column-unpulled-from-upstream


### PR DESCRIPTION
Played with the _magit-list-repositories_ and encountered two differences between implementation and the manual.

Updated the manual regarding _magit-repository-directories-depth_ and _magit-repolist-column-flags_ to the best of my knowledge.
