### PR TITLE
magit-log-remove-graph-args: ask user to provide all variants

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -70,7 +70,9 @@
   :type 'hook)
 
 (defcustom magit-log-remove-graph-args '("--follow" "--grep" "-G" "-S" "-L")
-  "The log arguments that cause the `--graph' argument to be dropped."
+  "The log arguments that cause the `--graph' argument to be dropped. For
+a predictable and consistent behavior, add _all_ variants on separate lines,
+example: --patch, -p and -u."
   :package-version '(magit . "2.3.0")
   :group 'magit-log
   :type '(repeat (string :tag "Argument"))


### PR DESCRIPTION
It's not practical for the average user to inspect the magit-log.el source code and find whether which it uses `-u` or `--patch` internally. It's much faster and simpler for the user to just add all variants.
