### PR TITLE
Fix syntax highlighting for staged changes

### DIFF
--- a/lisp/magit-diff.el
+++ b/lisp/magit-diff.el
@@ -3684,6 +3684,10 @@ actually a `diff' but a `diffstat' section."
 
 (defun magit-diff--get-hunk-syntax (hunk side rev file)
   (let ((args (magit-diff--get-hunk-text hunk (eq side 'old))))
+    ;; For syntax highlighting, treat "{index}" as "{worktree}" since
+    ;; we only need syntax rules, not actual index content.
+    (when (equal rev "{index}")
+      (setq rev "{worktree}"))
     (with-current-buffer (magit-find-file-hidden rev file)
       (save-excursion ; FIXME necessary? if so, fix?
         (apply #'diff-syntax-fontify-props nil args)))))

--- a/lisp/magit-files.el
+++ b/lisp/magit-files.el
@@ -94,7 +94,7 @@ the line and column corresponding to that location."
   "Read FILE from REV into a buffer and return the buffer.
 REV is a revision or one of \"{worktree}\" or \"{index}\"."
   (when (and (equal rev "{index}")
-             (length> (magit--file-index-stages file) t))
+             (length> (magit--file-index-stages file) 1))
     (setq rev "{worktree}"))
   (cond-let*
     [[topdir (magit-toplevel)]
@@ -138,7 +138,9 @@ REV is a revision or one of \"{worktree}\" or \"{index}\"."
         (col (current-column)))
     (setq magit-buffer-blob-oid (magit-blob-oid magit-buffer-revision
                                                 magit-buffer-file-name))
-    (setq magit-buffer-revision-oid (magit-commit-oid magit-buffer-revision))
+    (setq magit-buffer-revision-oid
+          (and (not (member magit-buffer-revision '("{worktree}" "{index}")))
+               (magit-commit-oid magit-buffer-revision)))
     (magit--refresh-blob-buffer t)
     (magit-find-file--restore-position (current-buffer)
                                        magit-buffer-revision-oid
@@ -148,7 +150,8 @@ REV is a revision or one of \"{worktree}\" or \"{index}\"."
 (defun magit--refresh-blob-buffer (&optional force)
   (let ((old-blob-oid magit-buffer-blob-oid))
     (setq magit-buffer-revision-oid
-          (magit-commit-oid magit-buffer-revision))
+          (and (not (member magit-buffer-revision '("{worktree}" "{index}")))
+               (magit-commit-oid magit-buffer-revision)))
     (setq magit-buffer-blob-oid
           (magit-blob-oid magit-buffer-revision magit-buffer-file-name))
     (when (or force (not (equal old-blob-oid magit-buffer-blob-oid)))


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the syntax highlighting feature for staged changes:

- **Fix typo in `magit-find-file-noselect`**: `length>` requires a number as its second argument, not `t`. Changed `(length> (magit--file-index-stages file) t)` to `(length> (magit--file-index-stages file) 1)`.

- **Handle `{index}` revision in `magit-diff--get-hunk-syntax`**: When viewing staged changes, the revision is `"{index}"` which cannot be dereferenced as a commit. For syntax highlighting purposes, we treat it as `"{worktree}"` since we only need the syntax rules from the file's major mode, not the actual index content.

## Testing

Tested with a Rust project that had staged changes - syntax highlighting now works correctly for both staged and unstaged diffs.