### PR TITLE
magit-copy-section-value: fix default case

### DIFF
--- a/lisp/magit-extras.el
+++ b/lisp/magit-extras.el
@@ -794,7 +794,7 @@ argument."
            (push (list value default-directory) magit-revision-stack)
            (kill-new (message "%s" (or (and current-prefix-arg ref)
                                        value)))))
-        ((kill-new (message "%s" value))))))))
+        (t (kill-new (message "%s" value))))))))
 
 ;;;###autoload
 (defun magit-copy-buffer-revision ()


### PR DESCRIPTION
If the current section type is not one of

    '(branch commit module-commit tag)

the intention here is to just copy the raw section value, but this was not being done. Instead, `magit-section-case` was unfortunately interpreting the `(kill-new (message ...))` expression as a list of section types. Whoops!

Use the default case to correct this error.