### PR TITLE
magit-branch: Add --force argument to the transient

### DIFF
--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -224,7 +224,9 @@ has to be used to view and change branch related variables."
     :inapt-if-not magit-get-some-remote)]
   ["Arguments"
    (7 "-r" "Recurse submodules when checking out an existing branch"
-      "--recurse-submodules")]
+      "--recurse-submodules")
+   (7 "-f" "proceed even if the index or the working tree differs from HEAD, and even if there are untracked files in the way."
+      "--force")]
   [["Checkout"
     ("b" "branch/revision"   magit-checkout)
     ("l" "local branch"      magit-branch-checkout)


### PR DESCRIPTION
The "magit-branch" transient (containing "checkout" commands) didn't have support for the `--force` parameter that both `git branch` and `git checkout` accept. This PR adds this new parameter to the transient but keep it invisible by default (level = 7).