### PR TITLE
magit-push-current: Warn if the branch names don't match

### DIFF
--- a/lisp/magit-push.el
+++ b/lisp/magit-push.el
@@ -181,7 +181,12 @@ the upstream."
                                        nil nil current 'confirm)
              (magit-push-arguments))
      (user-error "No branch is checked out")))
-  (magit-git-push (magit-get-current-branch) target args))
+  (let ((current-branch (magit-get-current-branch))
+	(remote-branch (substring target (1+ (string-match "/" target)))))
+    (if (or (string= current-branch remote-branch)
+	    (y-or-n-p (format "Current branch is '%s' but destination branch is '%s'.  Proceed? "
+			      current-branch remote-branch)))
+	(magit-git-push (magit-get-current-branch) target args))))
 
 ;;;###autoload
 (defun magit-push-other (source target args)


### PR DESCRIPTION
I keep copies of a couple of open-source projects on both `gitlab.common-lisp.net` and `github.com`, and use Magit's "push elsewhere" heavily to keep them in sync.  Today I unintentionally pushed a feature branch to `master` that way, and was a little surprised, on reflection, that Magit hadn't asked me about it.  So I've added a little code to `magit-push-current` to ask for confirmation if the destination branch is different from the local current branch.

I'm still using 3.3.0, actually, but it doesn't look like any similar change has been made since.
