### PR TITLE
spinoff can look at push branches too

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -5161,9 +5161,10 @@ The variables are described in [[*Branch Git Variables]].
 
   This command creates and checks out a new branch starting at and
   tracking the current branch.  That branch in turn is reset to the
-  last commit it shares with its upstream.  If the current branch has
-  no upstream or no unpushed commits, then the new branch is created
-  anyway and the previously current branch is not touched.
+  last commit it shares with its upstream or push remote.  If the
+  current branch has no upstream or no unpushed commits, then the new
+  branch is created anyway and the previously current branch is not
+  touched.
 
   This is useful to create a feature branch after work has already
   began on the old branch (likely but not necessarily "master").

--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -504,7 +504,8 @@ from the source branch's upstream, then an error is raised."
     (message "Staying on HEAD due to uncommitted changes")
     (setq checkout t))
   (if-let ((current (magit-get-current-branch)))
-      (let ((tracked (magit-get-upstream-branch current))
+      (let ((tracked (or (magit-get-upstream-branch current)
+                         (magit-get-push-branch current)))
             base)
         (when from
           (unless (magit-rev-ancestor-p from current)


### PR DESCRIPTION
I often wish I had something like `magit-branch-spinoff` but that respected `pushRemote` instead of merely checking the "upstream" of the branch. I tried to surface this need in https://github.com/magit/magit/discussions/4822 but today I looked more closely at the code and I thought I could see a way to implement it easily, so I thought I would upgrade my discussion into a PR.

I tried to test this by:

- Using `C-x C-e` on my changed version
- Going to a repo with a feature branch that I had pushed
- Adding an empty commit to that branch with the message "Test"
- Using `b s` to create a new branch called `bloop`
- Viewing the log to verify that `bloop` contained the new commit and was based off the pushed state of the feature branch
- Switching to the feature branch and verifying that it no longer had any unpushed commits

Thanks for your efforts on magit!
