### PR TITLE
Use git common dir when adding private gitignore rules

### DIFF
--- a/lisp/magit-git.el
+++ b/lisp/magit-git.el
@@ -946,18 +946,20 @@ Also see `magit-git-config-p'."
   (and$ (magit-gitdir)
         (if path (expand-file-name (convert-standard-filename path) $) $)))
 
-(defun magit-gitdir (&optional directory)
+(defun magit-gitdir (&optional directory common)
   "Return the absolute and resolved path of the .git directory.
 
 If the `GIT_DIR' environment variable is defined, return that.
 Otherwise return the .git directory for DIRECTORY, or if that is
 nil, then for `default-directory' instead.  If the directory is
-not located inside a Git repository, then return nil."
+not located inside a Git repository, then return nil.  If COMMON
+is t and the directory is a worktree, return the git common
+dir (shared by all worktrees)."
   (let ((default-directory (or directory default-directory)))
     (magit--with-refresh-cache (list default-directory 'magit-gitdir)
       (magit--with-safe-default-directory nil
         (and-let*
-            ((dir (magit-rev-parse-safe "--git-dir"))
+            ((dir (magit-rev-parse-safe (if common "--git-common-dir" "--git-dir")))
              (dir (file-name-as-directory (magit-expand-git-file-name dir))))
           (if (file-remote-p dir)
               dir

--- a/lisp/magit-gitignore.el
+++ b/lisp/magit-gitignore.el
@@ -77,10 +77,13 @@ Also stage the file."
 ;;;###autoload(autoload 'magit-gitignore-in-gitdir "magit-gitignore" nil t)
 (transient-define-suffix magit-gitignore-in-gitdir (rule)
   "Add the Git ignore RULE to \"$GIT_DIR/info/exclude\".
-Rules in that file only affects this clone of the repository."
+Rules in that file only affect this clone of the repository (and
+any of its worktrees)."
   :description "privately (.git/info/exclude)"
   (interactive (list (magit-gitignore-read-pattern)))
-  (magit--gitignore rule (expand-file-name "info/exclude" (magit-gitdir))))
+  (magit--gitignore
+   rule
+   (expand-file-name "info/exclude" (magit-gitdir nil t))))
 
 ;;;###autoload(autoload 'magit-gitignore-on-system "magit-gitignore" nil t)
 (transient-define-suffix magit-gitignore-on-system (rule)


### PR DESCRIPTION
Fixes: #5614

Applies the fix suggested by @kyleam in the linked issue/discussion, with some documentation updates. When adding a private git ignore rule from a worktree, this ensures the rule is stored in the exclude file that git actually uses when determining file excludes. Without this fix, the ignore rule gets added to a worktree-specific exclude file that actually does not get used (possibly only for some versions of git and/or worktrees created with some versions of git).
