### PR TITLE
magit-xref-restore: Remove redundant second refresh

### DIFF
--- a/lisp/magit-mode.el
+++ b/lisp/magit-mode.el
@@ -1460,8 +1460,7 @@ Later, when the buffer is buried, it may be restored by
 
 (defun magit-xref-restore (fn dir args)
   (setq default-directory dir)
-  (funcall fn major-mode nil args)
-  (magit-refresh-buffer))
+  (funcall fn major-mode nil args))
 
 ;;; Repository-Local Cache
 


### PR DESCRIPTION
magit-setup-buffer-internal already refreshes the Magit buffer, which makes the trailing refresh redundant and needlessly doubles the work. Removing it makes magit-go-forward/backward almost twice as fast, which is especially noticeable in large repositories.