### PR TITLE
Function to show the difference between HEAD and n commits.

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -3151,6 +3151,11 @@ Also see [[man:git-diff]]
   revisions, choose a revision to view changes along, starting at the
   common ancestor of both revisions (i.e., use a "..."  range).
 
+- Key: d h (magit-diff-head) ::
+
+  Prompt for a number of commits n and show the differences between
+  your current working tree and HEAD~n.
+
 - Key: d w (magit-diff-working-tree) ::
 
   Show changes between the current working tree and the ~HEAD~ commit.

--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -942,6 +942,7 @@ and `:slant'."
   ["Actions"
    [("d" "Dwim"          magit-diff-dwim)
     ("r" "Diff range"    magit-diff-range)
+    ("h" "Diff HEAD"     magit-diff-head)
     ("p" "Diff paths"    magit-diff-paths)]
    [("u" "Diff unstaged" magit-diff-unstaged)
     ("s" "Diff staged"   magit-diff-staged)
@@ -1300,6 +1301,12 @@ revisions (i.e., use a \"...\" range)."
                                                       nil current-prefix-arg)
                      (magit-diff-arguments)))
   (magit-diff-setup-buffer rev-or-range nil args files 'committed))
+
+;;;###autoload
+(defun magit-diff-head (n)
+  "Show the diff of HEAD and the previous `n' commits."
+  (interactive "nEnter number of commits: ")
+  (magit-diff-range (format "HEAD~%d" n)))
 
 ;;;###autoload
 (defun magit-diff-working-tree (&optional rev args files)


### PR DESCRIPTION
Function to show the difference between HEAD and n commits.

This will prompt the user for input n then show the diff of
range HEAD~n.

Since this is a common operation, this reduces the friction of running `magit-diff-range` then typing HEAD~n