### PR TITLE
Don't try to load magit-libgit when magit-inhibit-libgit is set

### DIFF
--- a/lisp/magit-core.el
+++ b/lisp/magit-core.el
@@ -37,7 +37,8 @@
 (require 'magit-transient)
 (require 'magit-autorevert)
 
-(when (magit--libgit-available-p)
+(when (and (not magit-inhibit-libgit)
+           (magit--libgit-available-p))
   (condition-case err
       (require 'magit-libgit)
     (error


### PR DESCRIPTION
The context of this patch is that the app-emacs/magit package in Gentoo Linux no longer requires app-emacs/libegit2 as a dependency; see downstream bug: https://bugs.gentoo.org/910381

However, without libegit2, magit-libgit.el can neither be byte-compiled nor loaded (because it requires libgit). Therefore the Gentoo package in its default configuration no longer installs magit-libgit.

Unfortunately, this leads to a warning message when the libegit2 module is present (for unrelated reasons) on the user's system:
```
Error while loading ‘magit-libgit’: (file-missing "Cannot open load file" "No such file or directory" "magit-libgit")
That is not fatal.  The ‘libegit2’ module just won’t be used.
```

This patch suppresses that warning message by testing `magit-inhibit-libgit` before trying to load magit-libgit.
