### PR TITLE
docs/magit.org: Use correct key E M for magit-ediff-resolve-all

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -3547,7 +3547,7 @@ information on how to use Ediff itself, see info:ediff.
   already resolved some conflicts, that means that these buffers
   may not contain the actual versions from the respective blobs.
 
-- Key: E m (magit-ediff-resolve-all) ::
+- Key: E M (magit-ediff-resolve-all) ::
 
   This command allows you to resolve all conflicts in the file at
   point using Ediff.  If there is no file at point or if it doesn't

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -4417,8 +4417,8 @@ markers in the worktree file.  Because you and/or Git may have
 already resolved some conflicts, that means that these buffers
 may not contain the actual versions from the respective blobs.
 
-@item @kbd{E m} (@code{magit-ediff-resolve-all})
-@kindex E m
+@item @kbd{E M} (@code{magit-ediff-resolve-all})
+@kindex E M
 @findex magit-ediff-resolve-all
 This command allows you to resolve all conflicts in the file at
 point using Ediff.  If there is no file at point or if it doesn't


### PR DESCRIPTION
The key for `magit-ediff-resolve-all` is wrong in the doc. Instead of `E m` it should be `E M`,