### PR TITLE
magit--straight-chase-links: replace with magit--chase-links

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -598,7 +598,7 @@ the output in the kill ring.
                          '("magit.el" "magit.el.gz")))
       (let ((load-suffixes (reverse load-suffixes))) ; prefer .el than .elc
         (setq toplib (locate-library "magit"))))
-    (setq toplib (and toplib (magit--straight-chase-links toplib)))
+    (setq toplib (and toplib (magit--chase-links toplib)))
     (push toplib debug)
     (when toplib
       (let* ((topdir (file-name-directory toplib))
@@ -606,7 +606,7 @@ the output in the kill ring.
                       ".git" (file-name-directory
                               (directory-file-name topdir))))
              (static (locate-library "magit-version.el" nil (list topdir)))
-             (static (and static (magit--straight-chase-links static))))
+             (static (and static (magit--chase-links static))))
         (or (progn
               (push 'repo debug)
               (when (and (file-exists-p gitdir)


### PR DESCRIPTION
Refactor function to work with straight.el and Elpaca.

magit-version: use magit--chase-links
