### PR TITLE
magit-clone-internal: correctly get origin value from args

### DIFF
--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -238,7 +238,7 @@ Then show the status buffer for the new repository."
 
 (defun magit-clone-internal (repository directory args &optional sparse)
   (let* ((checkout (not (member (car args) '("--bare" "--mirror"))))
-         (remote (or (transient-arg-value "--origin" args)
+         (remote (or (transient-arg-value "--origin=" args)
                      (magit-get "clone.defaultRemote")
                      "origin"))
          (set-push-default


### PR DESCRIPTION
Fixes a bug in `magit-clone-internal` where the function would mistakenly ignore the `--origin` value from args