### PR TITLE
Git commit accept ssh key passphrase

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -157,7 +157,7 @@ itself from the hook, to avoid further futile attempts."
   :type 'regexp)
 
 (defcustom magit-process-password-prompt-regexps
-  '("^\\(Enter \\)?[Pp]assphrase\\( for \\(RSA \\)?key '.*'\\)?: ?$"
+  '("^\\(Enter \\)?[Pp]assphrase\\( for \\(RSA \\)?\\(key \\)?['\"].*['\"]\\)?: ?$"
     ;; Match-group 99 is used to identify the "user@host" part.
     "^\\(Enter \\|([^) ]+) \\)?\
 [Pp]assword\\( for '?\\(https?://\\)?\\(?99:[^']+\\)'?\\)?: ?$"


### PR DESCRIPTION
Add regexps to match the ssh-key prompts when requesting a passphrase
for ssh-key, this likely relates to this prompt:
https://github.com/openssh/openssh-portable/blob/826483d51a9fee60703298bbf839d9ce37943474/sshconnect2.c#L1533

fixes #5288