### PR TITLE
Specify the shade of "green"

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -278,7 +278,7 @@ Also see https://github.com/magit/magit/issues/4720
 and https://debbugs.gnu.org/cgi/bugreport.cgi?bug=62093.")
 
 (defface magit-process-ok
-  '((t :inherit magit-section-heading :foreground "green"))
+  '((t :inherit magit-section-heading :foreground "#00ff00"))
   "Face for zero exit-status."
   :group 'magit-faces)
 

--- a/lisp/magit-reflog.el
+++ b/lisp/magit-reflog.el
@@ -71,7 +71,7 @@ AUTHOR-WIDTH has to be an integer.  When the name of the author
 
 ;;; Faces
 
-(defface magit-reflog-commit '((t :foreground "green"))
+(defface magit-reflog-commit '((t :foreground "#00ff00"))
   "Face for commit commands in reflogs."
   :group 'magit-faces)
 
@@ -79,7 +79,7 @@ AUTHOR-WIDTH has to be an integer.  When the name of the author
   "Face for amend commands in reflogs."
   :group 'magit-faces)
 
-(defface magit-reflog-merge '((t :foreground "green"))
+(defface magit-reflog-merge '((t :foreground "#00ff00"))
   "Face for merge, checkout and branch commands in reflogs."
   :group 'magit-faces)
 
@@ -95,7 +95,7 @@ AUTHOR-WIDTH has to be an integer.  When the name of the author
   "Face for rebase commands in reflogs."
   :group 'magit-faces)
 
-(defface magit-reflog-cherry-pick '((t :foreground "green"))
+(defface magit-reflog-cherry-pick '((t :foreground "#00ff00"))
   "Face for cherry-pick commands in reflogs."
   :group 'magit-faces)
 

--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -198,7 +198,7 @@ and/or `magit-branch-remote-head'."
   :group 'magit-faces)
 
 (defface magit-signature-good
-  '((t :foreground "green"))
+  '((t :foreground "#00ff00"))
   "Face for good signatures."
   :group 'magit-faces)
 


### PR DESCRIPTION
This works around Emacs bug 66538 (https://debbugs.gnu.org/cgi/bugreport.cgi?bug=66538).
