### PR TITLE
magit-process-interrupt: support sending SIGINT to running subprocess

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -1825,7 +1825,13 @@ sections are available.  There is one additional command.
 
 - Key: k (magit-process-kill) ::
 
-  This command kills the process represented by the section at point.
+  This command kills the process represented by the section at point
+  by sending the signal ~SIGKILL~.
+
+- Key: M-x magit-process-interrupt ::
+
+  This command kills the process represented by the section at point
+  by sending the signal ~SIGINT~.
 
 - Variable: magit-git-debug ::
 

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -2364,7 +2364,13 @@ sections are available.  There is one additional command.
 @item @kbd{k} (@code{magit-process-kill})
 @kindex k
 @findex magit-process-kill
-This command kills the process represented by the section at point.
+This command kills the process represented by the section at point
+by sending the signal @code{SIGKILL}.
+
+@item @kbd{M-x magit-process-interrupt}
+@findex magit-process-interrupt
+This command kills the process represented by the section at point
+by sending the signal @code{SIGINT}.
 @end table
 
 @defvar magit-git-debug

--- a/lisp/magit-base.el
+++ b/lisp/magit-base.el
@@ -162,6 +162,7 @@ The value has the form ((COMMAND nil|PROMPT DEFAULT)...).
     (const trash-module-gitdirs)
     (const stash-apply-3way)
     (const kill-process)
+    (const interrupt-process)
     (const safe-with-wip)))
 
 (defcustom magit-no-confirm '(set-and-push)

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -357,6 +357,15 @@ optional NODISPLAY is non-nil also display it."
     (magit-confirm 'kill-process)
     (kill-process process)))
 
+(defun magit-process-interrupt ()
+  "Interrupt the process at point."
+  (interactive)
+  (when-let ((process (magit-section-value-if 'process)))
+    (unless (eq (process-status process) 'run)
+      (user-error "Process isn't running"))
+    (magit-confirm 'interrupt-process)
+    (interrupt-process process)))
+
 ;;; Synchronous Processes
 
 (defvar magit-process-raise-error nil)


### PR DESCRIPTION
This addresses https://github.com/magit/magit/discussions/5086, by providing a nicer workflow for canceling long-running actions (often pre-commit hooks, but could be anything) while giving those processes a chance to clean up after themselves gracefully.

I don't know where/whether we'd want to add this to the docs somewhere. I'm happy to try to help with that, and also happy for a maintainer to jump in and do it if they prefer.
