### PR TITLE
magit-stash-save: Use diff with "--default-prefix"

### DIFF
--- a/lisp/magit-stash.el
+++ b/lisp/magit-stash.el
@@ -430,7 +430,8 @@ Then apply STASH, dropping it if it applies cleanly."
                            (magit-stash-create message index worktree untracked))
         (if (eq keep 'worktree)
             (with-temp-buffer
-              (magit-git-insert "diff" "--cached" "--no-ext-diff")
+              (magit-git-insert
+               "diff" "--cached" "--no-ext-diff" "--default-prefix")
               (magit-run-git-with-input
                "apply" "--reverse" "--cached" "--ignore-space-change" "-")
               (magit-run-git-with-input


### PR DESCRIPTION
Without this, if Git is configured with `diff.noprefix = true`, then saving a stash with e.g. `magit-stash-index` fails with "git diff header lacks filename information when removing 1 leading pathname component" after saving the stash, leaving the stashed data in the index.
