### PR TITLE
git-commit: make trailer regex matches lax

### DIFF
--- a/lisp/git-commit.el
+++ b/lisp/git-commit.el
@@ -1048,10 +1048,10 @@ Added to `font-lock-extend-region-functions'."
 (defconst git-commit-font-lock-keywords-1
   '(;; Trailers
     (eval . `(,(git-commit--trailer-regexp)
-              (1 'git-commit-trailer-token)
-              (2 'git-commit-trailer-value)
-              (3 'git-commit-trailer-token)
-              (4 'git-commit-trailer-value)))
+              (1 'git-commit-trailer-token nil t)
+              (2 'git-commit-trailer-value nil t)
+              (3 'git-commit-trailer-token nil t)
+              (4 'git-commit-trailer-value nil t)))
     ;; Summary
     (eval . `(,(git-commit-summary-regexp)
               (1 'git-commit-summary)))


### PR DESCRIPTION
The git-commit--trailer-regexp regex is written so that either groups 1 and 2 will match or groups 3 and 4 will match, but it is impossible for all 4 groups to match.

This patch updates the font-lock regex checker to be lax about whether or not the group matched. Without this patch we have errors like:

  Error during redisplay: (jit-lock-function 77) signaled (error "No match 3 in highlight (3 'git-commit-trailer-token)")

See #5317 