### PR TITLE
fix(blame): correct custom type of `magit-blame-styles`

### DIFF
--- a/lisp/magit-blame.el
+++ b/lisp/magit-blame.el
@@ -128,7 +128,7 @@ part of the default value:
    (margin-body-face . (magit-blame-dimmed)))"
   :package-version '(magit . "2.13.0")
   :group 'magit-blame
-  :type 'string)
+  :type '(alist :key-type symbol :value-type (alist :key-type symbol :value-type sexp)))
 
 (defcustom magit-blame-echo-style 'lines
   "The blame visualization style used by `magit-blame-echo'.


### PR DESCRIPTION
The `magit-blame-styles` variable was incorrectly declared with `:type 'string`, even though its value is an alist of style definitions. This caused warnings when customizing the variable or setting it with `setopt`.

This commit changes the custom type to a proper nested alist type to match the actual data structure and suppress spurious warnings.
