### PR TITLE
Use ansi-color in magit-process-filter

### DIFF
--- a/lisp/magit-process.el
+++ b/lisp/magit-process.el
@@ -843,6 +843,7 @@ Magit status buffer."
         (setq string (substring string (1+ ret-pos)))
         (delete-region (line-beginning-position) (point)))
       (setq string (magit-process-remove-bogus-errors string))
+      (setq string (ansi-color-apply string))
       (insert (propertize string 'magit-section
                           (process-get proc 'section)))
       (set-marker (process-mark proc) (point))


### PR DESCRIPTION
This change use ansi-colors for the magit-process buffer output while the process is sending it's output.
I know about `magit-process-finish-apply-ansi-colors` variable but it only apply the coloring at`magit-process-finish`, maybe I missed some complexity that forcing applying the coloring only then.
