### PR TITLE
magit-revert-rev-file-buffer: Adapt to upstream changes in Emacs 30

### DIFF
--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -178,7 +178,8 @@ then only after asking.  A non-nil value for REVERT is ignored if REV is
     (let ((buffer-file-name magit-buffer-file-name)
           (after-change-major-mode-hook
            (seq-difference after-change-major-mode-hook
-                           '(global-diff-hl-mode-enable-in-buffers
+                           '(global-diff-hl-mode-enable-in-buffer ; Emacs >= 30
+                             global-diff-hl-mode-enable-in-buffers ; Emacs < 30
                              eglot--maybe-activate-editing-mode)
                            #'eq)))
       (normal-mode t))


### PR DESCRIPTION
Hello!

In Emacs commit [9506b9392e], `define-globalized-minor-mode` was refactored, and in Emacs 30 only the function `MODE-enable-in-buffer` is added to `after-change-major-mode-hook`. So in this PR we remove both the new and the old functions from the hook to avoid activating `diff-hl-mode` for blob buffers.

Thank you!

[9506b9392e]: https://git.savannah.gnu.org/cgit/emacs.git/commit/lisp/emacs-lisp/easy-mmode.el?id=9506b9392e8c3548b769d9951a1c9d4abad9ee21