### PR TITLE
magit-section: Display visibility indicators in left margin

### DIFF
--- a/lisp/magit-section.el
+++ b/lisp/magit-section.el
@@ -1961,19 +1961,17 @@ When `magit-section-preserve-visibility' is nil, return nil."
            (eoh (magit--eol-position beg)))
       (cond
        ((symbolp (car-safe magit-section-visibility-indicator))
-        (let ((ov (magit--overlay-at beg 'magit-vis-indicator 'fringe)))
+        (let ((ov (magit--overlay-at beg 'magit-vis-indicator 'margin)))
           (unless ov
             (setq ov (make-overlay beg eoh nil t))
             (overlay-put ov 'evaporate t)
-            (overlay-put ov 'magit-vis-indicator 'fringe))
+            (overlay-put ov 'magit-vis-indicator 'margin))
           (overlay-put
            ov 'before-string
-           (propertize "fringe" 'display
-                       (list 'left-fringe
-                             (if (oref section hidden)
-                                 (car magit-section-visibility-indicator)
-                               (cdr magit-section-visibility-indicator))
-                             'fringe)))))
+           (propertize "margin" 'display
+                       `((margin left-margin)
+                         ,(propertize (if (oref section hidden) "🞂" "🞃")
+                                      'face 'default))))))
        ((stringp (car-safe magit-section-visibility-indicator))
         (let ((ov (magit--overlay-at (1- eoh) 'magit-vis-indicator 'eoh)))
           (cond ((oref section hidden)


### PR DESCRIPTION
Magit currently allows displaying visibility indicators either in the fringe or at the end of section headings, configured via `magit-section-visibility-indicators`. For those using high-DPI displays, fringe indicators get scaled up naively and appear blocky. Ideally, Emacs would support displaying SVGs as fringe indicators, and there was some talk on emacs-devel about this, but my understanding is that it is seen as low priority and there is not much progress towards it. 

To work around this issue, I prefer to disable fringes and use margins for indicators instead. This works quite well with a font with broad Unicode coverage (like Iosevka). Some packages (like Flycheck) have built-in support for margin indicators (precisely for the reason I describe above). Magit currently does not support margin indicators, but I have been using my fork with margin indicators hardcoded into `magit-section` for about a year now. I have not run into any issues so far; would you be open to adding support for this? 

I have only created this PR to start a discussion; of course either there would need to be a new variable to control this or we could allow an additional form for the value of `magit-section-visibility-indicators`. There are also other decisions like whether the change would need to reside in `magit-section.el` or `magit-margin.el`.

Here's how it looks with my current setup. What do you think?

<img width="832" height="882" alt="Screen Shot 2025-08-18 at 13 18 57" src="https://github.com/user-attachments/assets/c899d856-47a3-4d25-ab3b-ba1d55ffe5f6" />
