### PR TITLE
Remove magit-section from Package-Requires

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -22,7 +22,6 @@
 ;;     (emacs "26.1")
 ;;     (compat "30.0.0.0")
 ;;     (dash "2.19.1")
-;;     (magit-section "4.1.0")
 ;;     (seq "2.24")
 ;;     (transient "0.7.5")
 ;;     (with-editor "3.4.2"))


### PR DESCRIPTION
It's already provided and it is causing unnecessary installation from ELPA