### PR TITLE
magit-dir-checkout: new function to reset dir

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -6356,6 +6356,11 @@ Also see [[man:git-reset]]
   Update file in the working tree and index to the contents from a
   revision.  Both the revision and file are read from the user.
 
+- Key: X d (magit-dir-checkout) ::
+
+  Update directory in the working tree and index to the contents from
+  a revision. Both the revision and directory are read from the user.
+
 ** Stashing
 
 Also see [[man:git-stash]]

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -507,7 +507,7 @@ Git, then fallback to using `delete-file'."
 (defvar magit-read-file-hist nil)
 (defvar magit-read-dir-hist nil)
 
-(defun magit-read-dir-from-rev (rev prompt &optional default)
+(defun magit-read-dir-from-rev (rev prompt)
   (let ((dirs (magit-revision-directories rev)))
     (magit-completing-read
      prompt dirs nil t nil 'magit-read-dir-hist)))

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -493,9 +493,24 @@ Git, then fallback to using `delete-file'."
   (magit-with-toplevel
     (magit-run-git "checkout" rev "--" file)))
 
+(defun magit-dir-checkout (rev dir)
+  "Checkout DIR from REV."
+  (interactive
+   (let ((rev (magit-read-branch-or-commit
+               "Checkout from revision" magit-buffer-revision)))
+     (list rev (magit-read-dir-from-rev rev "Checkout dir"))))
+  (magit-with-toplevel
+    (magit-run-git "checkout" rev "--" dir)))
+
 ;;; Read File
 
 (defvar magit-read-file-hist nil)
+(defvar magit-read-dir-hist nil)
+
+(defun magit-read-dir-from-rev (rev prompt &optional default)
+  (let ((dirs (magit-revision-directories rev)))
+    (magit-completing-read
+     prompt dirs nil t nil 'magit-read-dir-hist)))
 
 (defun magit-read-file-from-rev (rev prompt &optional default)
   (let ((files (magit-revision-files rev)))

--- a/lisp/magit-reset.el
+++ b/lisp/magit-reset.el
@@ -36,7 +36,8 @@
   :man-page "git-reset"
   [["Reset"
     ("b" "branch" magit-branch-reset)
-    ("f" "file"   magit-file-checkout)]
+    ("f" "file"   magit-file-checkout)
+    ("d" "dir"    magit-dir-checkout)]
    ["Reset this"
     ("m" "mixed    (HEAD and index)" magit-reset-mixed)
     ("s" "soft     (HEAD only)"      magit-reset-soft)


### PR DESCRIPTION
- Reset a directory to a given commit.
- Reading the commit and directory from users using existing functions. 
- Adding new binding `X d`.
- Mention in the Org documentation.