### PR TITLE
test: define committer info for git-commit

### DIFF
--- a/test/magit-tests.el
+++ b/test/magit-tests.el
@@ -37,12 +37,11 @@
   (declare (indent 0) (debug t))
   (let ((dir (make-symbol "dir")))
     `(let ((,dir (file-name-as-directory (make-temp-file "magit-" t)))
-           (process-environment process-environment)
            (magit-git-global-arguments
             (nconc (list "-c" "protocol.file.allow=always")
+                   (list "-c" "user.name=\"A U Thor\"")
+                   (list "-c" "user.email=\"a.u.thor@example.com\"")
                    magit-git-global-arguments)))
-       (push "GIT_AUTHOR_NAME=A U Thor" process-environment)
-       (push "GIT_AUTHOR_EMAIL=a.u.thor@example.com" process-environment)
        (condition-case err
            (cl-letf (((symbol-function #'message) (lambda (&rest _))))
              (let ((default-directory (file-truename ,dir)))


### PR DESCRIPTION
`magit-with-test-directory` adds "GIT_AUTHOR_NAME" and "GIT_AUTHOR_EMAIL" to the environment.  However, git-commit also requires the name and e-mail of the committer:

```
  $ testdir=$(mktemp -d)
  $ cd $testdir
  $ git -c init.defaultBranch=main init
  Initialized empty Git repository in /tmp/tmp.9kL3SoUfii/.git/
  $ GIT_AUTHOR_NAME='A. U. Thor' GIT_AUTHOR_EMAIL=a.u.thor@example.com \
  > git commit --allow-empty -m init
  Committer identity unknown

  *** Please tell me who you are.

  Run

    git config --global user.email "you@example.com"
    git config --global user.name "Your Name"

  to set your account's default identity.
  Omit --global to set the identity only in this repository.

  fatal: empty ident name (for <aztest@ulthar.dreamlands>) not allowed
  $ GIT_AUTHOR_NAME='A. U. Thor' GIT_AUTHOR_EMAIL=a.u.thor@example.com \
  > GIT_COMMITTER_NAME='A. U. Thor' GIT_COMMITTER_EMAIL=a.u.thor@example.com \
  > git commit --allow-empty -m init
  [master (root-commit) 6eac356] init
```

When running `make test`, it leads to failures like this:

```
  Keeping test directory:
    /tmp/magit-dOToha/
  Test magit-get backtrace:
    signal(magit-git-error ("empty ident name (for <aztest@ulthar.dreaml
    (condition-case err (let* ((vnew #'(lambda (&rest _))) (old (symbol-
    (let ((dir (file-name-as-directory (make-temp-file "magit-" t))) (pr
    (closure (t) nil (let ((dir (file-name-as-directory (make-temp-file
    ert--run-test-internal(#s(ert--test-execution-info :test #s(ert-test
    ert-run-test(#s(ert-test :name magit-get :documentation nil :body (c
    ert-run-or-rerun-test(#s(ert--stats :selector t :tests ... :test-map
    ert-run-tests(t #f(compiled-function (event-type &rest event-args) #
    ert-run-tests-batch(nil)
    ert-run-tests-batch-and-exit()
    (progn (load-file "../test/magit-tests.el") (ert-run-tests-batch-and
    command-line-1(("-L" "../lisp" "-L" "/usr/share/emacs/site-lisp/elpa
    command-line()
    normal-top-level()
  Test magit-get condition:
      (magit-git-error "empty ident name (for <aztest@ulthar.dreamlands>) not allowed (in /tmp/magit-dOToha/remote/)")
     FAILED  13/31  magit-get (0.073941 sec) at magit-tests.el:182
```

Rather than adding "GIT_COMMITTER_NAME" and "GIT_COMMITTER_EMAIL" as well, replace the environment variables with the "user.name" and "user.email" config variables.
