### PR TITLE
magit-tag-release: also read message for --sign/--local-user

### DIFF
--- a/lisp/magit-tag.el
+++ b/lisp/magit-tag.el
@@ -192,7 +192,9 @@ like \"/path/to/foo-bar\"."
                     (match-string 2 tag)))
           (args (magit-tag-arguments)))
        (list tag
-             (and (member "--annotate" args)
+             (and (or (member "--annotate" args)
+                      (member "--sign" args)
+                      (seq-some (lambda (x) (string-prefix-p "--local-user" x)) args))
                   (read-string
                    (format "Message for %S: " tag)
                    (cond ((and pver (string-match (regexp-quote pver) pmsg))


### PR DESCRIPTION
git tag requires a message for all "heavy" tags that have an associated tag object.  --annotate, --sign, and --local-user= all create tag objects.  Make magit-tag-release read a message in all of these cases.
