### PR TITLE
docs only: typo: replace "strick" with "strict"

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -361,7 +361,7 @@ file, but then only a subset of the commands is available.
 
 The global key bindings mentioned in the previous two paragraphs are
 quite inconvenient.  We recommend using ~C-c g~ and ~C-c f~ instead, but
-cannot use those key sequences by default because they are strickly
+cannot use those key sequences by default because they are strictly
 reserved for bindings added by the user.  See [[*Global Bindings]], if you
 want to explicitly opt-in to the recommended key bindings.
 
@@ -7621,7 +7621,7 @@ By default Magit defines a few global key bindings.  These bindings
 are a compromise between providing no bindings at all and providing
 the better bindings I would have liked to use instead.  Magit cannot
 provide the set of recommended bindings by default because those key
-sequences are stricktly reserved for bindings added by the user.
+sequences are strictly reserved for bindings added by the user.
 Also see [[*Global Bindings]] and [[info:elisp#Key Binding Conventions]].
 
 To use the recommended bindings, add this to your init file and

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -694,7 +694,7 @@ file, but then only a subset of the commands is available.
 
 The global key bindings mentioned in the previous two paragraphs are
 quite inconvenient.  We recommend using @code{C-c g} and @code{C-c f} instead, but
-cannot use those key sequences by default because they are strickly
+cannot use those key sequences by default because they are strictly
 reserved for bindings added by the user.  See @ref{Global Bindings}, if you
 want to explicitly opt-in to the recommended key bindings.
 
@@ -9476,7 +9476,7 @@ By default Magit defines a few global key bindings.  These bindings
 are a compromise between providing no bindings at all and providing
 the better bindings I would have liked to use instead.  Magit cannot
 provide the set of recommended bindings by default because those key
-sequences are stricktly reserved for bindings added by the user.
+sequences are strictly reserved for bindings added by the user.
 Also see @ref{Global Bindings} and @ref{Key Binding Conventions,,,elisp,}.
 
 To use the recommended bindings, add this to your init file and


### PR DESCRIPTION
## Changes I propose
This pull request applies to docs only; in particular, it applies to only `magit.org`.

In that file I replace:
- "strickly" -> "strictly"
- "stricktly" -> "strictly"

## Reason for changes
I change this because I find results on Google for "strictly" but not "strick(t)ly"

## `magit.texi` and `magit-section.texi`
I ask the maintainers to make `magit.texi`. 

I commit changes only to `magit.org`. I made `magit.texi` with
```shell
make texi
```
I did not commit the resulting `magit-section.texi` or `magit.texi` because the versions I made locally removed the newline at the end of the file, and in the section of `PULL_REQUEST_TEMPLATE` "Do NOT use Github to edit files and create commit messages" I saw a concern about newlines at end of commits. So I was cautious about (a) newlines at the end of doc files and (b) editing the generated files.

Separately I tried to make `magit.texi` using `C-c C-e i t` in the buffer visiting `magit.org`. `C-c C-e` brought up buffer `*Org Export Dispatcher*` but `i` gives error `Invalid key`, and the menu does not include an option that uses `i`. 

`M-x org-version` gives `Org mode version 9.6.6`. I thought that might work because it is later than the version listed [in the GitHub magit wiki](https://github.com/magit/magit/wiki/Documentation-tools-and-conventions) (i.e. `release_9.5.2-390-g282a01f22`), but the version I have is not a development version, and that could be the important difference.