### PR TITLE
Avoid activating Eglot for buffers visiting blobs

### DIFF
--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -177,8 +177,10 @@ then only after asking.  A non-nil value for REVERT is ignored if REV is
       (setq buffer-file-coding-system last-coding-system-used))
     (let ((buffer-file-name magit-buffer-file-name)
           (after-change-major-mode-hook
-           (remq 'global-diff-hl-mode-enable-in-buffers
-                 after-change-major-mode-hook)))
+           (seq-difference after-change-major-mode-hook
+                           '(global-diff-hl-mode-enable-in-buffers
+                             eglot--maybe-activate-editing-mode)
+                           #'eq)))
       (normal-mode t))
     (setq buffer-read-only t)
     (set-buffer-modified-p nil)


### PR DESCRIPTION
Hi!

Eglot may be activated for buffers visiting blobs, and most LSP servers bail out in that case. So in this commit we remove the activation function from the relevant hook.

Note that when started, Eglot checks and attempts to manage existing buffers as well. However, at that point, buffers visiting blobs have 'buffer-file-name' being nil, and Eglot will ignore them. So we only need to modify the hook instead of advising the function.

This is to achieve the same effect as the advice for 'lsp', introduced in f8353f57.

Thank you!