### PR TITLE
magit-start-process: Handle tramp-pipe-stty-settings being unbound

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ Bug fixes:
   that margin, then the old width was not restored when the mode was
   disabled.  #5236
 
+- Prior to Tramp being loaded, setting ~magit-tramp-pipe-stty-settings~
+  to ~nil~ resulted in an error, due to ~tramp-pipe-stty-settings~ not
+  being bound yet.  #5240
+
 * v4.1.1    2024-10-01
 
 - Avoid unnecessary work when ~auto-revert-remote-files~ is ~nil~.  #5222

--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -619,7 +619,7 @@ Magit status buffer."
                         ;; Defaults to "", to allow staging hunks over
                         ;; Tramp again.  #4720
                         magit-tramp-pipe-stty-settings)
-                   tramp-pipe-stty-settings))
+                   (bound-and-true-p tramp-pipe-stty-settings)))
               (process-environment (magit-process-environment))
               (default-process-coding-system (magit--process-coding-system)))
           (apply #'start-file-process


### PR DESCRIPTION
Currently, if you set `magit-tramp-pipe-stty-settings` to `'pty` it will bind `tramp-pipe-stty-settings` to its own symbol value. But if tramp has not been loaded yet this will result in referencing a void variable. We fix this by checking if the variable is bound before referencing it. 


## To reproduce the issue

`(setq magit-tramp-pipe-stty-settings 'pty)`

call `magit-status`.


