### PR TITLE
magit-insert-worktrees: mention in documentation

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -7519,6 +7519,11 @@ Also see [[man:git-worktree]]
   If the worktree at point is the one whose status is already being
   displayed in the current buffer, then show it in Dired instead.
 
+If you want the status buffer to list worktrees, add the function
+~magit-insert-worktrees~ to ~magit-status-sections-hook~ as described
+in [[*Status Sections]].  If there is only one worktree, this function
+inserts nothing.
+
 ** Sparse checkouts
 
 Sparse checkouts provide a way to restrict the working tree to a

--- a/docs/magit.texi
+++ b/docs/magit.texi
@@ -9053,6 +9053,11 @@ If the worktree at point is the one whose status is already being
 displayed in the current buffer, then show it in Dired instead.
 @end table
 
+If you want the status buffer to list worktrees, add the function
+@code{magit-insert-worktrees} to @code{magit-status-sections-hook} as described
+in @ref{Status Sections}.  If there is only one worktree, this function
+inserts nothing.
+
 @node Sparse checkouts
 @section Sparse checkouts
 


### PR DESCRIPTION
This section inserter is handy, and has existed since 2.7.0 / 82bfdd46295c5d6fa5d1a26a5058994e5b4f7c56... but appears to not yet be documented.

This documentation is modeled in the style of `magit-sparse-checkout-insert-header`, where it is mentioned in the docs for the relevant commands rather than the docs of `magit-status`, since most people who wish see a list of worktrees are likely using `magit-worktree` / reading its documentation.

---

Thanks for Magit!
