### PR TITLE
Correct "appropriat" and "unspecifed" misspellings

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -57,6 +57,7 @@ Phil Sainty <phil@catalyst.net.nz> <phil-s@users.noreply.github.com>
 Philippe Vaucher <philippe.vaucher@gmail.com> <philippe@stvs.ch>
 Raimon Grau <raimon@3scale.net> <raimonster@gmail.com>
 Robert Irelan <robert.irelan@bytedance.com>
+Ron Parker <rdparker@gmail.com> <rparker@a123systems.com>
 Rémi Vanicat <vanicat@debian.org> <github.20.vanicat@mamber.net>
 Rüdiger Sonderfeld <ruediger@c-plusplus.net> <ruediger@c-plusplus.de>
 Sean Allred <code@seanallred.com> <allred.sean@gmail.com>

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -2518,12 +2518,12 @@ buffers.
   docstring of ~tabulated-list--get-sort~.  Alternatively ~<~ and
   ~magit-repolist-version<~ can be used as those functions are
   automatically replaced with functions that satisfy the interface.
-  Set ~:sort~ to ~nil~ to inhibit sorting; if unspecifed, then the
+  Set ~:sort~ to ~nil~ to inhibit sorting; if unspecified, then the
   column is sortable using the default sorter.
 
   You may wish to display a range of numeric columns using just one
   character per column and without any padding between columns, in
-  which case you should use an appropriat HEADER, set WIDTH to 1,
+  which case you should use an appropriate HEADER, set WIDTH to 1,
   and set ~:pad-right~ to 9. ~+~ is substituted for numbers higher than 9.
 
 #+texinfo: @noindent
@@ -7026,12 +7026,12 @@ the super-repository by adding ~magit-insert-modules~ to the hook
   docstring of ~tabulated-list--get-sort~.  Alternatively ~<~ and
   ~magit-repolist-version<~ can be used as those functions are
   automatically replaced with functions that satisfy the interface.
-  Set ~:sort~ to ~nil~ to inhibit sorting; if unspecifed, then the
+  Set ~:sort~ to ~nil~ to inhibit sorting; if unspecified, then the
   column is sortable using the default sorter.
 
   You may wish to display a range of numeric columns using just one
   character per column and without any padding between columns, in
-  which case you should use an appropriat HEADER, set WIDTH to 1,
+  which case you should use an appropriate HEADER, set WIDTH to 1,
   and set ~:pad-right~ to 9. ~+~ is substituted for numbers higher than 9.
 
 *** Submodule Transient

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -3131,12 +3131,12 @@ The @code{:sort} function has a weird interface described in the
 docstring of @code{tabulated-list--get-sort}.  Alternatively @code{<} and
 @code{magit-repolist-version<} can be used as those functions are
 automatically replaced with functions that satisfy the interface.
-Set @code{:sort} to @code{nil} to inhibit sorting; if unspecifed, then the
+Set @code{:sort} to @code{nil} to inhibit sorting; if unspecified, then the
 column is sortable using the default sorter.
 
 You may wish to display a range of numeric columns using just one
 character per column and without any padding between columns, in
-which case you should use an appropriat HEADER, set WIDTH to 1,
+which case you should use an appropriate HEADER, set WIDTH to 1,
 and set @code{:pad-right} to 9. @code{+} is substituted for numbers higher than 9.
 @end defopt
 
@@ -8765,12 +8765,12 @@ The @code{:sort} function has a weird interface described in the
 docstring of @code{tabulated-list--get-sort}.  Alternatively @code{<} and
 @code{magit-repolist-version<} can be used as those functions are
 automatically replaced with functions that satisfy the interface.
-Set @code{:sort} to @code{nil} to inhibit sorting; if unspecifed, then the
+Set @code{:sort} to @code{nil} to inhibit sorting; if unspecified, then the
 column is sortable using the default sorter.
 
 You may wish to display a range of numeric columns using just one
 character per column and without any padding between columns, in
-which case you should use an appropriat HEADER, set WIDTH to 1,
+which case you should use an appropriate HEADER, set WIDTH to 1,
 and set @code{:pad-right} to 9. @code{+} is substituted for numbers higher than 9.
 @end defopt
 

--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -93,12 +93,12 @@ The `:sort' function has a weird interface described in the
 docstring of `tabulated-list--get-sort'.  Alternatively `<' and
 `magit-repolist-version<' can be used as those functions are
 automatically replaced with functions that satisfy the interface.
-Set `:sort' to nil to inhibit sorting; if unspecifed, then the
+Set `:sort' to nil to inhibit sorting; if unspecified, then the
 column is sortable using the default sorter.
 
 You may wish to display a range of numeric columns using just one
 character per column and without any padding between columns, in
-which case you should use an appropriat HEADER, set WIDTH to 1,
+which case you should use an appropriate HEADER, set WIDTH to 1,
 and set `:pad-right' to 0.  \"+\" is substituted for numbers higher
 than 9."
   :package-version '(magit . "2.12.0")

--- a/lisp/magit-submodule.el
+++ b/lisp/magit-submodule.el
@@ -100,12 +100,12 @@ The `:sort' function has a weird interface described in the
 docstring of `tabulated-list--get-sort'.  Alternatively `<' and
 `magit-repolist-version<' can be used as those functions are
 automatically replaced with functions that satisfy the interface.
-Set `:sort' to nil to inhibit sorting; if unspecifed, then the
+Set `:sort' to nil to inhibit sorting; if unspecified, then the
 column is sortable using the default sorter.
 
 You may wish to display a range of numeric columns using just one
 character per column and without any padding between columns, in
-which case you should use an appropriat HEADER, set WIDTH to 1,
+which case you should use an appropriate HEADER, set WIDTH to 1,
 and set `:pad-right' to 0.  \"+\" is substituted for numbers higher
 than 9."
   :package-version '(magit . "2.8.0")


### PR DESCRIPTION
The words "appropriate" and "unspecified" were misspelled in the docstrings for `magit-repolist-columns` and `magit-submodule-list-columns`, as well as their entries in the manual.

I've also aliased my ancient email account in `.mailmap`, although I wasn't sure what the protocol was for updating that.  It only appeared in one pre-1.2.0 commit.