### PR TITLE
Update melpa testing instructions in bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,7 +42,7 @@ to save a shell command to the `kill-ring` and the system's clip-board, which yo
 Finally, if that didn't work and you have installed Magit from Melpa, then run commands similar to the ones above, but use tab completion to replace the various Ns with the correct versions:
 
     $ cd ~/.emacs.d/elpa/magit-N
-    $ emacs -Q --debug-init --eval '(setq debug-on-error t)' -L ../llama-N -L ../seq-N -L ../transient-N -L ../with-editor-N -L . -l magit
+    $ emacs -Q --debug-init --eval '(setq debug-on-error t)' -L ../llama-N -L ../seq-N -L ../transient-N -L ../with-editor-N -L ../cond-let-N -L ../magit-section-N -L . -l magit
 
 More debugging tools are described in the manual.
 


### PR DESCRIPTION
The bug reporting instructions include a section to test magit in isolation when downloaded from MELPA.

As a bug reporter, I want it to be easy and straightforward to make pre-submission assessment. While reporting a bug, attempting to run the instructions in my environment failed. This PR includes the updated command line call.