### PR TITLE
magit--find-buffer condition changes during iteration

### DIFF
--- a/lisp/magit-base.el
+++ b/lisp/magit-base.el
@@ -1210,11 +1210,12 @@ Like `message', except that `message-log-max' is bound to nil."
 (defun magit--find-buffer (&rest plist)
   "Like `find-buffer' but take multiple VARIABLE-VALUE pairs."
   (seq-find (lambda (buf)
-              (while (and plist
-                          (equal (buffer-local-value (car plist) buf)
-                                 (cadr plist)))
-                (setq plist (cddr plist)))
-              (not plist))
+              (let ((plist plist))
+                (while (and plist
+                            (equal (buffer-local-value (car plist) buf)
+                                   (cadr plist)))
+                  (setq plist (cddr plist)))
+                (not plist)))
             (buffer-list)))
 
 ;;; _


### PR DESCRIPTION
Hi, I updated from MELPA today and found ediff-dwim on a file line inside a magit-revision buffer broke; it displays the parent commit of that file twice, compare it against itself and says no change.  Followed it in edebug and found this function likely broken.