### PR TITLE
Fix rewording empty commits during rebase

### DIFF
--- a/lisp/magit-sequence.el
+++ b/lisp/magit-sequence.el
@@ -805,16 +805,29 @@ argument, prompt for the first commit to potentially squash into."
       nil nil t)))
 
 (defun magit-rebase--perl-editor (action since)
-  (let ((commit (magit-rev-abbrev (magit-rebase--target-commit since))))
-    (format "%s -i -p -e '++$x if not $x and s/^pick %s/%s %s/'"
+  (let* ((commit (magit-rebase--target-commit since))
+         (abbrev (magit-rev-abbrev commit))
+         (replacement
+          (cl-case action
+            (edit   (format "edit %s" abbrev))
+            (remove (format "noop\n# pick %s" abbrev))
+            (reword (if (magit-rebase--empty-commit-p commit)
+                        (concat "$&\\n"
+                                "exec git commit --amend "
+                                "--allow-empty --only --edit")
+                      (format "reword %s" abbrev)))
+            (t      (error "Unknown action: %s" action)))))
+    (format "%s -i -p -e '++$x if not $x and s/^pick %s\\S*.*$/%s/'"
             magit-perl-executable
-            commit
-            (cl-case action
-              (edit   "edit")
-              (remove "noop\n# pick")
-              (reword "reword")
-              (t      (error "Unknown action: %s" action)))
-            commit)))
+            abbrev
+            replacement)))
+
+(defun magit-rebase--empty-commit-p (commit)
+  (let ((tree (magit-rev-parse (concat commit "^{tree}"))))
+    (equal tree
+           (if-let ((parent (car (magit-commit-parents commit))))
+               (magit-rev-parse (concat parent "^{tree}"))
+             (magit-git-string "mktree")))))
 
 ;;;###autoload
 (defun magit-rebase-continue (&optional noedit)

--- a/test/magit-tests.el
+++ b/test/magit-tests.el
@@ -25,6 +25,7 @@
 (require 'tramp-sh)
 
 (require 'magit)
+(require 'magit-sequence)
 
 (defun magit-test-init-repo (dir &rest args)
   (let ((magit-git-global-arguments
@@ -69,6 +70,12 @@
         (unless raw
           (setq result (string-trim result)))
         result))))
+
+(defun magit-test-rebase-with-editor (editor &rest args)
+  (let ((process-environment (copy-sequence process-environment)))
+    (push "GIT_EDITOR=true" process-environment)
+    (push (concat "GIT_SEQUENCE_EDITOR=" editor) process-environment)
+    (apply #'magit-git-success "rebase" "-i" args)))
 
 ;;; Git
 
@@ -212,6 +219,31 @@
     (should     (magit-get-boolean "a.b"))
     (let ((magit--refresh-cache (list (cons 0 0))))
      (should    (magit-get-boolean "a.b")))))
+
+(ert-deftest magit-rebase-reword-commit:empty-root ()
+  (magit-with-test-repository
+    (magit-git "commit" "--allow-empty" "-m" "root")
+    (let ((root (magit-rev-parse "HEAD")))
+      (should (magit-test-rebase-with-editor
+               (magit-rebase--perl-editor 'reword root)
+               "--root")))
+    (should (equal (magit-git-string "log" "-1" "--format=%s") "root"))))
+
+(ert-deftest magit-rebase-reword-commit:empty-past ()
+  (magit-with-test-repository
+    (write-region "one\n" nil "file")
+    (magit-git "add" "file")
+    (magit-git "commit" "-m" "one")
+    (magit-git "commit" "--allow-empty" "-m" "two")
+    (write-region "one\ntwo\n" nil "file")
+    (magit-git "add" "file")
+    (magit-git "commit" "-m" "three")
+    (let ((commit (magit-rev-parse "HEAD~1")))
+      (should (magit-test-rebase-with-editor
+               (magit-rebase--perl-editor 'reword (concat commit "^"))
+               (concat commit "^"))))
+    (should (equal (magit-git-lines "log" "--format=%s" "--reverse")
+                   '("one" "two" "three")))))
 
 (ert-deftest magit-get-{current|next}-tag ()
   (magit-with-test-repository


### PR DESCRIPTION
Hello,

This commit is AI generated. It supposedly fixes my problem: when I try to reword the root commit of a repository it fails. E.g doing `rw` on the root commit. Everything "works" but then the commit is still not reworded.

I'll let you judge if fix is appropriate.

---

This fixes a bug in Magit's single-commit reword flow for empty commits, including the root commit case the user reported. Invoking `rw` currently rewrites the rebase todo entry to use Git's `reword` action, but when the targeted commit is empty Git later tries to amend that commit without `--allow-empty`. The result is that the rebase stops with Git claiming that amending the commit would make it empty, even though the commit was already empty and the user only wanted to change its message.

The root cause is that `magit-rebase--perl-editor` always rewrote the selected todo entry to `reword`, regardless of whether the target commit was empty. That is fine for normal commits, but it routes empty commits through a broken Git path. This patch teaches Magit to detect empty target commits and, for the reword action only, keep the original `pick` entry and append an `exec git commit --amend --allow-empty --only --edit` step instead. That preserves the existing interactive-rebase workflow for non-empty commits while using a safe amend path for empty commits. The change covers empty root commits and empty non-root commits with the same logic.

I added regression tests that execute Git using the exact `GIT_SEQUENCE_EDITOR` string Magit generates. One test covers rewording an empty root commit with `git rebase -i --root`; the other covers rewording an empty non-root commit during an interactive rebase range. Both tests verify that the rebase completes successfully and that the commit history remains intact.

Validation for this patch consisted of running the two new ERT tests in batch mode and byte-compiling the touched files.
