### PR TITLE
manual: extend documentation of rebase subset with git equivalent

### DIFF
--- a/docs/magit.org
+++ b/docs/magit.org
@@ -6094,6 +6094,10 @@ Remotes]].
   commits from START to ~HEAD~ onto NEWBASE.  START has to be selected
   from a list of recent commits.
 
+  This command calls ~git rebase --onto NEWBASE START HEAD~.  Because
+  the range always ends at ~HEAD~, you must first check out the branch
+  or commit you want as the upper bound (a detached ~HEAD~ works too).
+
 By default Magit uses the ~--autostash~ argument, which causes
 uncommitted changes to be stored in a stash before the rebase begins.
 These changes are restored after the rebase completes and if possible


### PR DESCRIPTION
The current entry for `r s` (`magit-rebase-subset`) in the manual does
not mention the underlying Git command it runs, nor does it explain that
`HEAD` must already be at the desired upper bound before invoking it.

This is a discoverability problem for users coming from the Git CLI.
`git rebase --onto NEWBASE START END` is a well-known pattern, but
there is no hint in the manual that `r s` is its Magit equivalent;
I had to read the source code to find that out.

The fix adds two sentences to the `r s` entry:

- `This command calls ~git rebase --onto NEWBASE START HEAD~.` makes
  the mapping to Git explicit, following the same pattern already used
  throughout the manual (e.g. `c e`, `c a`, `c f`, `c s` in the
  Committing section).

- A note that because the range always ends at `HEAD`, the user must
  check out the target branch or commit first (detached `HEAD` works
  too). This covers the general `git rebase --onto NEWBASE START END`
  use case: checking out `END` is how you set it.

Only `docs/magit.org` is changed; I did not commit the autogenerated
`docs/magit.texi` because, due to a different version of org-mode,
(Emacs built-in 9.7.11), it produced many other changes that were not desirable.
I trust that the small change proposed in this PR will not break the build chain of
the self-documentation.

