### PR TITLE
magit-status-setup-buffer: Ensure correct position when narrowed

### DIFF
--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -426,8 +426,8 @@ Type \\[magit-commit] to create a commit.
                                   magit-status-use-buffer-arguments))
          (file (and magit-status-goto-file-position
                     (magit-file-relative-name)))
-         (line (and file (line-number-at-pos)))
-         (col  (and file (current-column)))
+         (line (and file (save-restriction (widen) (line-number-at-pos))))
+         (col  (and file (save-restriction (widen) (current-column))))
          (buf  (magit-setup-buffer #'magit-status-mode nil
                  (magit-buffer-diff-args  (nth 0 d))
                  (magit-buffer-diff-files (nth 1 d))


### PR DESCRIPTION
-------

When using `M-x magit-status-here` in a narrowed buffer, something like this is necessary to visit the corresponding position of the file.

~I thought about using `pcase-let*` instead to avoid having to `widen` twice, but I also didn't want to clutter the diff and `git blame` sessions.~

I changed my mind, `save-restriction` and `widen` might not necessarily be fast.