### PR TITLE
magit-diff-wash-diffstat: Allow empty renames

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -2250,7 +2250,7 @@ section or a child thereof."
             (push (magit-decode-git-path
                    (let ((f (match-string 1)))
                      (cond
-                      ((string-match "{.+ => \\(.+\\)}" f)
+                      ((string-match "{.* => \\(.*\\)}" f)
                        (replace-match (match-string 1 f) nil t f))
                       ((string-match " => " f)
                        (substring f (match-end 0)))


### PR DESCRIPTION
This patch complements 564cff8a40c2d7c8d4e679f1c7c2974c97f5f149 by also allowing following file renames formatted as follows:

* `foo/{ => bar/baz}/qux/quux.c`
* `foo/{bar/baz => }/qux/quux.c`