### PR TITLE
* lisp/magit-commit.el (magit-commit-absorb): Remove -v option

### DIFF
--- a/lisp/magit-commit.el
+++ b/lisp/magit-commit.el
@@ -457,8 +457,7 @@ arguments.  This command requires git-absorb executable, which
 is available from https://github.com/tummychow/git-absorb.
 See `magit-commit-autofixup' for an alternative implementation."
   ["Arguments"
-   ("-f" "Skip safety checks"       ("-f" "--force"))
-   ("-v" "Display more output"      ("-v" "--verbose"))]
+   ("-f" "Skip safety checks"       ("-f" "--force"))]
   ["Actions"
    ("x"  "Absorb" magit-commit-absorb)]
   (interactive (if current-prefix-arg


### PR DESCRIPTION
The option "-v" is forced in the call to `magit-run-git-async`. Adding
it through the transient crashes the command because git-absorb
doesn't accept duplicate options.

How to reproduce the issue:
1. Type `C-u M-x magit-commit-absorb`
2. Type `-v`
2. Type `x` to start git-absorb

Actual: You get an error because `-v` is specified twice

-------