### PR TITLE
magit-list-special-refnames: Fix usage of seq-keep

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1981,7 +1981,9 @@ SORTBY is a key or list of keys to pass to the `--sort' flag of
 
 (defun magit-list-special-refnames ()
   (let ((gitdir (magit-gitdir)))
-    (seq-keep (lambda (name) (file-exists-p (expand-file-name name gitdir)))
+    (seq-keep (lambda (name)
+                (and (file-exists-p (expand-file-name name gitdir))
+                     name))
               magit-special-refnames)))
 
 (defun magit-list-branch-names ()


### PR DESCRIPTION
seq-keep applies the function to the returned sequence, resulting a list of '(t t t ...) being returned.  Adjust the lambda to return the ref when the ref exists.

Before this fix, when using Push -> Another branch you would get "t" suggested instead of "HEAD".

Fixes: 621b67fc (magit-list-special-refnames: Cosmetics, 2024-11-22)