### PR TITLE
Ediff not cleaning up properly when quiting out of conflict resolution

### DIFF
--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -229,9 +229,7 @@ and alternative commands."
            (when (buffer-live-p ediff-buffer-C) (kill-buffer ediff-buffer-C))
            (when (buffer-live-p ediff-ancestor-buffer)
              (kill-buffer ediff-ancestor-buffer))
-           (magit-ediff--cleanup-buffers)
-           (let ((magit-ediff-previous-winconf winconf))
-             (run-hooks 'magit-ediff-quit-hook))))))))
+           (magit-ediff--quit winconf)))))))
 
 ;;;###autoload(autoload 'magit-ediff-stage "magit-ediff" nil t)
 (transient-define-suffix magit-ediff-stage (file)
@@ -495,8 +493,9 @@ is put in FILE.
 
 Neutralize the hooks `ediff-quit-hook' and `ediff-quit-merge-hook'
 because they usually feature functions that do not work for Magit.
-Instead run optional QUIT (if non-nil), `magit-ediff--cleanup-buffers'
-and `magit-ediff-quit-hook', with no arguments.
+Instead run optional QUIT (if non-nil) with no arguments, followed
+by `magit-ediff--quit', which cleans up and runs
+`magit-ediff-quit-hook'.
 
 Optional SETUP, if non-nil, is called with no arguments after Ediff
 is done setting up buffers."
@@ -511,11 +510,8 @@ is done setting up buffers."
                (setq-local ediff-quit-hook nil)
                (when quit
                  (add-hook 'ediff-quit-hook quit nil t))
-               (add-hook 'ediff-quit-hook #'magit-ediff--cleanup-buffers t t)
                (add-hook 'ediff-quit-hook
-                         (lambda ()
-                           (let ((magit-ediff-previous-winconf winconf))
-                             (run-hooks 'magit-ediff-quit-hook)))
+                         (lambda () (magit-ediff--quit winconf))
                          t t))))
      (pcase (list (and c t) (and file t))
        ('(nil nil) 'ediff-buffers)
@@ -532,6 +528,16 @@ is done setting up buffers."
     buffer))
 
 ;;; Quit
+
+(defun magit-ediff--quit (winconf)
+  "Clean up after an Ediff session and run `magit-ediff-quit-hook'.
+Bind `magit-ediff-previous-winconf' to WINCONF while running the
+hook, for the benefit of `magit-ediff-restore-previous-winconf'.
+This is the shared tail of every quit path in this file; do not
+inline it, or the copies will drift apart again."
+  (magit-ediff--cleanup-buffers)
+  (let ((magit-ediff-previous-winconf winconf))
+    (run-hooks 'magit-ediff-quit-hook)))
 
 (defun magit-ediff--cleanup-buffers ()
   (magit-ediff--bury-buffer ediff-buffer-A)

--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -223,6 +223,7 @@ and alternative commands."
          (when (buffer-live-p ediff-buffer-C) (kill-buffer ediff-buffer-C))
          (when (buffer-live-p ediff-ancestor-buffer)
            (kill-buffer ediff-ancestor-buffer))
+         (magit-ediff--cleanup-buffers)
          (let ((magit-ediff-previous-winconf smerge-ediff-windows))
            (run-hooks 'magit-ediff-quit-hook)))))))
 

--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -224,6 +224,12 @@ and alternative commands."
                (erase-buffer)
                (insert-buffer-substring bufC)
                (save-buffer)))
+           ;; These kills are not redundant with the ones in
+           ;; `magit-ediff--cleanup-buffers'.  That function only
+           ;; kills buffers created by `magit-ediff--find-file',
+           ;; which marks them as volatile; the temporary buffers
+           ;; created by `smerge-ediff' are not so marked and would
+           ;; be leaked.
            (when (buffer-live-p ediff-buffer-A) (kill-buffer ediff-buffer-A))
            (when (buffer-live-p ediff-buffer-B) (kill-buffer ediff-buffer-B))
            (when (buffer-live-p ediff-buffer-C) (kill-buffer ediff-buffer-C))

--- a/lisp/magit-ediff.el
+++ b/lisp/magit-ediff.el
@@ -210,22 +210,28 @@ and alternative commands."
       (setq-local
        ediff-quit-hook
        (lambda ()
-         (let ((bufC ediff-buffer-C)
+         ;; This hook runs with the Ediff control buffer current.
+         ;; `smerge-ediff-windows' and `smerge-ediff-buf' are local
+         ;; to that buffer and have no global value, and the control
+         ;; buffer does not survive `magit-ediff--cleanup-buffers',
+         ;; so capture their values before tearing anything down.
+         (let ((winconf smerge-ediff-windows)
+               (bufC ediff-buffer-C)
                (bufS smerge-ediff-buf))
            (with-current-buffer bufS
              (when (yes-or-no-p (format "Conflict resolution finished; save %s? "
                                         buffer-file-name))
                (erase-buffer)
                (insert-buffer-substring bufC)
-               (save-buffer))))
-         (when (buffer-live-p ediff-buffer-A) (kill-buffer ediff-buffer-A))
-         (when (buffer-live-p ediff-buffer-B) (kill-buffer ediff-buffer-B))
-         (when (buffer-live-p ediff-buffer-C) (kill-buffer ediff-buffer-C))
-         (when (buffer-live-p ediff-ancestor-buffer)
-           (kill-buffer ediff-ancestor-buffer))
-         (magit-ediff--cleanup-buffers)
-         (let ((magit-ediff-previous-winconf smerge-ediff-windows))
-           (run-hooks 'magit-ediff-quit-hook)))))))
+               (save-buffer)))
+           (when (buffer-live-p ediff-buffer-A) (kill-buffer ediff-buffer-A))
+           (when (buffer-live-p ediff-buffer-B) (kill-buffer ediff-buffer-B))
+           (when (buffer-live-p ediff-buffer-C) (kill-buffer ediff-buffer-C))
+           (when (buffer-live-p ediff-ancestor-buffer)
+             (kill-buffer ediff-ancestor-buffer))
+           (magit-ediff--cleanup-buffers)
+           (let ((magit-ediff-previous-winconf winconf))
+             (run-hooks 'magit-ediff-quit-hook))))))))
 
 ;;;###autoload(autoload 'magit-ediff-stage "magit-ediff" nil t)
 (transient-define-suffix magit-ediff-stage (file)


### PR DESCRIPTION
At least in my configuration, using `e` to use ediff on a merge conflict would leave the control panel open after saying Y to closing everything. Then discovered there are additional runtime connections between operations around window configuration restoration, which is the story these 4 commits tell. 

LLM was used to track down the issue, which I though had to be in my code, and review fix, not for this code. 

