### PR TITLE
Address XR/Relint regexp/syntax linter warnings

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -730,7 +730,7 @@ the minibuffer too."
                     (string-replace "%N" idx eob-format)))
             (save-excursion
               (goto-char (point-max))
-              (skip-syntax-backward ">s-")
+              (skip-syntax-backward ">-")
               (beginning-of-line)
               (if (and comment-start (looking-at comment-start))
                   (while (looking-at comment-start)

--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -780,7 +780,7 @@ argument."
        (replace-regexp-in-string
         (format "^\\%c.*\n?" (if (< (prefix-numeric-value arg) 0) ?+ ?-))
         "")
-       (replace-regexp-in-string "^[ \\+\\-]" "")))
+       (replace-regexp-in-string "^[ +-]" "")))
     (deactivate-mark))
    ((use-region-p)
     (call-interactively #'copy-region-as-kill))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1266,7 +1266,7 @@ Do not add this to a hook variable."
           "\\(?:\\(?:[^@\n]+@{\\(?6:[^}\n]+\\)}\0" ; date
                                                  ;;; refsub
           "\\(?10:merge \\|autosave \\|restart \\|rewritten \\|[^:\n]+: \\)?"
-          "\\(?2:.*\\)?\\)\\|\0\\)$"))             ; msg
+          "\\(?2:.*\\)\\)\\|\0\\)$"))              ; msg
 
 (defconst magit-reflog-subject-re
   (concat "\\(?1:[^ ]+\\) ?"                       ; command
@@ -1388,8 +1388,7 @@ Do not add this to a hook variable."
             (insert (magit-reflog-format-subject
                      (substring refsub 0
                                 (if (string-search ":" refsub) -2 -1))))))
-        (when msg
-          (insert (funcall magit-log-format-message-function hash msg)))
+        (insert (funcall magit-log-format-message-function hash msg))
         (when (and refs magit-log-show-refname-after-summary)
           (insert ?\s)
           (insert (magit-format-ref-labels refs)))

--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1460,7 +1460,7 @@ Do not add this to a hook variable."
       (magit--put-face (match-beginning 0) (1- boundary)
                        'magit-keyword-squash msg))
     (when magit-log-highlight-keywords
-      (while (string-match "\\[[^[]*?]" msg boundary)
+      (while (string-match "\\[[^][]*]" msg boundary)
         (setq boundary (match-end 0))
         (magit--put-face (match-beginning 0) boundary
                          'magit-keyword msg))))

--- a/lisp/magit-notes.el
+++ b/lisp/magit-notes.el
@@ -63,7 +63,7 @@
 (defun magit-notes-merging-p ()
   (let ((dir (expand-file-name "NOTES_MERGE_WORKTREE" (magit-gitdir))))
     (and (file-directory-p dir)
-         (directory-files dir nil "^[^.]"))))
+         (directory-files dir nil "\\`[^.]"))))
 
 (transient-define-infix magit-core.notesRef ()
   :class 'magit--git-variable

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -152,13 +152,13 @@ itself from the hook, to avoid further futile attempts."
                  (const :tag "Don't start a cache daemon" nil)))
 
 (defcustom magit-process-yes-or-no-prompt-regexp
-  (concat " [\[(]"
+  (concat " [([]"
           "\\([Yy]\\(?:es\\)?\\)"
           "[/|]"
           "\\([Nn]o?\\)"
           ;; OpenSSH v8 prints this.  See #3969.
           "\\(?:/\\[fingerprint\\]\\)?"
-          "[\])] ?[?:]? ?$")
+          "[])] ?[?:]? ?$")
   "Regexp matching Yes-or-No prompts of Git and its subprocesses."
   :package-version '(magit . "2.1.0")
   :group 'magit-process

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -143,7 +143,7 @@ has to be used to view and change remote related variables."
     (when (equal (magit-get "remote.pushDefault") remote)
       (magit-set new-name "remote.pushDefault"))
     (dolist (var (magit-git-lines "config" "--name-only"
-                                  "--get-regexp" "^branch\.[^.]*\.pushRemote"
+                                  "--get-regexp" "^branch\\.[^.]*\\.pushRemote"
                                   (format "^%s$" remote)))
       (magit-call-git "config" (and (not new-name) "--unset") var new-name))))
 

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -1034,7 +1034,7 @@ status buffer (i.e., the reverse of how they will be applied)."
 
 (defun magit-rebase-patches ()
   (directory-files (expand-file-name "rebase-apply" (magit-gitdir))
-                   t "^[0-9]\\{4\\}$"))
+                   t "\\`[0-9]\\{4\\}\\'"))
 
 (defun magit-sequence-insert-sequence (stop onto &optional orig)
   (let ((head (magit-rev-parse "HEAD")) done)

--- a/lisp/magit-tag.el
+++ b/lisp/magit-tag.el
@@ -127,7 +127,7 @@ defaulting to the tag at point.
 See also `magit-release-tag-regexp'.")
 
 (defvar magit-release-tag-regexp "\\`\
-\\(?1:\\(?:v\\(?:ersion\\)?\\|r\\(?:elease\\)?\\)?[-_]?\\)?\
+\\(?1:\\(?:v\\(?:ersion\\)?\\|r\\(?:elease\\)?\\)[-_]?\\)?\
 \\(?2:[0-9]+\\(?:\\.[0-9]+\\)*\
 \\(?:-[a-zA-Z0-9-]+\\(?:\\.[a-zA-Z0-9-]+\\)*\\)?\\)\\'"
   "Regexp used by `magit-tag-release' to parse release tags.

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -556,7 +556,7 @@ is run in the top-level directory of the current working tree."
 (defconst magit-font-lock-keywords
   (eval-when-compile
     `((,(concat "(\\(magit-define-section-jumper\\)\\_>"
-                "[ \t'\(]*"
+                "[ \t'(]*"
                 "\\(\\(?:\\sw\\|\\s_\\)+\\)?")
        (1 'font-lock-keyword-face)
        (2 'font-lock-function-name-face nil t))


### PR DESCRIPTION
Cc: @kyleam

1. `M-x emacs-version RET`

   ```
   GNU Emacs 30.0.50 (build 1, x86_64-pc-linux-gnu, X toolkit, cairo version 1.16.0, Xaw3d scroll bars) of 2023-08-10
   ```

2. Install GNU ELPA package [`relint`](https://elpa.gnu.org/packages/relint.html)
3. `M-x relint-directory RET path/to/magit RET`

   ```
   Relint results for /home/blc/.emacs.d/src/magit/
   lisp/magit-extras.el:733:39: In call to skip-syntax-backward: Invalid char `s' in syntax string (pos 1)
     ">s-"
      .^
   lisp/magit-extras.el:783:41: In call to replace-regexp-in-string: Duplicated `\' inside character alternative (pos 5)
     "^[ \\+\\-]"
      ......^
   lisp/magit-log.el:1269:23: In magit-log-reflog-re: Optional expression matching an empty string (pos 127)
     "^\\(?1:[^\000\n]+\\)\000\\(?5:[^\000\n]*\\)\000\\(?:\\(?:[^@\n]+@{\\(?6:[^}\n]+\\)}\000\\(?10:merge \\|autosave \\|restart \\|rewritten \\|[^:\n]+: \\)?\\(?2:.*\\)?\\)\\|\000\\)$"
      ...................................................................................................................................................................^
   lisp/magit-log.el:1463:34: In call to string-match: Suspect `[' in char alternative (pos 4)
     "\\[[^[]*?]"
      .....^
   lisp/magit-notes.el:66:36: In call to directory-files: Use \` instead of ^ in file-matching regexp (pos 0)
     "^[^.]"
      ^
   lisp/magit-process.el:155:14: Ineffective string escape `\['
   lisp/magit-process.el:161:13: Ineffective string escape `\]'
   lisp/magit-remote.el:146:58: Ineffective string escape `\.'
   lisp/magit-remote.el:146:65: Ineffective string escape `\.'
   lisp/magit-sequence.el:1037:23: In call to directory-files: Use \` instead of ^ in file-matching regexp (pos 0)
     "^[0-9]\\{4\\}$"
      ^
   lisp/magit-sequence.el:1037:36: In call to directory-files: Use \' instead of $ in file-matching regexp (pos 11)
     "^[0-9]\\{4\\}$"
      .............^
   lisp/magit-tag.el:130:59: In magit-release-tag-regexp: Optional expression matching an empty string (pos 51)
     "\\`\\(?1:\\(?:v\\(?:ersion\\)?\\|r\\(?:elease\\)?\\)?[-_]?\\)?\\(?2:[0-9]+\\(?:\\.[0-9]+\\)*\\(?:-[a-zA-Z0-9-]+\\(?:\\.[a-zA-Z0-9-]+\\)*\\)?\\)\\'"
      .............................................................^
   lisp/magit.el:559:23: Ineffective string escape `\('

   Finished -- 13 errors.
   ```

This PR tries to address all warnings (details in commit message), except for the `` Suspect `[' in char alternative `` which looks like a false positive: mattiase/xr#7

WDYT?
Thanks.