### PR TITLE
magit-revision-diff-merges-option

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -520,6 +520,13 @@ log's file filter is always honored."
   :group 'magit-revision
   :type 'boolean)
 
+(defcustom magit-revision-diff-merges-option "--cc"
+  "Diff semantics for git-show of merge commits."
+  :package-version '(magit . "3.3.1")
+  :group 'magit-revision
+  :type `(choice (const :tag "Dense-combined" "--cc")
+                 (const :tag "First-parent" "--diff-merges=first-parent")))
+
 ;;;; Visit Commands
 
 (defcustom magit-diff-visit-previous-blob t
@@ -2579,7 +2586,7 @@ Staging and applying changes is documented in info node
 (defun magit-insert-revision-diff ()
   "Insert the diff into this `magit-revision-mode' buffer."
   (magit--insert-diff t
-    "show" "-p" "--cc" "--format=" "--no-prefix"
+    "show" "-p" magit-revision-diff-merges-option "--format=" "--no-prefix"
     (and (member "--stat" magit-buffer-diff-args) "--numstat")
     magit-buffer-diff-args
     (magit--rev-dereference magit-buffer-revision)

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -524,7 +524,7 @@ log's file filter is always honored."
   "Diff semantics for git-show of merge commits."
   :package-version '(magit . "3.3.1")
   :group 'magit-revision
-  :type `(choice (const :tag "Dense-combined" "--cc")
+  :type '(choice (const :tag "Dense-combined" "--cc")
                  (const :tag "First-parent" "--diff-merges=first-parent")))
 
 ;;;; Visit Commands


### PR DESCRIPTION
The pedants will say first-parent shouldn't be the default but they're wrong.  While there's no convincing a pedant, we should at least make first-parent possible.
