### PR TITLE
Respect the value of smerge-command-prefix in magit-hunk-section-base-map

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2088,13 +2088,19 @@ keymap is the parent of their keymaps."
   :doc "Keymap for `file' sections."
   :parent magit-diff-section-base-map)
 
-(defvar-keymap magit-hunk-section-map
-  :doc "Keymap for `hunk' sections."
-  :parent magit-diff-section-base-map
-  "C-c ^ RET" #'magit-smerge-keep-current
-  "C-c ^ u"   #'magit-smerge-keep-upper
-  "C-c ^ b"   #'magit-smerge-keep-base
-  "C-c ^ l"   #'magit-smerge-keep-lower)
+(cl-labels ((add-smerge-prefix (key)
+              (thread-last
+                key
+                key-parse
+                (concat smerge-command-prefix)
+                key-description)))
+  (defvar-keymap magit-hunk-section-map
+    :doc "Keymap for `hunk' sections."
+    :parent magit-diff-section-base-map
+    (add-smerge-prefix "RET") #'magit-smerge-keep-current
+    (add-smerge-prefix "u")   #'magit-smerge-keep-upper
+    (add-smerge-prefix "b")   #'magit-smerge-keep-base
+    (add-smerge-prefix "l")   #'magit-smerge-keep-lower))
 
 (defconst magit-diff-conflict-headline-re
   (concat "^" (regexp-opt


### PR DESCRIPTION
This is just a small change where instead of having `magit-smerge-*` commands bound to the prefix `C-c ^`, which is the default for Smerge, it actually uses the value of `smerge-command-prefix`. I tried adding `:prefix smerge-command-prefix` to the `defvar-keymap` call, but it doesn't work together with the `:parent` keyword (I think it means something different than what I was thinking it did).

I've implemented it as a `cl-labels` just because I didn't think it would make a lot of sense to have that defined as a whole function since its used only in one place, but I don't feel strongly about it and can change to be a full `defun` if that's desired.