### PR TITLE
Add --force to magit-pull and magit-fetch

### DIFF
--- a/lisp/magit-fetch.el
+++ b/lisp/magit-fetch.el
@@ -37,7 +37,8 @@
   ["Arguments"
    ("-p" "Prune deleted branches" ("-p" "--prune"))
    ("-t" "Fetch all tags" ("-t" "--tags"))
-   (7 "-u" "Fetch full history" "--unshallow")]
+   (7 "-u" "Fetch full history" "--unshallow")
+   ("-F" "Force" ("-f" "--force"))]
   ["Fetch from"
    ("p" magit-fetch-from-pushremote)
    ("u" magit-fetch-from-upstream)

--- a/lisp/magit-pull.el
+++ b/lisp/magit-pull.el
@@ -47,7 +47,8 @@
    (lambda () (if magit-pull-or-fetch "Pull arguments" "Arguments"))
    ("-f" "Fast-forward only" "--ff-only")
    ("-r" "Rebase local commits" ("-r" "--rebase"))
-   ("-A" "Autostash" "--autostash" :level 7)]
+   ("-A" "Autostash" "--autostash" :level 7)
+   ("-F" "Force" ("-f" "--force"))]
   [:description
    (lambda ()
      (if-let ((branch (magit-get-current-branch)))


### PR DESCRIPTION
git pull and git fetch allow the --force option to force update local branches. From man git-fetch(1):

    -f, --force
        When git fetch is used with <src>:<dst> refspec it may refuse to
        update the local branch as discussed in the <refspec> part
        below. This option overrides that check.

Add that option to magit-pull and magit-fetch. Use -F as the suffix to be consistent with magit-push.