### PR TITLE
manual: Remove inaccurate sentence about magit-diff-visit-file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -28,6 +28,4 @@ Please summarize the changes made in the commits.  Explain why you are making th
 How to update the manual
 =================================================================
 
-If you make changes to the manual, then edit only "magit.org".  Do not manually edit "magit.texi".  The latter has to be generated from the former.  If you want to do that yourself, then follow the instructions at [2].  Otherwise a maintainer will do it and amend that to your commit.
-
-  [2]: https://github.com/magit/magit/wiki/Documentation-tools-and-conventions
+If you make changes to the manual, then edit only "magit.org".  Do not update "magit.texi"; a maintainer will do it and amend to your commit.

--- a/docs/magit.org
+++ b/docs/magit.org
@@ -4065,12 +4065,9 @@ These commands can only be used when point is inside a diff.
 - Key: RET (magit-diff-visit-file) ::
 
   This command visits the appropriate version of the file that the
-  diff at point is about.
-
-  This commands visits the worktree version of the appropriate file.
-  The location of point inside the diff determines which file is being
-  visited.  The visited version depends on what changes the diff is
-  about.
+  diff at point is about. The location of point inside the diff
+  determines which file is being visited. The visited version depends
+  on what changes the diff is about.
 
   1. If the diff shows uncommitted changes (i.e., staged or unstaged
      changes), then visit the file in the working tree (i.e., the

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -4783,12 +4783,9 @@ These commands can only be used when point is inside a diff.
 @kindex RET
 @findex magit-diff-visit-file
 This command visits the appropriate version of the file that the
-diff at point is about.
-
-This commands visits the worktree version of the appropriate file.
-The location of point inside the diff determines which file is being
-visited.  The visited version depends on what changes the diff is
-about.
+diff at point is about. The location of point inside the diff
+determines which file is being visited. The visited version depends
+on what changes the diff is about.
 
 @enumerate
 @item

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -1596,9 +1596,9 @@ Display the buffer in the selected window.  With a prefix
 argument OTHER-WINDOW display the buffer in another window
 instead.
 
-Visit the worktree version of the appropriate file.  The location
-of point inside the diff determines which file is being visited.
-The visited version depends on what changes the diff is about.
+The location of point inside the diff determines which file is
+being visited.  The visited version depends on what changes the
+diff is about.
 
 1. If the diff shows uncommitted changes (i.e., stage or unstaged
    changes), then visit the file in the working tree (i.e., the


### PR DESCRIPTION
From my reading, the existing documentation for `magit-diff-visit-file` accidentally copies a line from `magit-diff-visit-worktree-file`, specifically "This commands [sic] visits the worktree version of the appropriate file". 

This PR deletes that sentence and also combines the existing "This command..." sentence with the following paragraph to be consistent with the other commands/options in the same section.