### PR TITLE
Only load package.el when it's enabled

### DIFF
--- a/lisp/magit.el
+++ b/lisp/magit.el
@@ -70,7 +70,8 @@
 (require 'git-commit)
 
 (require 'format-spec)
-(require 'package nil t) ; used in `magit-version'
+(when package-enable-at-startup
+  (require 'package nil t)) ; used in `magit-version'
 (require 'with-editor)
 
 ;; For `magit:--gpg-sign'


### PR DESCRIPTION
When using other package managers, such as straight.el, it's common to disable package.el by setting 'package-enable-at-startup' to 'nil'. This change will prevent loading of package.el when the user has disabled it in that way.