### PR TITLE
Percent escape magit-confirm prompts

### DIFF
--- a/lisp/magit-apply.el
+++ b/lisp/magit-apply.el
@@ -548,9 +548,11 @@ of a side, then keep that side without prompting."
       (funcall apply section "--reverse" "--index"))))
 
 (defun magit-discard-hunks (sections)
-  (magit-confirm 'discard (format "Discard %s hunks from %s"
+  (magit-confirm 'discard (format "Discard %d hunks from %s"
                                   (length sections)
-                                  (magit-section-parent-value (car sections))))
+                                  (string-replace
+                                   "%" "%%"
+                                   (magit-section-parent-value (car sections)))))
   (magit-discard-apply-n sections #'magit-apply-hunks))
 
 (defun magit-discard-apply-n (sections apply)
@@ -738,9 +740,11 @@ so causes the change to be applied to the index as well."
 
 (defun magit-reverse-hunks (sections args)
   (magit-confirm 'reverse
-    (format "Reverse %s hunks from %s"
+    (format "Reverse %d hunks from %s"
             (length sections)
-            (magit-section-parent-value (car sections))))
+            (string-replace
+             "%" "%%"
+             (magit-section-parent-value (car sections)))))
   (magit-reverse-apply sections #'magit-apply-hunks args))
 
 (defun magit-reverse-file (section args)

--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -634,11 +634,11 @@ prompt is confusing."
         (cond
          ((magit-confirm 'delete-branch-on-remote
             (format "Deleting local %s.  Also delete on %s"
-                    (magit-ref-fullname (car branches))
-                    remote)
+                    (string-replace "%" "%%" (magit-ref-fullname (car branches)))
+                    (string-replace "%" "%%" remote))
             (format "Deleting %d local refs.  Also delete on %s"
                     (length refs)
-                    remote)
+                    (string-replace "%" "%%" remote))
             'noabort refs)
           ;; The ref may actually point at another rev on the remote,
           ;; but this is better than nothing.
@@ -724,7 +724,8 @@ prompt is confusing."
           (when (member refspec refspecs)
             (if (and (length= refspecs 1)
                      (magit-confirm 'delete-pr-remote
-                       (format "Also delete remote %s (%s)" remote
+                       (format "Also delete remote %s (%s)"
+                               (string-replace "%" "%%" remote)
                                "no pull-request branch remains")
                        nil t))
                 (magit-call-git "remote" "rm" remote)

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -206,8 +206,10 @@ the now stale refspecs.  Other stale branches are not removed."
         (if (if (length= stale 1)
                 (pcase-let ((`(,refspec . ,refs) (car stale)))
                   (magit-confirm 'prune-stale-refspecs
-                    (format "Prune stale refspec %s and branch %%s" refspec)
-                    (format "Prune stale refspec %s and %%d branches" refspec)
+                    (format "Prune stale refspec %s and branch %%s"
+                            (string-replace "%" "%%" refspec))
+                    (format "Prune stale refspec %s and %%d branches"
+                            (string-replace "%" "%%" refspec))
                     nil refs))
               (magit-confirm 'prune-stale-refspecs nil
                 (format "Prune %%d stale refspecs and %d branches"

--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -348,7 +348,8 @@ When the region is active offer to drop all contained stashes."
 (defun magit-stash-clear (ref)
   "Remove all stashes saved in REF's reflog by deleting REF."
   (interactive (let ((ref (or (magit-section-value-if 'stashes) "refs/stash")))
-                 (magit-confirm t (format "Drop all stashes in %s" ref))
+                 (magit-confirm t
+                   (format "Drop all stashes in %s" (string-replace "%" "%%" ref)))
                  (list ref)))
   (magit-run-git "update-ref" "-d" ref))
 


### PR DESCRIPTION
`magit-branch-delete` fails with `Invalid format operation error` when the branch name contains a `%`. I had encountered this same issue when pushing branches back in #4428. The issue is that the `%` ends up in the prompt passed to `magit-confirm` which it uses as a format.

This PR fixes `magit-branch-delete` specifically, and also some (all?) other problematic calls to `magit-confirm`.

Repro steps for `magit-branch-delete`:
1. Create a branch called `foo%target=dev`
2. Push the branch to `origin`
3. `b k` (`magit-branch-delete`) `origin/foo%target=dev`

(Alternatively you can use a remote with a `%` in the name to trigger the same problem)