### PR TITLE
Fix magit-read-char-case macro usages

### DIFF
--- a/lisp/magit-clone.el
+++ b/lisp/magit-clone.el
@@ -308,7 +308,7 @@ Then show the status buffer for the new repository."
         (concat "file://"
                 (magit-convert-filename-for-git
                  (read-directory-name "Clone repository: file://"))))
-    (?b "or [b]undle"
+    (?b "[b]undle"
         (magit-convert-filename-for-git
          (read-file-name "Clone from bundle: ")))))
 

--- a/lisp/magit-remote.el
+++ b/lisp/magit-remote.el
@@ -199,7 +199,7 @@ the now stale refspecs.  Other stale branches are not removed."
                  variable))
             (?r "[r]emove remote"
                 (magit-call-git "remote" "rm" remote))
-            (?a "or [a]abort"
+            (?a "[a]abort"
                 (user-error "Abort")))
         (if (if (length= stale 1)
                 (pcase-let ((`(,refspec . ,refs) (car stale)))


### PR DESCRIPTION
This update removes the redundant "or" from the prompt messages.

The `magit-read-char-case` macro has been updated to automatically format prompt messages in natural English and correctly add "or" before the last entry.  However, this change led to some prompt messages containing duplicated "or" words.  For instance, the prompt for the `magit-clone` command previously displayed:

> Clone from [u]rl or name, [p]ath, [l]ocal url, or **or** [b]undle

This update addresses that issue by removing the redundant "or."