### PR TITLE
magit-worktree-delete: Use git to remove worktree when not trashing

### DIFF
--- a/lisp/magit-worktree.el
+++ b/lisp/magit-worktree.el
@@ -204,8 +204,10 @@ The primary worktree cannot be deleted."
       (magit-confirm-files (if magit-delete-by-moving-to-trash 'trash 'delete)
                            (list worktree))
       (when (file-exists-p worktree)
-        (let ((delete-by-moving-to-trash magit-delete-by-moving-to-trash))
-          (delete-directory worktree t magit-delete-by-moving-to-trash)))
+        (if magit-delete-by-moving-to-trash
+            (let ((delete-by-moving-to-trash t))
+              (delete-directory worktree t t))
+          (magit-call-git "worktree" "remove" "--force" worktree)))
       (if (file-exists-p default-directory)
           (magit-run-git "worktree" "prune")
         (let ((default-directory primary))


### PR DESCRIPTION
The previous implementation used Emacs's delete-directory to remove the worktree directory, which is very slow for worktrees containing many files (e.g., a Python .venv with thousands of files).

When magit-delete-by-moving-to-trash is nil, use git-worktree-remove instead, which is much faster.  The --force flag is used because git-worktree-remove otherwise refuses to remove worktrees containing untracked files.  This is backward compatible since the old behavior also removed untracked files without warning.