### PR TITLE
magit-margin: Require 'magit-section

### DIFF
--- a/lisp/magit-margin.el
+++ b/lisp/magit-margin.el
@@ -32,6 +32,7 @@
 (require 'magit-base)
 (require 'magit-transient)
 (require 'magit-mode)
+(require 'magit-section)
 
 ;;; Options
 


### PR DESCRIPTION
This is needed because otherwise we will see an error saying that
`magit-section-visibility-indicator` is undefined.