### PR TITLE
magit-stashed-files: Use magit-git-items directly without apply

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1119,7 +1119,7 @@ tracked file."
                    "--exclude-standard" "--directory"))
 
 (defun magit-stashed-files (stash)
-  (apply #'magit-git-items "stash" "show" "-z" "--name-only" stash))
+  (magit-git-items "stash" "show" "-z" "--name-only" stash))
 
 (defun magit-skip-worktree-files ()
   (--keep (and (= (aref it 0) ?S)

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -252,7 +252,7 @@ If nothing is staged, then try to reinstate the stashed index.
 Doing so is not possible if there are staged changes.  Do not
 remove the stash, if it cannot be applied."
   (interactive (list (magit-read-stash "Pop stash")))
-  (magit-run-git "stash" "apply" stash
+  (magit-run-git "stash" "pop" stash
                  (and (not (apply #'magit-anything-staged-p nil
                                   (magit-stashed-files stash)))
                       "--index")))


### PR DESCRIPTION
Fixes a type error preventing stashes being popped from https://github.com/magit/magit/commit/f6f4b96b641a5af75e90b5431a32369ab0f664a7. 

Since `stash` is a string, there's no need for to `apply` `magit-git-items`, it can be called directly.

EDITED: (Also fixes an issue with stashes not being popped, see comment below).

Backtrace of the error this fixes:
 ```
Debugger entered--Lisp error: (wrong-type-argument listp "stash@{0}")
  apply(magit-git-items "stash" "show" "-z" "--name-only" "stash@{0}")
  magit-stashed-files("stash@{0}")
  (apply #'magit-anything-staged-p nil (magit-stashed-files stash))
  (not (apply #'magit-anything-staged-p nil (magit-stashed-files stash)))
  (and (not (apply #'magit-anything-staged-p nil (magit-stashed-files stash))) "--index")
  (magit-run-git "stash" "apply" stash (and (not (apply #'magit-anything-staged-p nil (magit-stashed-files stash))) "--index"))
  (closure (t) (stash) "Apply a stash to the working tree and remove it fr..." (interactive (list (magit-read-stash "Pop stash"))) (magit-run-git "stash" "apply" stash (and (not (apply #'magit-anything-staged-p nil (magit-stashed-files stash))) "--index")))("stash@{0}")
  apply((closure (t) (stash) "Apply a stash to the working tree and remove it fr..." (interactive (list (magit-read-stash "Pop stash"))) (magit-run-git "stash" "apply" stash (and (not (apply #'magit-anything-staged-p nil (magit-stashed-files stash))) "--index"))) "stash@{0}")
  (unwind-protect (apply fn args) (let* ((unwind (and t (eieio-oref prefix 'unwind-suffix)))) (if unwind (progn (transient--debug 'unwind-command) (funcall unwind suffix)) nil)) (if (symbolp suffix) (advice-remove suffix advice) (let* ((new (advice--remove-function (default-value 'suffix) advice))) (if (eq new (default-value 'suffix)) nil (set-default 'suffix new)))) (eieio-oset prefix 'unwind-suffix nil))
  (closure ((advice lambda (fn &rest args) (interactive (closure (#3 (suffix . magit-stash-pop) (prefix . #<transient-prefix transient-prefix-1573f37f3b7e>)) (spec) (let (...) (unwind-protect ... ...)))) (apply '#0 fn args)) (suffix . magit-stash-pop) (prefix . #<transient-prefix transient-prefix-1573f37f3b7e>)) (fn &rest args) (unwind-protect (apply fn args) (let* ((unwind (and t (eieio-oref prefix ...)))) (if unwind (progn (transient--debug 'unwind-command) (funcall unwind suffix)) nil)) (if (symbolp suffix) (advice-remove suffix advice) (let* ((new (advice--remove-function ... advice))) (if (eq new (default-value ...)) nil (set-default 'suffix new)))) (eieio-oset prefix 'unwind-suffix nil)))((closure (t) (stash) "Apply a stash to the working tree and remove it fr..." (interactive (list (magit-read-stash "Pop stash"))) (magit-run-git "stash" "apply" stash (and (not (apply #'magit-anything-staged-p nil (magit-stashed-files stash))) "--index"))) "stash@{0}")
  apply((closure ((advice lambda (fn &rest args) (interactive (closure (#4 (suffix . magit-stash-pop) (prefix . #<transient-prefix transient-prefix-1573f37f3b7e>)) (spec) (let (...) (unwind-protect ... ...)))) (apply '#1 fn args)) (suffix . magit-stash-pop) (prefix . #<transient-prefix transient-prefix-1573f37f3b7e>)) (fn &rest args) (unwind-protect (apply fn args) (let* ((unwind (and t (eieio-oref prefix ...)))) (if unwind (progn (transient--debug 'unwind-command) (funcall unwind suffix)) nil)) (if (symbolp suffix) (advice-remove suffix advice) (let* ((new (advice--remove-function ... advice))) (if (eq new (default-value ...)) nil (set-default 'suffix new)))) (eieio-oset prefix 'unwind-suffix nil))) (closure (t) (stash) "Apply a stash to the working tree and remove it fr..." (interactive (list (magit-read-stash "Pop stash"))) (magit-run-git "stash" "apply" stash (and (not (apply #'magit-anything-staged-p nil (magit-stashed-files stash))) "--index"))) "stash@{0}")
  (lambda (fn &rest args) (interactive (closure ((advice . #0) (suffix . magit-stash-pop) (prefix . #<transient-prefix transient-prefix-1573f37f3b7e>)) (spec) (let ((abort t)) (unwind-protect (prog1 (advice-eval-interactive-spec spec) (setq abort nil)) (if abort (progn ... ... ...)))))) (apply '(closure ((advice . #0) (suffix . magit-stash-pop) (prefix . #<transient-prefix transient-prefix-1573f37f3b7e>)) (fn &rest args) (unwind-protect (apply fn args) (let* (...) (if unwind ... nil)) (if (symbolp suffix) (advice-remove suffix advice) (let* ... ...)) (eieio-oset prefix 'unwind-suffix nil))) fn args))((closure (t) (stash) "Apply a stash to the working tree and remove it fr..." (interactive (list (magit-read-stash "Pop stash"))) (magit-run-git "stash" "apply" stash (and (not (apply #'magit-anything-staged-p nil (magit-stashed-files stash))) "--index"))) "stash@{0}")
  apply((lambda (fn &rest args) (interactive (closure ((advice . #1) (suffix . magit-stash-pop) (prefix . #<transient-prefix transient-prefix-1573f37f3b7e>)) (spec) (let ((abort t)) (unwind-protect (prog1 (advice-eval-interactive-spec spec) (setq abort nil)) (if abort (progn ... ... ...)))))) (apply '(closure ((advice . #1) (suffix . magit-stash-pop) (prefix . #<transient-prefix transient-prefix-1573f37f3b7e>)) (fn &rest args) (unwind-protect (apply fn args) (let* (...) (if unwind ... nil)) (if (symbolp suffix) (advice-remove suffix advice) (let* ... ...)) (eieio-oset prefix 'unwind-suffix nil))) fn args)) (closure (t) (stash) "Apply a stash to the working tree and remove it fr..." (interactive (list (magit-read-stash "Pop stash"))) (magit-run-git "stash" "apply" stash (and (not (apply #'magit-anything-staged-p nil (magit-stashed-files stash))) "--index"))) "stash@{0}")
  magit-stash-pop("stash@{0}")
  funcall-interactively(magit-stash-pop "stash@{0}")
  command-execute(magit-stash-pop)
```

