### PR TITLE
Proof of concept for limited magit refresh

### DIFF
--- a/lisp/magit-bisect.el
+++ b/lisp/magit-bisect.el
@@ -242,7 +242,8 @@ bisect run'."
 ;;; Sections
 
 (defun magit-bisect-in-progress-p ()
-  (file-exists-p (expand-file-name "BISECT_LOG" (magit-gitdir))))
+  (magit--with-refresh-cache (list default-directory 'bisect-in-progress-p)
+    (file-exists-p (expand-file-name "BISECT_LOG" (magit-gitdir)))))
 
 (defun magit-bisect-terms ()
   (magit-file-lines (expand-file-name "BISECT_TERMS" (magit-gitdir))))

--- a/lisp/magit-merge.el
+++ b/lisp/magit-merge.el
@@ -266,7 +266,8 @@ then also remove the respective remote branch."
 ;;; Utilities
 
 (defun magit-merge-in-progress-p ()
-  (file-exists-p (expand-file-name "MERGE_HEAD" (magit-gitdir))))
+  (magit--with-refresh-cache (list default-directory 'merge-in-progress-p)
+    (file-exists-p (expand-file-name "MERGE_HEAD" (magit-gitdir)))))
 
 (defun magit--merge-range (&optional head)
   (unless head

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -414,8 +414,9 @@ before use.
 
 Process output goes into a new section in the buffer returned by
 `magit-process-buffer'."
-  (run-hooks 'magit-pre-call-git-hook)
-  (let ((default-process-coding-system (magit--process-coding-system)))
+  (let ((default-process-coding-system (magit--process-coding-system))
+        (magit--refresh-cache (or magit--refresh-cache (list (cons 0 0)))))
+    (run-hooks 'magit-pre-call-git-hook)
     (apply #'magit-call-process
            (magit-git-executable)
            (magit-process-git-arguments args))))
@@ -579,8 +580,9 @@ current when this function was called (if it is a Magit buffer
 and still alive), as well as the respective Magit status buffer.
 
 See `magit-start-process' for more information."
-  (run-hooks 'magit-pre-start-git-hook)
-  (let ((default-process-coding-system (magit--process-coding-system)))
+  (let ((default-process-coding-system (magit--process-coding-system))
+        (magit--refresh-cache (or magit--refresh-cache (list (cons 0 0)))))
+    (run-hooks 'magit-pre-start-git-hook)
     (apply #'magit-start-process (magit-git-executable) input
            (magit-process-git-arguments args))))
 

--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -357,13 +357,14 @@ the process manually."
 
 (defun magit-cherry-pick-in-progress-p ()
   ;; .git/sequencer/todo does not exist when there is only one commit left.
-  (let ((dir (magit-gitdir)))
-    (or (file-exists-p (expand-file-name "CHERRY_PICK_HEAD" dir))
-        ;; And CHERRY_PICK_HEAD does not exist when a conflict happens
-        ;; while picking a series of commits with --no-commit.
-        (and-let* ((line (magit-file-line
-                          (expand-file-name "sequencer/todo" dir))))
-          (string-prefix-p "pick" line)))))
+  (magit--with-refresh-cache (list default-directory 'cherry-pick-in-progress-p)
+    (let ((dir (magit-gitdir)))
+      (or (file-exists-p (expand-file-name "CHERRY_PICK_HEAD" dir))
+          ;; And CHERRY_PICK_HEAD does not exist when a conflict happens
+          ;; while picking a series of commits with --no-commit.
+          (and-let* ((line (magit-file-line
+                            (expand-file-name "sequencer/todo" dir))))
+            (string-prefix-p "pick" line))))))
 
 ;;; Revert
 
@@ -415,13 +416,14 @@ without prompting."
 
 (defun magit-revert-in-progress-p ()
   ;; .git/sequencer/todo does not exist when there is only one commit left.
-  (let ((dir (magit-gitdir)))
-    (or (file-exists-p (expand-file-name "REVERT_HEAD" dir))
-        ;; And REVERT_HEAD does not exist when a conflict happens
-        ;; while reverting a series of commits with --no-commit.
-        (and-let* ((line (magit-file-line
-                          (expand-file-name "sequencer/todo" dir))))
-          (string-prefix-p "revert" line)))))
+  (magit--with-refresh-cache (list default-directory 'revert-in-progress-p)
+    (let ((dir (magit-gitdir)))
+      (or (file-exists-p (expand-file-name "REVERT_HEAD" dir))
+          ;; And REVERT_HEAD does not exist when a conflict happens
+          ;; while reverting a series of commits with --no-commit.
+          (and-let* ((line (magit-file-line
+                            (expand-file-name "sequencer/todo" dir))))
+            (string-prefix-p "revert" line))))))
 
 ;;; Patch
 
@@ -515,7 +517,8 @@ This discards all changes made since the sequence started."
   (magit-run-git "am" "--abort"))
 
 (defun magit-am-in-progress-p ()
-  (file-exists-p (expand-file-name "rebase-apply/applying" (magit-gitdir))))
+  (magit--with-refresh-cache (list default-directory 'am-in-progress-p)
+    (file-exists-p (expand-file-name "rebase-apply/applying" (magit-gitdir)))))
 
 ;;; Rebase
 
@@ -867,9 +870,10 @@ edit.  With a prefix argument the old message is reused as-is."
 
 (defun magit-rebase-in-progress-p ()
   "Return t if a rebase is in progress."
-  (let ((dir (magit-gitdir)))
-    (or (file-exists-p (expand-file-name "rebase-merge" dir))
-        (file-exists-p (expand-file-name "rebase-apply/onto" dir)))))
+  (magit--with-refresh-cache (list default-directory 'rebase-in-progress-p)
+    (let ((dir (magit-gitdir)))
+      (or (file-exists-p (expand-file-name "rebase-merge" dir))
+          (file-exists-p (expand-file-name "rebase-apply/onto" dir))))))
 
 (defun magit--rebase-resume-command ()
   (if (file-exists-p (expand-file-name "rebase-recursive" (magit-gitdir)))

--- a/lisp/magit-status.el
+++ b/lisp/magit-status.el
@@ -86,6 +86,10 @@ all."
   :group 'magit-status
   :type 'hook)
 
+(defvar magit-status--limited-refresh nil)
+(defvar magit-status--refresh-cache nil)
+(defvar magit-status--refresh-cache-toplevel nil)
+
 (defcustom magit-status-initial-section '(1)
   "The section point is placed on when a status buffer is created.
 
@@ -432,7 +436,12 @@ Type \\[magit-commit] to create a commit.
     buf))
 
 (defun magit-status-refresh-buffer ()
-  (magit-git-exit-code "update-index" "--refresh")
+  (unless (and magit-status--limited-refresh
+               (equal magit-status--refresh-cache-toplevel default-directory))
+    (setq magit-status--refresh-cache magit--refresh-cache
+          magit--insert-cache nil)
+    (magit-git-exit-code "update-index" "--refresh"))
+  (setq magit-status--refresh-cache-toplevel default-directory)
   (magit-insert-section (status)
     (magit-run-section-hook 'magit-status-sections-hook)))
 


### PR DESCRIPTION
I have been looking into magit performance on large repos, particularly over tramp. In my particular case running `magit-status-refresh-buffer` takes about 6 seconds. That means there is at least a 6 second delay to any command in the status buffer, which is very painful. Here is the verbose output:

```
Refreshing magit...
Running magit-pre-refresh-hook...
  magit-maybe-save-repository-buffers                0.074059
Running magit-pre-refresh-hook...done (0.074s)
Refreshing buffer ‘magit: repo_cluster’...
  magit-insert-error-header                          0.000001 
  magit-insert-diff-filter-header                    0.329797 !!
  magit-insert-head-branch-header                    0.132646 !!
  magit-insert-upstream-branch-header                0.000216 
  magit-insert-push-branch-header                    0.224527 !!
  magit-insert-tags-header                           0.966151 !!
  magit-insert-status-headers                        1.725762 !!
  magit-insert-merge-log                             0.241909 !!
  magit-insert-rebase-sequence                       0.240397 !!
  magit-insert-am-sequence                           0.064967 !!
  magit-insert-sequencer-sequence                    0.205455 !!
  magit-insert-bisect-output                         0.073950 !!
  magit-insert-bisect-rest                           0.000002 
  magit-insert-bisect-log                            0.000001 
  magit-insert-untracked-files                       1.274190 !!
  magit-insert-unstaged-changes                      0.484438 !!
  magit-insert-staged-changes                        0.210606 !!
  magit-insert-stashes                               0.340388 !!
  magit-insert-unpushed-to-pushremote                0.173376 !!
  magit-insert-unpushed-to-upstream-or-recent        0.359119 !!
  magit-insert-unpulled-from-pushremote              0.106821 !!
  magit-insert-unpulled-from-upstream                0.000005 
Refreshing buffer ‘magit: repo_cluster’...done (5.962s)
Running magit-post-refresh-hook...
  magit-auto-revert-buffers                          0.000003
Running magit-post-refresh-hook...done (0.000s)
Refreshing magit...done (6.040s, cached 54/90 (60%))
```

I initially thought that it was some issue with magit that caused these commands take so long, but it turns out this is just a big repo and that these operations take a long time. 

Most operations do not require a refresh of all the information in the status buffer. This proof of concept code enables a "limited refresh" where we only refresh the parts of the buffer that would actually change for a given command. Everything else is read from a cache. For example here is new verbose output with limited refresh when we stage a file:

```
Refreshing magit...
Running magit-pre-refresh-hook...
  magit-maybe-save-repository-buffers                0.000001
Running magit-pre-refresh-hook...done (0.000s)
Refreshing buffer ‘magit: repo_cluster’...
  magit-insert-error-header                          0.000001 
  magit-insert-diff-filter-header                    0.000083 
  magit-insert-head-branch-header                    0.000070 
  magit-insert-upstream-branch-header                0.000253 
  magit-insert-push-branch-header                    0.000066 
  magit-insert-tags-header                           0.000048 
  magit-insert-status-headers                        0.007927 
  magit-insert-merge-log                             0.000009 
  magit-insert-rebase-sequence                       0.000009 
  magit-insert-am-sequence                           0.000002 
  magit-insert-sequencer-sequence                    0.000005 
  magit-insert-bisect-output                         0.000009 
  magit-insert-bisect-rest                           0.000001 
  magit-insert-bisect-log                            0.000001 
  magit-insert-untracked-files                       0.000264 
  magit-insert-unstaged-changes                      0.850395 !!
  magit-insert-staged-changes                        0.214693 !!
  magit-insert-stashes                               0.000285 
  magit-insert-unpushed-to-pushremote                0.000369 
  magit-insert-unpushed-to-upstream-or-recent        0.000613 
  magit-insert-unpulled-from-pushremote              0.000047 
  magit-insert-unpulled-from-upstream                0.000002 
Refreshing buffer ‘magit: repo_cluster’...done (1.080s)
Running magit-post-refresh-hook...
  magit-auto-revert-buffers                          0.000006
Running magit-post-refresh-hook...done (0.000s)
Refreshing magit...done (1.083s, cached 1/4 (25%))
```

So it took the total time from 6 seconds to 1. Likewise, discarding a file now takes 0.25 seconds instead of 6. This makes working with magit so much more efficient and pleasant. 


To facilitate this, I created a new variable `magit-status--limited-refresh` that can be dynamically bound to the set of hooks that we want to run during a "limited refresh". So far I have only implemented this for the commands in `magit-apply` (stage, unstage, discard, etc).

This code is very much a proof of concept and is not ready to be merged. It is just hacked on and not nearly as elegant or well organized as the normal magit code. But I wanted to get feedback and see if this is something you would want to support in magit. It could make a huge difference for users of large repos or repos over tramp. 
