### PR TITLE
magit-show-commit: diff an unintended revision (bugfix)

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1395,7 +1395,6 @@ for a revision."
   (interactive
    (pcase-let* ((mcommit (magit-section-value-if 'module-commit))
                 (atpoint (or mcommit
-                             (magit-thing-at-point 'git-revision t)
                              (magit-branch-or-commit-at-point)))
                 (`(,args ,files) (magit-show-commit--arguments)))
      (list (or (and (not current-prefix-arg) atpoint)


### PR DESCRIPTION
When I created a branch named `manual' (denoted by [manual]), and my
point is positioned at ⏎. Magit will diff b3e4f956 (unexpected)
instead of 8edb6405 (expected).

      bf58615a * magit/main v4.3.2 Release version 4.3.2
    ✓ 8edb6405 * Regenerate manual⏎
      2a789033 * Bump dependencies
    ✗ b3e4f956 * [manual] Update changelog

This was casued by unintended revision precednece issue. Digging a
little bit of #magit-branch-or-commit-at-point, I found that it has
already included the '(magit-thing-at-point 'git-revision t) and it's
precedency is acutally expected. So the fixup should be remove the
previous redandant '(magit-thing-at-point 'git-revision t).
