### PR TITLE
Add missing require on magit-process

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -102,6 +102,7 @@
 
 (require 'magit-mode)
 
+(require 'magit-process)
 (require 'log-edit)
 (require 'ring)
 (require 'server)


### PR DESCRIPTION
(Originally reported by Timon at Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1090886)

When loading git-commit without magit and visit a COMMIT_EDITMSG buffer, Emacs will report `(void-function magit-process-git)'.  The backtrace looks like below:

```
,----
| Debugger entered--Lisp error: (void-function magit-process-git)
|   magit-process-git((t nil) ("rev-parse" "HEAD"))
|   magit--git-insert(nil "rev-parse" "HEAD")
|   magit-git-insert("rev-parse" "HEAD")
|   magit-git-string("rev-parse" "HEAD")
|   magit-rev-parse("HEAD")
|   git-commit-setup()
|   git-commit-setup-check-buffer()
|   run-hooks(find-file-hook)
|   after-find-file(t t)
|   find-file-noselect-1(#<buffer COMMIT_EDITMSG> "~/Projects/debian-packaging/emacs-bazel-mode/COMMI..." nil nil "~/Projects/debian-packaging/emacs-bazel-mode/COMMI..." nil)
|   find-file-noselect("/home/manphiz/Projects/debian-packaging/emacs-baze...")
|   command-line-1(("--eval=(progn (toggle-debug-on-error)(require 'git..." "COMMIT_EDITMSG"))
|   command-line()
|   normal-top-level()
`----
```

This shows that git-commit should require magit-process to be able to work independently without loading magit.

This patch adds the missing require.
