### PR TITLE
Correct target of obsolete alias git-commit-known-pseudo-headers

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -1233,7 +1233,7 @@ Elisp doc-strings, including this one.  Unlike in doc-strings,
   "git-commit 4.0.0")
 (define-obsolete-variable-alias
   'git-commit-known-pseudo-headers
-  'git-commit-trailer
+  'git-commit-trailers
   "git-commit 4.0.0")
 (define-obsolete-face-alias
  'git-commit-pseudo-header

--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -142,6 +142,11 @@
 (defvar font-lock-end)
 (defvar recentf-exclude)
 
+(define-obsolete-variable-alias
+  'git-commit-known-pseudo-headers
+  'git-commit-trailers
+  "git-commit 4.0.0")
+
 ;;; Options
 ;;;; Variables
 
@@ -1230,10 +1235,6 @@ Elisp doc-strings, including this one.  Unlike in doc-strings,
 (define-obsolete-function-alias
   'git-commit-insert-header
   'git-commit--insert-ident-trailer
-  "git-commit 4.0.0")
-(define-obsolete-variable-alias
-  'git-commit-known-pseudo-headers
-  'git-commit-trailers
   "git-commit 4.0.0")
 (define-obsolete-face-alias
  'git-commit-pseudo-header


### PR DESCRIPTION
Fixes typo in the original change.