### PR TITLE
magit-worktree: Add force option

### DIFF
--- a/lisp/magit-worktree.el
+++ b/lisp/magit-worktree.el
@@ -45,6 +45,8 @@ Used by `magit-worktree-checkout' and `magit-worktree-branch'."
 (transient-define-prefix magit-worktree ()
   "Act on a worktree."
   :man-page "git-worktree"
+  ["Arguments"
+   ("-F" "Force" ("-f" "--force"))]
   [["Create new"
     ("b" "worktree"              magit-worktree-checkout)
     ("c" "branch and worktree"   magit-worktree-branch)]


### PR DESCRIPTION
Git worktree has many options that aren't in Magit: https://git-scm.com/docs/git-worktree#_options

This adds the force option.

I just happened to need the force option due to this: https://stackoverflow.com/questions/74566599/how-do-i-remove-a-git-worktree-that-contains-a-submodule

I could add more options, but I'm not very familiar with this codebase.

Perhaps this shouldn't be added because it's a bit unsafe to do? And one might better just reset the worktree first and then delete it to be safe? I personally like the speed this brings.

Thoughts?