### PR TITLE
Add --merge option for git checkout

### DIFF
--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -230,6 +230,7 @@ has to be used to view and change branch related variables."
    ("B" "Update default branch" magit-update-default-branch
     :inapt-if-not magit-get-some-remote)]
   ["Arguments"
+   (6 "-m" "Automatically merge conflicting local modifications" "--merge")
    (7 "-r" "Recurse submodules when checking out an existing branch"
       "--recurse-submodules")]
   [["Checkout"
@@ -388,7 +389,8 @@ when using `magit-branch-and-checkout'."
      (magit--checkout branch (magit-branch-arguments))
      (magit-refresh))
     (t
-     (when (magit-anything-modified-p t)
+     (when (and (magit-anything-modified-p t)
+                (not (transient-arg-value "--merge" (magit-branch-arguments))))
        (user-error "Cannot checkout when there are uncommitted changes"))
      (magit-run-git-async "checkout" (magit-branch-arguments)
                           "-b" branch start-point)

--- a/lisp/magit-branch.el
+++ b/lisp/magit-branch.el
@@ -230,6 +230,7 @@ has to be used to view and change branch related variables."
    ("B" "Update default branch" magit-update-default-branch
     :inapt-if-not magit-get-some-remote)]
   ["Arguments"
+   ("-m" "Automatically merge conflicting local modifications" "--merge")
    (7 "-r" "Recurse submodules when checking out an existing branch"
       "--recurse-submodules")]
   [["Checkout"
@@ -388,7 +389,8 @@ when using `magit-branch-and-checkout'."
      (magit--checkout branch (magit-branch-arguments))
      (magit-refresh))
     (t
-     (when (magit-anything-modified-p t)
+     (when (and (magit-anything-modified-p t)
+                (not (transient-arg-value "--merge" (magit-branch-arguments))))
        (user-error "Cannot checkout when there are uncommitted changes"))
      (magit-run-git-async "checkout" (magit-branch-arguments)
                           "-b" branch start-point)


### PR DESCRIPTION
This additionally disables the guard in `magit-branch-checkout` that prevents checking out with uncommited changes, since setting `-m` implies that is exactly your intent. It's possible though that this is a [Chesterton's fence](https://en.wikipedia.org/wiki/G._K._Chesterton#Chesterton's_Fence) that I'm not aware of, though.

In https://github.com/magit/magit/discussions/4889#discussioncomment-5201615, it was suggested that this should be a hidden flag, though I haven't done that here. IMO, it's a pretty intuitive flag and can be immediately helpful when someone less familiar with git tries to switch branches with uncommitted changes, without forcing them to do the stash-checkout-unstash dance. Happy to make it hidden though if that argument isn't convincing enough. :)

For the wording I went with "Automatically merge conflicting local modifications" which feels pretty okay to me.