### PR TITLE
Optimize magit--abrrev-if-oid and magit-ref-p

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -2291,30 +2291,47 @@ specified using `core.worktree'."
                    (if (> (length line) 8) (substring line 9) t)))))
     (nreverse worktrees)))
 
-(defun magit-symbolic-ref-p (name)
-  (magit-git-success "symbolic-ref" "--quiet" name))
+(defun magit-symbolic-ref-p (string)
+  "Return t if STRING is a reference, nil otherwise."
+  (cl-assert (stringp string))
+  (magit-git-success "symbolic-ref" "--quiet" string))
 
-(defun magit-ref-p (rev)
-  (or (car (member rev (magit-list-refs "refs/")))
-      (car (member rev (magit-list-refnames "refs/")))))
+(defun magit-ref-p (string)
+  "Return t if STRING is a reference, nil otherwise."
+  (cl-assert (stringp string))
+  (and (magit-ref-fullname string)
+       (not (magit-symbolic-ref-p string))))
 
-(defun magit-branch-p (rev)
-  (or (car (member rev (magit-list-branches)))
-      (car (member rev (magit-list-branch-names)))))
+(defun magit-branch-p (string)
+  "Return t if STRING is a local or remote-tracking branch, nil otherwise."
+  (cl-assert (stringp string))
+  (or (magit-local-branch-p string)
+      (magit-remote-branch-p string)))
 
-(defun magit-local-branch-p (rev)
-  (or (car (member rev (magit-list-local-branches)))
-      (car (member rev (magit-list-local-branch-names)))))
+(defun magit-local-branch-p (string)
+  "Return t if STRING is a local branch."
+  (cl-assert (stringp string))
+  (magit-git-success "show-ref" "--quiet" "--branches" string))
 
-(defun magit-remote-branch-p (rev)
-  (or (car (member rev (magit-list-remote-branches)))
-      (car (member rev (magit-list-remote-branch-names)))))
+(defun magit-remote-branch-p (string)
+  "Return t if STRING is a remote-tracking branch, nil otherwise."
+  (cl-assert (stringp string))
+  (seq-some (lambda (line)
+              (let ((ref (cadr (split-string line " "))))
+                (or (equal string ref)
+                    (equal string (substring ref 5))
+                    (equal string (substring ref 13)))))
+            (magit-git-lines "show-ref" string)))
 
-(defun magit-tag-p (obj)
-  (equal (magit-object-type obj) "tag"))
+(defun magit-tag-p (string)
+  "Return t if STRING is a tag, nil otherwise."
+  (cl-assert (stringp string))
+  (magit-git-success "show-ref" "--quiet" "--tags" string))
 
 (defun magit-remote-p (string)
-  (car (member string (magit-list-remotes))))
+  "Return t if STRING is a remote, nil otherwise."
+  (cl-assert (stringp string))
+  (and (member string (magit-list-remotes)) t))
 
 (defun magit-branch-set-face (branch)
   (magit--propertize-face branch (if (magit-local-branch-p branch)

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -2389,7 +2389,7 @@ If `first-parent' is set, traverse only first parents."
   (magit-rev-parse (magit-abbrev-arg "short") rev))
 
 (defun magit--abbrev-if-oid (obj)
-  (cond ((or (magit-ref-p obj) (member obj '("{index}" "{worktree}"))) obj)
+  (cond ((or (member obj '("{index}" "{worktree}")) (magit-ref-p obj)) obj)
         ((magit-rev-parse (magit-abbrev-arg "short") obj))
         (obj)))
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -2389,7 +2389,8 @@ If `first-parent' is set, traverse only first parents."
   (magit-rev-parse (magit-abbrev-arg "short") rev))
 
 (defun magit--abbrev-if-oid (obj)
-  (cond ((or (member obj '("{index}" "{worktree}")) (magit-ref-p obj)) obj)
+  (cond ((member obj '("{index}" "{worktree}")) obj)
+        ((magit-ref-p obj) obj)
         ((magit-rev-parse (magit-abbrev-arg "short") obj))
         (obj)))
 

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -2310,16 +2310,16 @@ specified using `core.worktree'."
   (or (car (member rev (magit-list-remote-branches)))
       (car (member rev (magit-list-remote-branch-names)))))
 
-(defun magit-branch-set-face (branch)
-  (magit--propertize-face branch (if (magit-local-branch-p branch)
-                                     'magit-branch-local
-                                   'magit-branch-remote)))
-
 (defun magit-tag-p (obj)
   (equal (magit-object-type obj) "tag"))
 
 (defun magit-remote-p (string)
   (car (member string (magit-list-remotes))))
+
+(defun magit-branch-set-face (branch)
+  (magit--propertize-face branch (if (magit-local-branch-p branch)
+                                     'magit-branch-local
+                                   'magit-branch-remote)))
 
 (defvar magit-main-branch-names
   '("main" "master" "trunk" "development")

--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -1659,9 +1659,8 @@ to, or to some other symbolic-ref that points to the same ref."
     (branch (oref it value))
     (commit (or (magit--painted-branch-at-point)
                 (magit-name-branch (oref it value))))
-    (pullreq (and (fboundp 'forge--pullreq-branch)
-                  (magit-branch-p
-                   (forge--pullreq-branch (oref it value)))))
+    (pullreq (and (fboundp 'forge--pullreq-branch-active)
+                  (forge--pullreq-branch-active (oref it value))))
     (related-refs (magit--painted-branch-at-point))
     ((unpulled unpushed)
      (magit-ref-abbrev
@@ -1715,11 +1714,10 @@ to, or to some other symbolic-ref that points to the same ref."
                     (let ((rev (oref it value)))
                       (or (magit-name-branch rev) rev))))
         (tag (magit-ref-maybe-qualify (oref it value) "tags/"))
-        (pullreq (or (and (fboundp 'forge--pullreq-branch)
-                          (magit-branch-p
-                           (forge--pullreq-branch (oref it value))))
-                     (magit-ref-p (format "refs/pullreqs/%s"
-                                          (oref (oref it value) number)))))
+        (pullreq (or (and (fboundp 'forge--pullreq-branch-active)
+                          (forge--pullreq-branch-active (oref it value)))
+                     (and (fboundp 'forge--pullreq-ref)
+                          (forge--pullreq-ref (oref it value)))))
         ((unpulled unpushed)
          (magit-ref-abbrev
           (replace-regexp-in-string "\\.\\.\\.?" "" (oref it value)))))


### PR DESCRIPTION
I use `magit-diff-fontify-hunk` to `'all` on Windows and I hit a situation were magit is really slow, more than the usual magit on Windows slowness. The context is having about 50 hunks in the status buffer, all visible (expanded), some unstaged, some staged, and I stage hunk by hunk, with a refresh after each change (default magit behavior), each refresh takes around 100s. For context my repo has around 6k refs (this will be relevant later).
I narrowed the issue to be between 1 and 2 calls to `magit-ref-p` per hunk to fontify.
The current implementation of `magit-ref-p` collects all ref names in long and short form and check if the given rev string is in one of those set, each collection taking around 600-800ms in my repo (because Windows + 6K refs), meaning each call to `magit-ref-p` is around 1.4s -> multiplied by hunk count * [1-2] that's a lot.
I replaced it by a call to `magit-ref-fullname` which returns non-nil (the ref full name) for ref and nil for non ref and is a way cheaper git call that is cached.

It does change the behavior is some cases. Here are the test case I and a LLM thought about.
With a test repo initialized with
```bash
git init repo && cd repo
git commit --allow-empty -m init
git branch foo
git tag foo
git branch bar/foo
```
The results are as follow
| Input | Before | After |
| --- | --- | --- |
| `main` | truthy | truthy |
| `bar/foo` | truthy | truthy |
| `refs/heads/main` (full) | truthy | truthy |
| `foo` (ambiguous short) | nil    | nil    |
| `heads/foo`, `tags/foo` (desambiguation) | truthy | truthy |
| `heads/main` (partial, unambiguous) | **nil** | **truthy** |
| `HEAD` or `@` (attached) | **nil** | **truthy** |
| `HEAD@{0}`, `main@{0}` (reflog syntax) | nil    | nil    |
| abbreviated / full OID | nil    | nil    |
| nonexistent refname | nil    | nil    |
| `{index}`, `{worktree}` | nil    | nil    |

My biggest worry was about ambiguous ref but it happens to work the same but on the way I saw that refs of the form `heads/<branch>` now return non-nil, this seems like an improvement to me. The other difference is with `HEAD` and probably other symbolic-ref which now also return non-nil, this also seems acceptable to me.

The other change is in `magit--abbrev-if-oid` to swap both condition to only call `magit-ref-p` for non `{index}` or `{worktree}` obj.

For completeness, here are the full profile obtained by running `magit-profile-refresh-buffer` in my status buffer with all hunks expanded.
<details>
<summary>Old - 105s</summary>
<pre>
magit-refresh-buffer                                     1           105.876699    105.876699
magit-section-update-highlight                           1           101.412946    101.412946
magit-section-update-paint                               49          99.696004999  2.0346123469
magit-section-paint                                      49          99.465113999  2.0299002857
magit-process-git                                        304         98.394131999  0.3236649078
magit-process-file                                       304         98.381867999  0.3236245657
magit-diff--update-hunk-syntax                           49          97.15089      1.9826712244
magit--git-insert                                        267         94.866520999  0.3553053220
magit-git-insert                                         264         94.220410999  0.3568954962
magit-diff--get-hunk-syntax                              98          93.902273     0.9581864591
magit-find-file-noselect                                 98          93.722224999  0.9563492346
magit-git-lines                                          178         88.668456     0.4981373932
magit--abbrev-if-oid                                     67          86.133807999  1.2855792238
magit-ref-p                                              67          86.057999     1.2844477462
magit-list-refs                                          134         86.052422999  0.6421822611
magit-list-refnames                                      67          58.759335     0.877005
magit-git-string                                         539         5.5250020000  0.0102504675
magit-run-section-hook                                   2           4.853264      2.426632
magit--refresh-blob-buffer                               67          4.417931      0.0659392686
magit-status-refresh-buffer                              1           3.828283      3.828283
magit-diff-visit--sides                                  49          3.1673459999  0.0646397142
magit-blob-oid                                           67          3.0361759999  0.0453160597
magit--file-index-stages                                 44          3.0225849999  0.0686951136
magit-git-exit-code                                      32          2.5236709999  0.0788647187
magit-anything-staged-p                                  31          2.4213049999  0.0781066129
magit-git-failure                                        31          2.4209819999  0.0780961935
magit-diff-update-hunk-refinement                        49          2.0972490000  0.0428010000
magit-section-show                                       78          1.933974      0.0247945384
magit--git-wash                                          3           1.91473       0.6382433333
magit-rev-verify                                         74          1.8200049999  0.0245946621
magit-wash-sequence                                      27          1.6001120000  0.0592634074
magit-blob-p                                             134         1.5510639999  0.0115751044
magit-object-type                                        134         1.5501480000  0.0115682686
magit-commit-oid                                         67          1.3802050000  0.0206000746
magit-section-match-1                                    1216        1.3514939999  0.0011114259
magit-insert-status-headers                              1           1.192861      1.192861
magit-insert-unpushed-to-upstream-or-recent              1           1.167835      1.167835
magit-insert-headers                                     1           1.128741      1.128741
magit-insert-recent-commits                              1           1.104845      1.104845
magit--insert-log                                        1           1.036391      1.036391
magit-section-match-2                                    1503        0.9557039999  0.0006358642
magit-git-str                                            4           0.9470000000  0.2367500000
magit--insert-diff                                       2           0.878408      0.439204
magit-insert-tags-header                                 1           0.820079      0.820079
magit-diff-wash-diffs                                    2           0.677509      0.3387545
magit-diff-wash-diff                                     24          0.677283      0.028220125
magit-diff-insert-file-section                           24          0.67498       0.0281241666
magit-diff--dwim                                         49          0.6413440000  0.0130886530
magit-log-wash-log                                       1           0.58334       0.58334
magit-section-match                                      87          0.5375110000  0.0061782873
magit-maybe-make-margin-overlay                          81          0.5228200000  0.0064545679
magit-insert-heading                                     78          0.517841      0.0066389871
magit-insert-staged-changes                              1           0.501536      0.501536
magit-diff-wash-hunk                                     71          0.4715689999  0.0066418169
magit-rev-parse                                          277         0.4523319999  0.0016329675
magit-log-wash-rev                                       10          0.450879      0.0450879
magit-insert-unstaged-changes                            1           0.443043      0.443043
magit-get-next-tag                                       1           0.429941      0.429941
magit-get-current-tag                                    1           0.389725      0.389725
magit-format-ref-labels                                  2           0.374185      0.1870925
magit-git-items                                          3           0.255824      0.0852746666
magit-section-hidden                                     196         0.2544350000  0.0012981377
magit-section-ident                                      323         0.2370240000  0.0007338204
magit-section-highlight                                  30          0.2041660000  0.0068055333
magit-insert-untracked-files                             1           0.195729      0.195729
magit-insert-files                                       1           0.195711      0.195711
magit-list-untracked-files                               1           0.195041      0.195041
magit-get                                                101         0.1899309999  0.0018805049
magit-get-all                                            101         0.1891159999  0.0018724356
magit-ref-abbrev                                         5           0.185508      0.0371016
magit-insert-section--create                             91          0.158197      0.0017384285
magit--get-blob-buffer                                   67          0.1510420000  0.0022543582
magit-abbrev-length                                      91          0.1424710000  0.0015656153
magit-rev-parse-safe                                     2           0.127389      0.0636945
magit-config-get-from-cached-list                        100         0.1272190000  0.0012721900
magit-insert-head-branch-header                          1           0.125015      0.125015
magit-insert-diff-filter-header                          1           0.123204      0.123204
magit-ignore-submodules-p                                1           0.1232        0.1232
magit-get-push-branch                                    5           0.1228740000  0.0245748
magit-section-cached-visibility                          91          0.0862890000  0.0009482307
magit-insert-section--finish                             91          0.0797519999  0.0008763956
forge-get-repository                                     9           0.078078      0.0086753333
forge-repository-at-point                                3           0.074657      0.0248856666
magit-rev-abbrev                                         45          0.0707370000  0.0015719333
forge-topic-at-point                                     3           0.0706939999  0.0235646666
magit-section-value-if                                   6           0.067484      0.0112473333
magit--refresh-buffer-set-positions                      1           0.067475      0.067475
magit-insert-merge-log                                   1           0.065739      0.065739
magit-merge-in-progress-p                                1           0.065733      0.065733
magit-gitdir                                             9           0.0656720000  0.0072968888
magit-toplevel                                           198         0.0650809999  0.0003286919
magit-insert-stashes                                     1           0.064545      0.064545
magit-rev-format                                         1           0.064496      0.064496
forge-insert-issues                                      1           0.064208      0.064208
magit-section-maybe-add-heading-map                      91          0.0630810000  0.0006931978
magit-get-upstream-branch                                4           0.062987      0.01574675
magit-section-equal                                      1           0.062166      0.062166
magit-bare-repo-p                                        1           0.061786      0.061786
magit-rev-parse-true                                     1           0.061697      0.061697
magit-git-true                                           1           0.061689      0.061689
magit-git-output                                         1           0.06168       0.06168
magit-insert-push-branch-header                          1           0.060253      0.060253
magit-get-current-branch                                 7           0.0601859999  0.008598
magit-diff-expansion-threshold                           91          0.052375      0.0005755494
magit-section-maybe-update-visibility-indicator          81          0.048956      0.0006043950
magit-diff--file-section                                 49          0.032013      0.0006533265
forge-insert-pullreqs                                    1           0.018517      0.018517
magit--find-buffer                                       67          0.016909      0.0002523731
magit-abbrev-arg                                         90          0.0108069999  0.0001200777
magit-section--refine                                    18          0.009937      0.0005520555
forge-insert-discussions                                 1           0.009889      0.009889
forge--list-topics                                       1           0.008018      0.008018
forge--list-topics-1                                     1           0.008005      0.008005
magit-section-selective-highlight-p                      42          0.0075340000  0.0001793809
forge--insert-topics                                     1           0.007524      0.007524
forge-sql                                                1           0.007429      0.007429
magit-diff--get-hunk-text                                98          0.0073020000  7.451...e-05
forge-get-pullreq                                        3           0.00696       0.00232
magit-section-hide                                       3           0.005441      0.0018136666
magit-diff-paint-tab                                     571         0.0044610000  7.812...e-06
magit-section-goto-successor                             1           0.003478      0.003478
magit-process-git-arguments                              304         0.0033210000  1.092...e-05
magit-section-match-assoc                                16          0.0029389999  0.0001836874
magit-section-goto-successor--same                       1           0.002798      0.002798
forge-buffer-repository                                  3           0.0016710000  0.0005570000
magit--refresh-buffer-get-positions                      1           0.001439      0.001439
magit-convert-filename-for-git                           89          0.0010789999  1.212...e-05
magit-delete-line                                        83          0.001078      1.298...e-05
magit-section--set-section-properties                    90          0.0009909999  1.101...e-05
magit-current-section                                    208         0.0009520000  4.576...e-06
magit-diff-type                                          49          0.0008489999  1.732...e-05
magit--process-coding-system                             304         0.0008350000  2.746...e-06
magit-process-environment                                304         0.0007580000  2.493...e-06
magit-diff-paint-whitespace                              571         0.0007190000  1.259...e-06
magit-diff-tab-width                                     49          0.0006300000  1.285...e-05
magit-hunk-section                                       49          0.0005700000  1.163...e-05
magit-get-section                                        1           0.000508      0.000508
magit-section-content-p                                  172         0.0004760000  2.767...e-06
magit-region-values                                      49          0.000461      9.408...e-06
magit-section-ident-value                                324         0.0004070000  1.256...e-06
magit-diff-scope                                         49          0.0003970000  8.102...e-06
magit-log--wash-summary                                  11          0.000348      3.163...e-05
magit-log-format-margin                                  10          0.000335      3.35e-05
magit-git-version<                                       24          0.0003110000  1.295...e-05
magit-delete-match                                       72          0.0003109999  4.319...e-06
magit-file-section                                       24          0.0003079999  1.283...e-05
magit-section--opportunistic-paint                       78          0.0002969999  3.807...e-06
magit-insert-sequencer-sequence                          1           0.000265      0.000265
magit-section-at                                         373         0.0002629999  7.050...e-07
magit--safe-default-directory                            2           0.000262      0.000131
magit-log-format-author-margin                           10          0.000255      2.550...e-05
magit-get-push-remote                                    3           0.0002270000  7.566...e-05
magit--meta-hunk-p                                       67          0.0002049999  3.059...e-06
magit--eol-position                                      158         0.0002029999  1.284...e-06
magit-format-file                                        24          0.0001880000  7.833...e-06
magit-section                                            7           0.000182      2.600...e-05
magit-section-maybe-cache-visibility                     81          0.0001709999  2.111...e-06
magit--overlay-at                                        79          0.0001669999  2.113...e-06
magit-section-parent-value                               49          0.0001589999  3.244...e-06
magit-cherry-pick-in-progress-p                          1           0.000156      0.000156
magit-file-line                                          2           0.000156      7.8e-05
magit-section--opportunistic-wash                        78          0.0001329999  1.705...e-06
magit-rebase-in-progress-p                               2           0.0001309999  6.549...e-05
magit-insert-unpushed-to-pushremote                      1           0.000125      0.000125
magit-commit-section                                     10          0.0001139999  1.139...e-05
magit--rev-dereference                                   68          0.0001119999  1.647...e-06
forge-thingatpt--topic                                   3           0.0001080000  3.6e-05
magit-insert-child-count                                 27          0.0001069999  3.962...e-06
magit-revert-in-progress-p                               1           0.000102      0.000102
magit-insert-upstream-branch-header                      1           9.9e-05       9.9e-05
magit-bisect-in-progress-p                               3           8.1e-05       2.700...e-05
magit-diff-use-hunk-region-p                             49          7.999...e-05  1.632...e-06
magit--assert-default-directory                          1           7.5e-05       7.5e-05
magit-rebase--get-state-lines                            1           7.2e-05       7.2e-05
magit-unpulled-section--eieio-childp                     81          7.099...e-05  8.765...e-07
forge-db                                                 8           7.000...e-05  8.750...e-06
magit-insert-rebase-sequence                             1           6.8e-05       6.8e-05
magit-file-section-p                                     91          6.699...e-05  7.362...e-07
magit-section-get-relative-position                      2           6.500...e-05  3.250...e-05
magit-unpushed-section--eieio-childp                     81          6.399...e-05  7.901...e-07
magit-section-visibility-indicator                       82          4.499...e-05  5.487...e-07
magit-format-file-default                                24          4.399...e-05  1.833...e-06
magit-insert-bisect-output                               1           4e-05         4e-05
magit-make-margin-overlay                                13          3.900...e-05  3.000...e-06
magit-git-version                                        24          3.9e-05       1.625e-06
magit-region-sections                                    51          3.899...e-05  7.647...e-07
magit-highlight-bracket-keywords                         11          3.700...e-05  3.363...e-06
magit-insert-am-sequence                                 1           3.3e-05       3.3e-05
magit-section-highlight-range                            30          2.900...e-05  9.666...e-07
magit--age                                               10          2.900...e-05  2.900...e-06
magit-expand-git-file-name                               2           2.9e-05       1.45e-05
magit-unpushed-section                                   1           2.8e-05       2.8e-05
magit-am-in-progress-p                                   1           2.8e-05       2.8e-05
magit-highlight-squash-markers                           11          2.700...e-05  2.454...e-06
magit-insert-bisect-rest                                 1           2.6e-05       2.6e-05
magit-insert-bisect-log                                  1           2.6e-05       2.6e-05
magit-focused-sections                                   1           2.5e-05       2.5e-05
magit--propertize-face                                   20          2.100...e-05  1.050...e-06
magit-process-unset-mode-line-error-status               1           1.7e-05       1.7e-05
magit-decode-git-path                                    48          1.400...e-05  2.916...e-07
forge--list-topics-2                                     1           1.2e-05       1.2e-05
magit-repository-local-get                               1           1e-05         1e-05
magit-insert-unpulled-from-pushremote                    1           7e-06         7e-06
magit--refresh-buffer-function                           1           6e-06         6e-06
magit--right-margin-option                               10          5.999...e-06  6e-07
forge--clone-buffer-topics-spec                          1           5e-06         5e-06
magit-section-maybe-paint-visibility-ellipses            1           5e-06         5e-06
magit-commit-section--eieio-childp                       3           4.999...e-06  1.666...e-06
magit-insert-unpulled-from-upstream                      1           4e-06         4e-06
magit-repository-local-exists-p                          1           3e-06         3e-06
magit-diff--maybe-add-stat-arguments                     3           2e-06         6.666...e-07
magit-section--maybe-enable-long-lines-shortcuts         1           1e-06         1e-06
magit-repository-local-repository                        1           1e-06         1e-06
magit-point                                              2           1e-06         5e-07
magit-insert-error-header                                1           1e-06         1e-06
forge--init-buffer-topics-spec                           1           0.0           0.0
</pre>
</details>
<details>
<summary>New - 18s</summary>
<pre>
magit-refresh-buffer                                     1           18.47939      18.47939
magit-section-update-highlight                           1           14.794989     14.794989
magit-process-git                                        171         13.290941999  0.0777248070
magit-process-file                                       171         13.283143     0.0776791988
magit-section-update-paint                               49          13.220897999  0.2698142448
magit-section-paint                                      49          13.089230999  0.2671271632
magit-diff--update-hunk-syntax                           49          10.885456999  0.2221521836
magit--git-insert                                        134         9.7200509999  0.0725376940
magit-git-insert                                         131         9.008804      0.0687694961
magit-diff--get-hunk-syntax                              98          7.9478229999  0.0811002346
magit-find-file-noselect                                 98          7.8466580000  0.0800679387
magit-git-string                                         584         5.6243760000  0.0096307808
magit--refresh-blob-buffer                               67          4.520372      0.0674682388
magit-run-section-hook                                   2           4.4167760000  2.2083880000
magit-status-refresh-buffer                              1           3.376378      3.376378
magit--file-index-stages                                 44          3.1408899999  0.0713838636
magit-blob-oid                                           67          3.1396749999  0.0468608208
magit-git-lines                                          44          3.1390930000  0.0713430227
magit-diff-visit--sides                                  49          2.8603180000  0.0583738367
magit-git-exit-code                                      32          2.550951      0.0797172187
magit-anything-staged-p                                  31          2.4439779999  0.0788379999
magit-git-failure                                        31          2.443677      0.0788282903
magit-diff-update-hunk-refinement                        49          2.070216      0.0422493061
magit-rev-verify                                         74          1.8308630000  0.0247413918
magit-blob-p                                             134         1.5230809999  0.0113662761
magit-object-type                                        134         1.5220709999  0.0113587388
magit--git-wash                                          3           1.483166      0.4943886666
magit-commit-oid                                         67          1.3790570000  0.0205829402
magit-insert-status-headers                              1           1.211634      1.211634
magit-insert-unpushed-to-upstream-or-recent              1           1.187512      1.187512
magit-insert-headers                                     1           1.149112      1.149112
magit-insert-recent-commits                              1           1.124659      1.124659
magit--insert-log                                        1           1.055554      1.055554
magit-section-show                                       78          0.9641410000  0.0123607820
magit-git-str                                            4           0.959407      0.23985175
magit-insert-tags-header                                 1           0.830391      0.830391
magit-wash-sequence                                      27          0.774292      0.0286774814
magit-log-wash-log                                       1           0.544879      0.544879
magit-rev-parse                                          322         0.5329359999  0.0016550807
magit-section-match-1                                    1216        0.5093590000  0.0004188807
magit-section-match-2                                    1503        0.4550879999  0.0003027864
magit-get-next-tag                                       1           0.44103       0.44103
magit--insert-diff                                       2           0.4276879999  0.2138439999
magit-log-wash-rev                                       10          0.4078        0.04078
magit-get-current-tag                                    1           0.38897       0.38897
magit-format-ref-labels                                  2           0.386384      0.193192
magit-diff--dwim                                         49          0.3066659999  0.0062584897
magit-insert-staged-changes                              1           0.288683      0.288683
magit-git-items                                          3           0.260909      0.0869696666
magit-diff-wash-diffs                                    2           0.2197180000  0.1098590000
magit-diff-wash-diff                                     24          0.2194850000  0.0091452083
magit-diff-insert-file-section                           24          0.2169369999  0.0090390416
magit-insert-unstaged-changes                            1           0.208582      0.208582
magit-insert-untracked-files                             1           0.201869      0.201869
magit-insert-files                                       1           0.201859      0.201859
magit-list-untracked-files                               1           0.201177      0.201177
magit-get                                                101         0.1893779999  0.0018750297
magit-ref-abbrev                                         5           0.1891769999  0.0378354
magit-get-all                                            101         0.1885989999  0.0018673168
magit-section-match                                      87          0.1626319999  0.0018693333
magit-maybe-make-margin-overlay                          81          0.1566530000  0.0019339876
magit-section-highlight                                  30          0.1537430000  0.0051247666
magit--get-blob-buffer                                   67          0.1524499999  0.0022753731
magit-insert-heading                                     78          0.1516149999  0.0019437820
magit-section-hidden                                     196         0.1513180000  0.0007720306
magit-diff-wash-hunk                                     71          0.1466549999  0.0020655633
magit-abbrev-length                                      91          0.1453200000  0.0015969230
magit--abbrev-if-oid                                     67          0.1402830000  0.0020937761
magit-insert-head-branch-header                          1           0.133423      0.133423
magit-rev-parse-safe                                     2           0.129464      0.064732
magit-get-push-branch                                    5           0.12671       0.0253419999
magit-config-get-from-cached-list                        100         0.1257729999  0.0012577299
magit-insert-diff-filter-header                          1           0.12289       0.12289
magit-ignore-submodules-p                                1           0.122887      0.122887
magit-section-ident                                      323         0.0851979999  0.0002637708
magit-rev-abbrev                                         45          0.0764569999  0.0016990444
magit-rev-format                                         1           0.069383      0.069383
magit-ref-p                                              45          0.0683089999  0.0015179777
magit-ref-fullname                                       45          0.0679640000  0.0015103111
magit-insert-merge-log                                   1           0.066954      0.066954
magit-merge-in-progress-p                                1           0.06695       0.06695
magit-gitdir                                             9           0.066918      0.0074353333
magit-insert-section--create                             91          0.065294      0.0007175164
magit-toplevel                                           198         0.0651779999  0.0003291818
magit-bare-repo-p                                        1           0.064578      0.064578
magit-rev-parse-true                                     1           0.064491      0.064491
magit-git-true                                           1           0.064484      0.064484
magit-git-output                                         1           0.064473      0.064473
magit-get-current-branch                                 7           0.063672      0.0090960000
magit-get-upstream-branch                                4           0.062851      0.01571275
magit-insert-stashes                                     1           0.062433      0.062433
magit-insert-push-branch-header                          1           0.062213      0.062213
magit-section-maybe-update-visibility-indicator          81          0.050991      0.0006295185
magit-section-cached-visibility                          91          0.0391480000  0.0004301978
magit-diff--file-section                                 49          0.0311589999  0.0006358979
magit-insert-section--finish                             91          0.0253910000  0.0002790219
forge-get-repository                                     9           0.0236370000  0.0026263333
forge-repository-at-point                                3           0.021399      0.0071330000
magit--find-buffer                                       67          0.0195909999  0.0002924029
forge-insert-pullreqs                                    1           0.019544      0.019544
forge-topic-at-point                                     3           0.0177459999  0.0059153333
magit-section-value-if                                   6           0.014789      0.0024648333
magit--refresh-buffer-set-positions                      1           0.014468      0.014468
magit-section--refine                                    18          0.0109850000  0.0006102777
forge-insert-issues                                      1           0.01052       0.01052
forge-insert-discussions                                 1           0.009557      0.009557
magit-section-equal                                      1           0.009187      0.009187
magit-abbrev-arg                                         90          0.008851      9.834...e-05
forge--list-topics                                       1           0.008491      0.008491
forge--list-topics-1                                     1           0.008478      0.008478
magit-section-maybe-add-heading-map                      91          0.0078819999  8.661...e-05
forge-sql                                                1           0.007854      0.007854
forge--insert-topics                                     1           0.007795      0.007795
magit-diff--get-hunk-text                                98          0.0077639999  7.922...e-05
magit-section-selective-highlight-p                      42          0.0072750000  0.0001732142
forge-get-pullreq                                        3           0.006411      0.002137
magit-diff-expansion-threshold                           91          0.0061289999  6.735...e-05
magit-section-hide                                       3           0.005109      0.0017029999
magit-diff-paint-tab                                     571         0.0038160000  6.683...e-06
magit-section-goto-successor                             1           0.003412      0.003412
magit-section-match-assoc                                16          0.00303       0.000189375
magit-section-goto-successor--same                       1           0.002739      0.002739
magit-process-git-arguments                              171         0.0026600000  1.555...e-05
magit--refresh-buffer-get-positions                      1           0.001621      0.001621
magit-delete-line                                        83          0.0012299999  1.481...e-05
forge-buffer-repository                                  3           0.001078      0.0003593333
magit-convert-filename-for-git                           89          0.0010329999  1.160...e-05
magit-section--set-section-properties                    90          0.0008939999  9.933...e-06
magit-current-section                                    208         0.0008810000  4.235...e-06
magit-diff-type                                          49          0.0007619999  1.555...e-05
magit-diff-tab-width                                     49          0.0005480000  1.118...e-05
magit-hunk-section                                       49          0.0005430000  1.108...e-05
magit-get-section                                        1           0.00049       0.00049
magit--process-coding-system                             171         0.0004720000  2.760...e-06
magit-delete-match                                       72          0.0004460000  6.194...e-06
magit-region-values                                      49          0.0004289999  8.755...e-06
magit-section-content-p                                  172         0.0004180000  2.430...e-06
magit-process-environment                                171         0.00041       2.397...e-06
magit-log--wash-summary                                  11          0.0004079999  3.709...e-05
magit-section-ident-value                                324         0.0003890000  1.200...e-06
magit-diff-scope                                         49          0.000366      7.469...e-06
magit-log-format-margin                                  10          0.000339      3.39e-05
magit-file-section                                       24          0.000296      1.233...e-05
magit-diff-paint-whitespace                              571         0.0002930000  5.131...e-07
magit-git-version<                                       24          0.000265      1.104...e-05
magit-section--opportunistic-paint                       78          0.0002580000  3.307...e-06
magit-log-format-author-margin                           10          0.000257      2.57e-05
magit-section-at                                         373         0.0002559999  6.863...e-07
magit-get-push-remote                                    3           0.000249      8.3e-05
magit-format-file                                        24          0.0002210000  9.208...e-06
magit--safe-default-directory                            2           0.000204      0.000102
magit--eol-position                                      158         0.0001789999  1.132...e-06
magit--meta-hunk-p                                       67          0.0001689999  2.522...e-06
magit-section                                            7           0.000158      2.257...e-05
magit--overlay-at                                        79          0.0001579999  1.999...e-06
magit-section-maybe-cache-visibility                     81          0.0001429999  1.765...e-06
magit-insert-sequencer-sequence                          1           0.000138      0.000138
magit-insert-unpushed-to-pushremote                      1           0.000137      0.000137
magit-section-parent-value                               49          0.0001260000  2.571...e-06
magit-insert-child-count                                 27          0.0001159999  4.296...e-06
magit-commit-section                                     10          0.0001119999  1.119...e-05
magit-section--opportunistic-wash                        78          0.0001119999  1.435...e-06
forge-thingatpt--topic                                   3           0.0001040000  3.466...e-05
magit-rebase-in-progress-p                               2           0.000104      5.2e-05
magit-insert-upstream-branch-header                      1           9.7e-05       9.7e-05
magit--rev-dereference                                   68          9.599...e-05  1.411...e-06
magit-diff-use-hunk-region-p                             49          8.599...e-05  1.755...e-06
magit-cherry-pick-in-progress-p                          1           8.5e-05       8.5e-05
magit-unpulled-section--eieio-childp                     81          8.199...e-05  1.012...e-06
magit-file-line                                          2           7.9e-05       3.95e-05
magit-file-section-p                                     91          7.599...e-05  8.351...e-07
magit-rebase--get-state-lines                            1           7.3e-05       7.3e-05
magit--assert-default-directory                          1           7.1e-05       7.1e-05
magit-unpushed-section--eieio-childp                     81          5.699...e-05  7.037...e-07
forge-db                                                 8           4.999...e-05  6.249...e-06
magit-revert-in-progress-p                               1           4.9e-05       4.9e-05
magit-section-get-relative-position                      2           4.700...e-05  2.350...e-05
magit-format-file-default                                24          4.200...e-05  1.750...e-06
magit-insert-rebase-sequence                             1           3.8e-05       3.8e-05
magit-git-version                                        24          3.7e-05       1.541...e-06
magit-highlight-bracket-keywords                         11          3.500...e-05  3.181...e-06
magit-make-margin-overlay                                13          3.400...e-05  2.615...e-06
magit-region-sections                                    51          3.100...e-05  6.078...e-07
magit-section-visibility-indicator                       82          3.100...e-05  3.780...e-07
magit-bisect-in-progress-p                               3           2.9e-05       9.666...e-06
magit-highlight-squash-markers                           11          2.700...e-05  2.454...e-06
magit-unpushed-section                                   1           2.7e-05       2.7e-05
magit-section-highlight-range                            30          2.600...e-05  8.666...e-07
magit--age                                               10          2.600...e-05  2.600...e-06
magit-expand-git-file-name                               2           2.4e-05       1.2e-05
magit--propertize-face                                   20          2.200...e-05  1.1e-06
magit-focused-sections                                   1           2.2e-05       2.2e-05
magit-process-unset-mode-line-error-status               1           2.1e-05       2.1e-05
magit-insert-am-sequence                                 1           2e-05         2e-05
magit-am-in-progress-p                                   1           1.7e-05       1.7e-05
magit-insert-bisect-output                               1           1.5e-05       1.5e-05
forge--list-topics-2                                     1           1.4e-05       1.4e-05
magit-repository-local-get                               1           1.3e-05       1.3e-05
magit-decode-git-path                                    48          1.100...e-05  2.291...e-07
magit-insert-bisect-rest                                 1           1.1e-05       1.1e-05
magit-insert-bisect-log                                  1           1e-05         1e-05
magit--right-margin-option                               10          6.999...e-06  6.999...e-07
magit-repository-local-exists-p                          1           6e-06         6e-06
forge--clone-buffer-topics-spec                          1           6e-06         6e-06
magit-section-maybe-paint-visibility-ellipses            1           6e-06         6e-06
magit--refresh-buffer-function                           1           6e-06         6e-06
magit-insert-unpulled-from-pushremote                    1           5e-06         5e-06
magit-commit-section--eieio-childp                       3           3e-06         1e-06
magit-insert-unpulled-from-upstream                      1           3e-06         3e-06
magit-diff--maybe-add-stat-arguments                     3           2e-06         6.666...e-07
magit-insert-error-header                                1           2e-06         2e-06
magit-section--maybe-enable-long-lines-shortcuts         1           1e-06         1e-06
magit-repository-local-repository                        1           1e-06         1e-06
magit-point                                              2           1e-06         5e-07
forge--init-buffer-topics-spec                           1           1e-06         1e-06
</pre>
</details>