### PR TITLE
Fixed typo in magit-section--enable-long-lines-shortcuts warning

### DIFF
--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -1761,7 +1761,7 @@ invisible."
     (display-warning 'magit "\
 Emacs has enabled redisplay shortcuts
 in this buffer because there are lines whose length go beyond
-`long-line-treshhold' \(%s characters).  As a result, section
+`long-line-treshold' \(%s characters).  As a result, section
 highlighting and the special appearance of the region has been
 disabled.  Some existing highlighting might remain in effect.
 


### PR DESCRIPTION
This pull request renames a variable containing a typo in a warning from function `magit-section--enable-long-lines-shortcuts`.

In this warning, the Emacs variable in question `long-line-threshold` was written as `long-line-threshhold`.

This caused me an issue while killing the variable from the warning and yanking it into the command `describe-variable`.