### PR TITLE
git-commit-setup: Fix auto-mode-alist for remote files

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -534,10 +534,17 @@ Used as the local value of `header-line-format', in buffer using
       (hack-dir-local-variables)
       (hack-local-variables-apply)))
   (when git-commit-major-mode
-    (let ((auto-mode-alist (list (cons (concat "\\`"
-                                               (regexp-quote buffer-file-name)
-                                               "\\'")
-                                       git-commit-major-mode)))
+    (let ((auto-mode-alist
+           ;; `set-auto-mode--apply-alist' removes the remote part from
+           ;; the file-name before looking it up in `auto-mode-alist'.
+           ;; For our temporary entry to be found, we have to modify the
+           ;; file-name the same way.
+           (list (cons (concat "\\`"
+                               (regexp-quote
+                                (or (file-remote-p buffer-file-name 'localname)
+                                    buffer-file-name))
+                               "\\'")
+                       git-commit-major-mode)))
           ;; The major-mode hook might want to consult these minor
           ;; modes, while the minor-mode hooks might want to consider
           ;; the major mode.


### PR DESCRIPTION
The filename added to `auto-mode-alist` must be adjusted to account for tramp and versions because that is how the `auto-mode-alist` matching is done.
    
This code is based on [these](https://github.com/emacs-mirror/emacs/blob/647bcec4f537d49b7a1e6d200ec787fec11ed81a/lisp/files.el#L3315-L3324) lines.

This fixes #4987

I tested this change on my desktop which has a tramp connection to files that I am working on.  Before the change, the commit message buffer opened as fundamental mode, but only only remote ssh files with tramp.  After the change, both the local files and the remote ones are honoring the `git-commit-major-mode`.