### PR TITLE
magit-repos: use uniquify-separator if set

### DIFF
--- a/lisp/magit-repos.el
+++ b/lisp/magit-repos.el
@@ -535,7 +535,9 @@ instead."
                 (magit-list-repos-uniquify
                  (mapcar (lambda (v)
                            (cons (concat
-                                  key "\\"
+                                  key
+                                  (or (bound-and-true-p uniquify-separator)
+                                      "\\")
                                   (file-name-nondirectory
                                    (directory-file-name
                                     (substring v 0 (- (1+ (length key)))))))


### PR DESCRIPTION
When the user has set `uniquify-separator`, use it in `magit-list-repos-uniquify` for consistency. Fixes a small nit where magit's uniquification is jarringly different from what I usually see. This change stops short of explicitly loading `uniquify`, since that seemed unnecessary.
