### PR TITLE
Add support for custom keywords similar to `squash!` / `fixup!`

### DIFF
--- a/lisp/magit-log.el
+++ b/lisp/magit-log.el
@@ -1476,6 +1476,10 @@ Do not add this to a hook variable."
       (setq boundary (match-end 0))
       (magit--put-face (match-beginning 0) (1- boundary)
                        'magit-keyword-squash msg))
+    (when (string-match "^\\(?:[a-zA-Z_][-a-zA-Z_]+[a-zA-Z_]\\)! " msg boundary)
+      (setq boundary (match-end 0))
+      (magit--put-face (match-beginning 0) (1- boundary)
+                       'magit-keyword-custom msg))
     (when magit-log-highlight-keywords
       (while (string-match "\\[[^][]*]" msg boundary)
         (setq boundary (match-end 0))

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -197,6 +197,11 @@ and/or `magit-branch-remote-head'."
   "Face for squash! and fixup! keywords in commit messages."
   :group 'magit-faces)
 
+(defface magit-keyword-custom
+  '((t :inherit font-lock-warning-face :foreground "orange red"))
+  "Face for custom xxx! keywords in commit messages."
+  :group 'magit-faces)
+
 (defface magit-signature-good
   '((t :foreground "green"))
   "Face for good signatures."


### PR DESCRIPTION
to support project/user specific markings.

For example:
- `wip! this commit isn't finished yet`
- `do-not-merge! this commit (whatever reasons are)`
  - eg printf-debugging commit
- `test! this commit isn't finished yet, it requires test`
