### PR TITLE
magit-unstage-file: Add missing colon to prompt

### DIFF
--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -450,7 +450,7 @@ ignored) files."
           (default (or (magit-section-value-if 'file)
                        (magit-file-relative-name)))
           (default (car (member default choices))))
-     (list (magit-completing-read-multiple "Unstage file,s" choices
+     (list (magit-completing-read-multiple "Unstage file,s: " choices
                                            nil t nil nil default))))
   (magit-with-toplevel
     ;; For backward compatibility, and because of


### PR DESCRIPTION
Prompts have `: ` at the end by convention; when missing, there is no space between the prompt and the minibuffer input, which is ugly.