### PR TITLE
* lisp/magit-section.el: Allow several functions as arguments

### DIFF
--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -2179,10 +2179,15 @@ again use `remove-hook'."
 
 (defun magit-disable-section-inserter (fn)
   "Disable the section inserter FN in the current repository.
+
+FN can be a single section inserter or a list of inserters.
+
 It is only intended for use in \".dir-locals.el\" and
 \".dir-locals-2.el\".  Also see info node `(magit)Per-Repository
 Configuration'."
-  (cl-pushnew fn magit-disabled-section-inserters))
+  (unless (listp fn) (cl-callf list fn))
+  (dolist (each fn)
+    (cl-pushnew each magit-disabled-section-inserters)))
 
 (put 'magit-disable-section-inserter 'safe-local-eval-function t)
 


### PR DESCRIPTION
-------

The function `magit-disable-section-inserter` is convenient in a
.dir-locals.el file to disable a section per repository. When more
than one section should be disabled, this function can be called
several times. This commit makes disabling several sections easier by
allowing more than one section as argument.