### PR TITLE
magit-refs: Fix error when HEAD is not symbolic

### DIFF
--- a/lisp/magit-refs.el
+++ b/lisp/magit-refs.el
@@ -589,7 +589,9 @@ line is inserted at all."
               (when (magit-refs--insert-refname-p branch)
                 (magit-insert-section (branch branch t)
                   (let ((headp (equal branch head))
-                        (abbrev (if magit-refs-show-remote-prefix
+                        (abbrev (if (or magit-refs-show-remote-prefix
+                                        (not (string-prefix-p (concat remote "/")
+                                                              branch)))
                                     branch
                                   (substring branch (1+ (length remote))))))
                     (magit-insert-heading


### PR DESCRIPTION
If the HEAD (tracking) ref of a remote is not symbolic, it will not hit the `(if head-branch` check.

We should probably not be chopping off prefixes blindly anyway.

---

Thanks!