### PR TITLE
Don't set comment-use-syntax to nil.

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -1070,7 +1070,6 @@ Added to `font-lock-extend-region-functions'."
                     "#"))
     (setq-local comment-start-skip (format "^%s+[\s\t]*" comment-start))
     (setq-local comment-end-skip "\n")
-    (setq-local comment-use-syntax nil)
     (setq-local git-commit--branch-name-regexp
                 (if (and (featurep 'magit-git)
                          ;; When using cygwin git, we may end up in a


### PR DESCRIPTION
Back when commit messages were always entered in `text-mode`, this was reasonable.  Now that `git-commit-major-mode` allows us to type our comments in different modes, we need to respect the comment style of whichever mode we are in.  This affects how `auto-fill-mode` can wrap lines.

The default for `comment-use-syntax` is to detect if the current major mode supports comments.  If so, it will use that.  If not, it will use the comment character that is specified in git's config (usually `#`).

This fixes #4990