### PR TITLE
manual: compat is also a required library

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -149,7 +149,7 @@ Now see [[*Post-Installation Tasks]].
 
 ** Installing from the Git Repository
 
-Magit depends on the ~dash~, ~transient~ and ~with-editor~ libraries
+Magit depends on the ~compat~, ~dash~, ~transient~ and ~with-editor~ libraries
 which are available from Melpa and Melpa-Stable.  Install them using
 ~M-x package-install RET <package> RET~.  Of course you may also install
 them manually from their repository.
@@ -167,7 +167,7 @@ Then compile the libraries and generate the info manuals:
   $ make
 #+end_src
 
-If you haven't installed ~dash~, ~transient~ and ~with-editor~ from
+If you haven't installed ~compat~, ~dash~, ~transient~ and ~with-editor~ from
 Melpa or at ~/path/to/magit/../<package>~, then you have to tell ~make~
 where to find them.  To do so create the file ~/path/to/magit/config.mk~
 with the following content before running ~make~:
@@ -176,7 +176,8 @@ with the following content before running ~make~:
   LOAD_PATH  = -L ~/.emacs.d/site-lisp/magit/lisp
   LOAD_PATH += -L ~/.emacs.d/site-lisp/dash
   LOAD_PATH += -L ~/.emacs.d/site-lisp/transient/lisp
-  LOAD_PATH += -L ~/.emacs.d/site-lisp/with-editor
+  LOAD_PATH += -L ~/.emacs.d/site-lisp/with-editor/lisp
+  LOAD_PATH += -L ~/.emacs.d/site-lisp/compat
 #+end_src
 
 Finally add this to your init file:


### PR DESCRIPTION
While installing magit manually I noticed that the manual left out that the library compat is also required. I also corrected the with-editor path.